### PR TITLE
add verify to deb demo

### DIFF
--- a/.github/workflows/sign-deb-example.yaml
+++ b/.github/workflows/sign-deb-example.yaml
@@ -27,3 +27,4 @@ jobs:
           GPG_TTY: no-tty
         run: |
           dpkg-sig --sign builder tests/*.deb
+          dpkg-sig --verify tests/*.deb


### PR DESCRIPTION
had to update to "real" deb package as hand rolled deb does not verify propperly, investigation as to why is byond my time constraints at this moment.