### PR TITLE
fix!: dpkg-sig and pin ubuntu

### DIFF
--- a/.github/workflows/sign-deb-example.yaml
+++ b/.github/workflows/sign-deb-example.yaml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
-      
+      - name: install dpkg-sig
+        run: |
+          sudo apt-get install dpkg-sig dpkg-dev
       - name: setup GPG
         uses: ./devops/setup-gpg
         with:

--- a/.github/workflows/sign-deb-example.yaml
+++ b/.github/workflows/sign-deb-example.yaml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   sign-deb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
       

--- a/.github/workflows/sign-file-example.yaml
+++ b/.github/workflows/sign-file-example.yaml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   sign-deb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
       

--- a/.github/workflows/sign-rpm-example.yaml
+++ b/.github/workflows/sign-rpm-example.yaml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   sign-rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@master
       

--- a/devops/setup-gpg/action.yaml
+++ b/devops/setup-gpg/action.yaml
@@ -1,90 +1,90 @@
-name: 'Setup GPG'
-description: 'Configures this action to run gpg with a given key and pass'
+name: "Setup GPG"
+description: "Configures this action to run gpg with a given key and pass"
 inputs:
-  gpg-private-key:  # id of input
+  gpg-private-key: # id of input
     required: true
-  gpg-key-pass:  # id of input
+  gpg-key-pass: # id of input
     required: true
-  gpg-key-name:  # id of input
+  gpg-key-name: # id of input
     required: true
     default: "Aerospike"
   gpg-public-key:
-    description: 'GPG public key exported as an ASCII armored version or its base64 encoding'
+    description: "GPG public key exported as an ASCII armored version or its base64 encoding"
     required: true
 runs:
   using: "composite"
   steps:
-      - name: "check if private key is not empty"
-        env: 
-            PRIVATE_KEY: ${{ inputs.gpg-private-key }}
-        if: ${{ env.PRIVATE_KEY == '' }}
-        run: |
-          echo "the gpg-private-key was empty"
-          exit 1
-        shell: bash
-      - name: "check if key name is not empty"
-        env: 
-            KEY_NAME: ${{ inputs.gpg-key-name }}
-        if: ${{ env.KEY_NAME == '' }}
-        run: |
-          echo "the gpg-key-name was empty"
-          exit 1
-        shell: bash
-      - name: "check if key pass is not empty"
-        env: 
-            KEY_PASS: ${{ inputs.gpg-key-pass }}
-        if: ${{ env.KEY_PASS == '' }}
-        run: |
-          echo "the secret gpg-key-pass was empty"
-          exit 1
-        shell: bash
-      - name: "check if public key pass is empty"
-        env: 
-            PUBLIC_KEY: ${{ inputs.gpg-public-key }}
-        if: ${{ env.PUBLIC_KEY == '' }}
-        run: |
-          echo "the secret gpg-public-pass was empty"
-          exit 1
-        shell: bash
-      - name: install tools
-        run: |
-          sudo apt-get update && sudo apt-get install ca-certificates gnupg dpkg-dev dpkg-sig rpm -y
-        shell: bash
-      - name: Set up GPG
-        env:
-          GPG_PRIVATE_KEY: ${{ inputs.gpg-private-key }}
-          GPG_KEY_PASS: ${{ inputs.gpg-key-pass }}
-          GPG_ID: ${{ inputs.gpg-key-name }}
-          GPG_PUBLIC_KEY: ${{ inputs.gpg-public-key }}
-        run: |
-          # Setup gpg
-          mkdir -p ~/.gnupg
-          chmod 700 ~/.gnupg
-          echo "$GPG_PRIVATE_KEY" | gpg --import --batch --yes
-          echo "$GPG_KEY_PASS"
+    - name: "check if private key is not empty"
+      env:
+        PRIVATE_KEY: ${{ inputs.gpg-private-key }}
+      if: ${{ env.PRIVATE_KEY == '' }}
+      run: |
+        echo "the gpg-private-key was empty"
+        exit 1
+      shell: bash
+    - name: "check if key name is not empty"
+      env:
+        KEY_NAME: ${{ inputs.gpg-key-name }}
+      if: ${{ env.KEY_NAME == '' }}
+      run: |
+        echo "the gpg-key-name was empty"
+        exit 1
+      shell: bash
+    - name: "check if key pass is not empty"
+      env:
+        KEY_PASS: ${{ inputs.gpg-key-pass }}
+      if: ${{ env.KEY_PASS == '' }}
+      run: |
+        echo "the secret gpg-key-pass was empty"
+        exit 1
+      shell: bash
+    - name: "check if public key pass is empty"
+      env:
+        PUBLIC_KEY: ${{ inputs.gpg-public-key }}
+      if: ${{ env.PUBLIC_KEY == '' }}
+      run: |
+        echo "the secret gpg-public-pass was empty"
+        exit 1
+      shell: bash
+    - name: install tools
+      run: |
+        sudo apt-get update && sudo apt-get install ca-certificates gnupg rpm -y
+      shell: bash
+    - name: Set up GPG
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg-private-key }}
+        GPG_KEY_PASS: ${{ inputs.gpg-key-pass }}
+        GPG_ID: ${{ inputs.gpg-key-name }}
+        GPG_PUBLIC_KEY: ${{ inputs.gpg-public-key }}
+      run: |
+        # Setup gpg
+        mkdir -p ~/.gnupg
+        chmod 700 ~/.gnupg
+        echo "$GPG_PRIVATE_KEY" | gpg --import --batch --yes
+        echo "$GPG_KEY_PASS"
 
-          # configure for non-interactive use
-          export GPG_TTY=no-tty
-          echo -e "pinentry-mode loopback\nuse-agent" >> ~/.gnupg/gpg.conf
-          echo -e "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+        # configure for non-interactive use
+        export GPG_TTY=no-tty
+        echo -e "pinentry-mode loopback\nuse-agent" >> ~/.gnupg/gpg.conf
+        echo -e "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
 
-          # configure rpm's
-          echo -e "$GPG_KEY_PASS" >> ~/pass
-          echo -e "%_signature gpg" >> ~/.rpmmacros
-          echo -e "%_gpg_path ~/.gnupg" >> ~/.rpmmacros
-          echo -e "%_gpg_name $GPG_ID" >> ~/.rpmmacros
-          echo -e "%_gpgbin /usr/bin/gpg" >> ~/.rpmmacros
-          echo -e "%__gpg /usr/bin/gpg" >> ~/.rpmmacros
-          echo -e "%__gpg_sign_cmd %{__gpg} \\" >> ~/.rpmmacros
-          echo -e "gpg --no-verbose --batch --no-tty --passphrase-file /home/runner/pass --pinentry-mode loopback \\" >> ~/.rpmmacros
-          echo -e "  %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \\" >> ~/.rpmmacros
-          echo -e "  --no-secmem-warning \\" >> ~/.rpmmacros
-          echo -e "  -u '%{_gpg_name}' -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+        # configure rpm's
+        echo -e "$GPG_KEY_PASS" >> ~/pass
+        echo -e "%_signature gpg" >> ~/.rpmmacros
+        echo -e "%_gpg_path ~/.gnupg" >> ~/.rpmmacros
+        echo -e "%_gpg_name $GPG_ID" >> ~/.rpmmacros
+        echo -e "%_gpgbin /usr/bin/gpg" >> ~/.rpmmacros
+        echo -e "%__gpg /usr/bin/gpg" >> ~/.rpmmacros
+        echo -e "%__gpg_sign_cmd %{__gpg} \\" >> ~/.rpmmacros
+        echo -e "gpg --no-verbose --batch --no-tty --passphrase-file /home/runner/pass --pinentry-mode loopback \\" >> ~/.rpmmacros
+        echo -e "  %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \\" >> ~/.rpmmacros
+        echo -e "  --no-secmem-warning \\" >> ~/.rpmmacros
+        echo -e "  -u '%{_gpg_name}' -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
 
-          # public key for verification
-          echo -e "$GPG_PUBLIC_KEY" >> ~/.gnupg/.public_key.asc
-          rpm --import ~/.gnupg/.public_key.asc
+        # public key for verification
+        echo -e "$GPG_PUBLIC_KEY" >> ~/.gnupg/.public_key.asc
+        rpm --import ~/.gnupg/.public_key.asc
 
-          # reload agent
-          gpg-connect-agent reloadagent /bye
-        shell: bash
+        # reload agent
+        gpg-connect-agent reloadagent /bye
+      shell: bash


### PR DESCRIPTION
- dpkg-sig and dpkg-dev are not available on ubuntu24, which is the new 'ubuntu-latest'. Remove both of them as they're not actually used by the action.
- pin the action to ubuntu22 anyway, until we can fully test an ubuntu24 action.

⚠️ 🗣️ 
~~I am planning on semver major bumping this; it removes a package that people _could_ be depending on, in which case this will break them.~~
I could be convinced to do a minor, though: we know(ish) all consumers, and the current 0.1.0 version means we don't _have_ to strictly follow semver _yet_: that can be when we merge #15 .