### PR TITLE
This will not be merged

### DIFF
--- a/.github/workflows/example_reusable-integration.yaml
+++ b/.github/workflows/example_reusable-integration.yaml
@@ -116,7 +116,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Download All Matrix Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: build-artifacts-*
           path: build-artifacts

--- a/.github/workflows/reusable_create-release-bundle.yaml
+++ b/.github/workflows/reusable_create-release-bundle.yaml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@f748a0599171a192a2668afee8d0497f7c1069df
+        uses: jfrog/setup-jfrog-cli@2bc6e55719cd37dfb2f655a1e4f16c3440182a9f
         env:
           JF_URL: ${{ inputs.artifactory-url }}
           JF_PROJECT: ${{ inputs.project }}

--- a/.github/workflows/reusable_execute-build.yaml
+++ b/.github/workflows/reusable_execute-build.yaml
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JFrog CLI
-        uses: jfrog/setup-jfrog-cli@f748a0599171a192a2668afee8d0497f7c1069df
+        uses: jfrog/setup-jfrog-cli@2bc6e55719cd37dfb2f655a1e4f16c3440182a9f
         env:
           JF_URL: ${{ inputs.artifactory-url }}
           JF_PROJECT: ${{ inputs.project }}

--- a/.github/workflows/reusable_upload-artifacts.yaml
+++ b/.github/workflows/reusable_upload-artifacts.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@f748a0599171a192a2668afee8d0497f7c1069df # v4.5.6
+        uses: jfrog/setup-jfrog-cli@2bc6e55719cd37dfb2f655a1e4f16c3440182a9f # v4.5.13
         env:
           JF_URL: ${{ inputs.artifactory-url }}
           JF_PROJECT: ${{ inputs.project }}

--- a/.github/workflows/reusable_upload-artifacts.yaml
+++ b/.github/workflows/reusable_upload-artifacts.yaml
@@ -78,7 +78,7 @@ jobs:
           jf c show
           jf rt ping
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.artifact-name }}
           path: ./build-artifacts

--- a/.github/workflows/test_sign-deb.yaml
+++ b/.github/workflows/test_sign-deb.yaml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-22.04
           #- ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4 # this was the dependabot update but the error is in signing
       - name: Check Ubuntu version
         # This action only supports Ubuntu 22.04. 24.04 has removed dpkg-sig
         run: |


### PR DESCRIPTION
~creating here to investigate dependabot failures~

The learning here is that if a job is triggered by dependabot it will not have access to secrets **∴** jobs like signing that need secrets will fail. To "fix" an internal user has to trigger the test run. 