### PR TITLE
CTRL-312: Add actions to promote Jira hygiene for PRs

### DIFF
--- a/.github/actions/jira-pr-hygeine/README.md
+++ b/.github/actions/jira-pr-hygeine/README.md
@@ -1,6 +1,10 @@
-# Setup GPG composite Action
+# Setup hygiene actions
 
 In this folder you will find two actions; one for checking that PR titles start with a reference to a Jira ticket, and one that relies on that check to extract that Jira ticket and prepend it to the git commit message on merge or squash. I recommend using both on repos to improve the git history and commit hygiene.
+
+The reason for having these is so that we can get strong automatic linking to the new Jira Deployments feature; which according to Atlassian support is the best way to make sure that linkage is granular and appropriate.
+
+The command `git push --force-with-lease origin $BASE_REF` may raise concerns; the `--force-with-least` option should make sure that no code can be over-written with it; it is intended to just modify the commit message with a prefix.
 
 ## Example Usage
 

--- a/.github/actions/jira-pr-hygeine/README.md
+++ b/.github/actions/jira-pr-hygeine/README.md
@@ -1,0 +1,61 @@
+# Setup GPG composite Action
+
+In this folder you will find two actions; one for checking that PR titles start with a reference to a Jira ticket, and one that relies on that check to extract that Jira ticket and prepend it to the git commit message on merge or squash. I recommend using both on repos to improve the git history and commit hygiene. 
+
+
+## Example Usage
+
+These are examples of actions that use the included workflows. Both are recommended.
+
+### Example of workflow using hygiene check
+
+How to use the hygiene workflow to check if a PR title includes a reference to a Jira ticket.
+
+```yaml
+name: PR Hygiene - Jira Ticket in Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-jira-ticket:
+    uses: ./.github/workflows/hygiene.yml
+    with:
+      pr_title: ${{ github.event.pull_request.title }}
+
+```
+
+### Example of workflow using PR merge check
+
+How to use the merge workflow to change a commit message to include the same Jira reference as the PR title if one is available. 
+
+```yaml
+name: PR Squash and Merge - Prepend Jira ticket
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge-with-jira:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_title: ${{ steps.get-merged-pull-request.outputs.title }}
+    steps:
+      - uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9 # v1.0.1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  call-merge-workflow:
+    needs: merge-with-jira
+    if: ${{ needs.merge-with-jira.outputs.pr_title != null }}
+    uses: ./.github/workflows/merge.yml
+    with:
+      pr_title: ${{ needs.merge-with-jira.outputs.pr_title }}
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      base_ref: ${{ github.event.pull_request.base.ref }}
+    secrets:
+      passed_github_token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/.github/actions/jira-pr-hygeine/README.md
+++ b/.github/actions/jira-pr-hygeine/README.md
@@ -1,7 +1,6 @@
 # Setup GPG composite Action
 
-In this folder you will find two actions; one for checking that PR titles start with a reference to a Jira ticket, and one that relies on that check to extract that Jira ticket and prepend it to the git commit message on merge or squash. I recommend using both on repos to improve the git history and commit hygiene. 
-
+In this folder you will find two actions; one for checking that PR titles start with a reference to a Jira ticket, and one that relies on that check to extract that Jira ticket and prepend it to the git commit message on merge or squash. I recommend using both on repos to improve the git history and commit hygiene.
 
 ## Example Usage
 
@@ -23,12 +22,11 @@ jobs:
     uses: ./.github/workflows/hygiene.yml
     with:
       pr_title: ${{ github.event.pull_request.title }}
-
 ```
 
 ### Example of workflow using PR merge check
 
-How to use the merge workflow to change a commit message to include the same Jira reference as the PR title if one is available. 
+How to use the merge workflow to change a commit message to include the same Jira reference as the PR title if one is available.
 
 ```yaml
 name: PR Squash and Merge - Prepend Jira ticket

--- a/.github/actions/jira-pr-hygeine/hygiene.yml
+++ b/.github/actions/jira-pr-hygeine/hygiene.yml
@@ -1,0 +1,32 @@
+name: Check for Jira Ticket in PR Title
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        required: true
+        type: string
+        description: 'PR title to check for JIRA ticket'
+
+jobs:
+  hygiene-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for JIRA ticket in PR title
+        run: |
+          # Extract PR title
+          PR_TITLE="${{ inputs.pr_title }}"
+          echo "PR Title: $PR_TITLE"
+          
+          # Extract JIRA ticket from PR title (ABC-123 format)
+          JIRA_TICKET=$(echo "$PR_TITLE" | grep -oE '([A-Za-z0-9]+-[0-9]+)' | head -1)
+          
+          if [ -z "$JIRA_TICKET" ]; then
+            echo "❌ ERROR: No JIRA ticket found in PR title!"
+            echo "Please include a JIRA ticket in the format 'ABC-123 in your PR title."
+            echo "Examples: ABC-123: Add new feature for database management'"
+            exit 1
+          else
+            echo "✅ JIRA ticket found: $JIRA_TICKET"
+            echo "PR hygiene check passed!"
+          fi

--- a/.github/actions/jira-pr-hygeine/hygiene.yml
+++ b/.github/actions/jira-pr-hygeine/hygiene.yml
@@ -6,7 +6,7 @@ on:
       pr_title:
         required: true
         type: string
-        description: 'PR title to check for JIRA ticket'
+        description: PR title to check for JIRA ticket
 
 jobs:
   hygiene-check:
@@ -17,13 +17,11 @@ jobs:
           # Extract PR title
           PR_TITLE="${{ inputs.pr_title }}"
           echo "PR Title: $PR_TITLE"
-          
           # Extract JIRA ticket from PR title (ABC-123 format)
           JIRA_TICKET=$(echo "$PR_TITLE" | grep -oE '([A-Za-z0-9]+-[0-9]+)' | head -1)
-          
           if [ -z "$JIRA_TICKET" ]; then
             echo "❌ ERROR: No JIRA ticket found in PR title!"
-            echo "Please include a JIRA ticket in the format 'ABC-123 in your PR title."
+            echo "Please include a JIRA ticket in the format ABC-123 in your PR title."
             echo "Examples: ABC-123: Add new feature for database management'"
             exit 1
           else

--- a/.github/actions/jira-pr-hygeine/merge.yml
+++ b/.github/actions/jira-pr-hygeine/merge.yml
@@ -1,0 +1,78 @@
+name: Add Jira ID to commit message during PR merge
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        required: true
+        type: string
+        description: 'PR title to extract JIRA ticket from'
+      merge_commit_sha:
+        required: true
+        type: string
+        description: 'Merge commit SHA to update'
+      base_ref:
+        required: true
+        type: string
+        description: 'Base branch reference'
+    secrets:
+      passed_github_token:
+        required: true
+        description: 'GitHub token for repository access'
+
+jobs:
+  # First job: Call the hygiene check workflow
+  hygiene-check:
+    uses: ./.github/actions/jira-pr-hygiene/hygiene.yml
+    with:
+      pr_title: ${{ inputs.pr_title }}
+
+  # Second job: Update commit message (depends on hygiene check)
+  update-commit:
+    runs-on: ubuntu-latest
+    needs: hygiene-check
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.passed_github_token }}
+      
+      - name: Extract JIRA ticket and update commit message
+        run: |
+          # Extract PR title and merge commit SHA
+          PR_TITLE="${{ inputs.pr_title }}"
+          MERGE_COMMIT_SHA="${{ inputs.merge_commit_sha }}"
+          BASE_REF="${{ inputs.base_ref }}"
+          
+          # Extract JIRA ticket from PR title (ABC-123 format)
+          JIRA_TICKET=$(echo "$PR_TITLE" | grep -oE '([A-Za-z0-9]+-[0-9]+)' | head -1)
+          
+          if [ -n "$JIRA_TICKET" ]; then
+            echo "Found JIRA ticket: $JIRA_TICKET"
+            echo "Merge commit SHA: $MERGE_COMMIT_SHA"
+            echo "Base ref: $BASE_REF"
+            
+            # Get current commit message
+            CURRENT_MESSAGE=$(git log --format=%B -n 1 $MERGE_COMMIT_SHA)
+            
+            # Check if JIRA ticket is already in the commit message
+            if [[ "$CURRENT_MESSAGE" != *"$JIRA_TICKET"* ]]; then
+              # Prepend JIRA ticket to commit message
+              NEW_MESSAGE="$JIRA_TICKET: $CURRENT_MESSAGE"
+              echo "Updating commit message to: $NEW_MESSAGE"
+              
+              # Configure git
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              
+              # Amend the commit message
+              git checkout $MERGE_COMMIT_SHA
+              git commit --amend -m "$NEW_MESSAGE"
+              git push --force-with-lease origin $BASE_REF
+            else
+              echo "JIRA ticket already present in commit message"
+            fi
+          else
+            echo "No JIRA ticket found in PR title"
+          fi

--- a/.github/actions/jira-pr-hygeine/merge.yml
+++ b/.github/actions/jira-pr-hygeine/merge.yml
@@ -6,19 +6,19 @@ on:
       pr_title:
         required: true
         type: string
-        description: 'PR title to extract JIRA ticket from'
+        description: PR title to extract JIRA ticket from
       merge_commit_sha:
         required: true
         type: string
-        description: 'Merge commit SHA to update'
+        description: Merge commit SHA to update
       base_ref:
         required: true
         type: string
-        description: 'Base branch reference'
+        description: Base branch reference
     secrets:
       passed_github_token:
         required: true
-        description: 'GitHub token for repository access'
+        description: GitHub token for repository access
 
 jobs:
   # First job: Call the hygiene check workflow
@@ -37,17 +37,16 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.passed_github_token }}
-      
+
       - name: Extract JIRA ticket and update commit message
         run: |
           # Extract PR title and merge commit SHA
           PR_TITLE="${{ inputs.pr_title }}"
           MERGE_COMMIT_SHA="${{ inputs.merge_commit_sha }}"
           BASE_REF="${{ inputs.base_ref }}"
-          
+
           # Extract JIRA ticket from PR title (ABC-123 format)
           JIRA_TICKET=$(echo "$PR_TITLE" | grep -oE '([A-Za-z0-9]+-[0-9]+)' | head -1)
-          
           if [ -n "$JIRA_TICKET" ]; then
             echo "Found JIRA ticket: $JIRA_TICKET"
             echo "Merge commit SHA: $MERGE_COMMIT_SHA"


### PR DESCRIPTION
Adds two actions that can be used to improve github <--> Jira hygiene. The first action checks to see if the PR title starts with a valid Jira-style identifier. The second action uses the first and prepends that Jira reference to the start of the commit message if it is not already there.