### PR TITLE
feat(setup-aerospike-server): [CLIENT-4616] fix templates, add tests

### DIFF
--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -487,6 +487,7 @@ runs:
           fi
 
           run_args+=("$image")
+          run_args+=("-e", "DEFAULT_TTL=2592000")
 
           # Pass --foreground since we bypassed the entrypoint
           if [[ "$bypass_entrypoint" == "true" ]]; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -193,6 +193,8 @@ runs:
             dns_idx=$(( dns_idx + 1 ))
           done
           echo "DNS.${dns_idx} = localhost"
+          dns_idx=$(( dns_idx + 1 ))
+          echo "DNS.${dns_idx} = docker"
           echo "IP.1 = 127.0.0.1"
         } > san.ext
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -487,7 +487,7 @@ runs:
           fi
 
           run_args+=("$image")
-          run_args+=("-e" "DEFAULT_TTL=2592000")
+          run_args+=("-e", "DEFAULT_TTL=2592000")
 
           # Pass --foreground since we bypassed the entrypoint
           if [[ "$bypass_entrypoint" == "true" ]]; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -487,7 +487,7 @@ runs:
           fi
 
           run_args+=("$image")
-          run_args+=("-e", "DEFAULT_TTL=2592000")
+          run_args+=("-e" "DEFAULT_TTL=2592000")
 
           # Pass --foreground since we bypassed the entrypoint
           if [[ "$bypass_entrypoint" == "true" ]]; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -467,6 +467,8 @@ runs:
             bypass_entrypoint="true"
           elif [[ "$effective_security" == "true" ]]; then
             bypass_entrypoint="true"
+          elif [[ -n "$config_path" ]]; then
+            bypass_entrypoint="true"
           fi
 
           # Mount aerospike.conf (read-only when bypassing entrypoint)

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -238,6 +238,12 @@ runs:
 
         render_tpl="${{ github.action_path }}/render-template.sh"
 
+        # Build feature-key-file directive (omitted from config when no features file is provided)
+        export FEATURE_KEY_FILE=""
+        if [[ -n "${{ inputs.features-file }}" || -n "${FEATURES_CONTENT}" ]]; then
+          FEATURE_KEY_FILE="feature-key-file /etc/aerospike/features.conf"
+        fi
+
         # Build security stanza from template
         export SECURITY=""
         if [[ "$effective_security" == "true" ]]; then
@@ -391,6 +397,12 @@ runs:
             tpl_dir="${{ github.action_path }}/templates"
             render_tpl="${{ github.action_path }}/render-template.sh"
 
+            # Build feature-key-file directive
+            export FEATURE_KEY_FILE=""
+            if [[ -n "$features_path" ]]; then
+              FEATURE_KEY_FILE="feature-key-file /etc/aerospike/features.conf"
+            fi
+
             # Build security stanza from template
             export SECURITY=""
             if [[ "$effective_security" == "true" ]]; then
@@ -446,15 +458,14 @@ runs:
           # Decide whether to bypass the entrypoint. The Aerospike Docker entrypoint
           # regenerates aerospike.conf, overwriting any mounted config. Bypass it
           # whenever we need a custom config that must not be overwritten.
-          # SC always requires a features file (enterprise), so bypass is safe.
-          # Security alone can work without features, so only bypass when a
-          # features file is available (entrypoint would overwrite our config).
           bypass_entrypoint="false"
           if (( num_nodes > 1 )); then
             bypass_entrypoint="true"
           elif [[ "$enable_sc" == "true" ]]; then
             bypass_entrypoint="true"
-          elif [[ "$effective_security" == "true" && -n "$features_path" ]]; then
+          elif [[ "$enable_tls" == "true" ]]; then
+            bypass_entrypoint="true"
+          elif [[ "$effective_security" == "true" ]]; then
             bypass_entrypoint="true"
           fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -487,7 +487,6 @@ runs:
           fi
 
           run_args+=("$image")
-          run_args+=("-e", "DEFAULT_TTL=2592000")
 
           # Pass --foreground since we bypassed the entrypoint
           if [[ "$bypass_entrypoint" == "true" ]]; then

--- a/.github/actions/setup-aerospike-server/templates/default.conf
+++ b/.github/actions/setup-aerospike-server/templates/default.conf
@@ -1,5 +1,5 @@
 service {
-    feature-key-file /etc/aerospike/features.conf
+    ${FEATURE_KEY_FILE}
     cluster-name docker
     proto-fd-max 15000
 }

--- a/.github/actions/setup-aerospike-server/templates/multi-node.conf
+++ b/.github/actions/setup-aerospike-server/templates/multi-node.conf
@@ -1,5 +1,5 @@
 service {
-    feature-key-file /etc/aerospike/features.conf
+    ${FEATURE_KEY_FILE}
     cluster-name docker
 }
 

--- a/.github/actions/setup-aerospike-server/templates/tls.conf
+++ b/.github/actions/setup-aerospike-server/templates/tls.conf
@@ -1,5 +1,5 @@
 service {
-    feature-key-file /etc/aerospike/features.conf
+    ${FEATURE_KEY_FILE}
     cluster-name docker
     proto-fd-max 15000
 }

--- a/.github/actions/setup-aerospike-server/templates/tls.conf
+++ b/.github/actions/setup-aerospike-server/templates/tls.conf
@@ -12,13 +12,12 @@ logging {
     }
 }
 
-tls aerospike-tls {
-    cert-file /etc/aerospike/tls/server.crt
-    key-file  /etc/aerospike/tls/server.key
-    ca-file   /etc/aerospike/tls/ca.crt
-}
-
 network {
+    tls aerospike-tls {
+        cert-file /etc/aerospike/tls/server.crt
+        key-file  /etc/aerospike/tls/server.key
+        ca-file   /etc/aerospike/tls/ca.crt
+    }
     service {
         address any
         port 3000

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+    paths:
+      - .github/actions/setup-aerospike-server/**
+      - .github/workflows/test_setup-aerospike-server.yaml
 
 permissions:
   contents: read

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -356,3 +356,179 @@ jobs:
           echo "Unauthenticated result: $result"
           [[ "$result" == *"ERROR"* || "$result" == *"not authenticated"* || "$result" == *"error"* ]] \
             || { echo "Expected unauthenticated access to be rejected"; exit 1; }
+
+  test-tls-with-security:
+    name: Single node with TLS and security
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Aerospike Server with TLS and security
+        id: setup-aerospike-server
+        uses: ./.github/actions/setup-aerospike-server
+        with:
+          enable-tls: "true"
+          enable-security: "true"
+          features-content: ${{ secrets.AES_FEATURES_CONF }}
+          startup-timeout: "60"
+          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+
+      - name: Verify TLS outputs
+        run: |
+          echo "tls-service-ports: ${{ steps.setup-aerospike-server.outputs.tls-service-ports }}"
+          echo "tls-cert-dir: ${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}"
+
+          [[ "${{ steps.setup-aerospike-server.outputs.tls-service-ports }}" == "4333" ]] \
+            || { echo "Unexpected tls-service-ports"; exit 1; }
+          [[ -n "${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}" ]] \
+            || { echo "tls-cert-dir is empty"; exit 1; }
+
+      - name: Verify cert files exist
+        run: |
+          cert_dir="${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}"
+          for f in ca.crt ca.key server.crt server.key client.crt client.key; do
+            [[ -f "$cert_dir/$f" ]] || { echo "Missing cert file: $f"; exit 1; }
+          done
+          echo "All expected cert files present"
+
+      - name: Verify authenticated access on service port
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          rc=0
+          result=$(docker run --rm --network "$network" "$tools_image" \
+            asinfo -h aerospike-1 -p 3000 -U admin -P admin -v status 2>&1) || rc=$?
+          echo "Exit code: $rc"
+          echo "asinfo status (auth, non-TLS): $result"
+          [[ $rc -eq 0 && "$result" == *"ok"* ]] || { echo "Expected status=ok with auth on service port"; exit 1; }
+
+      - name: Verify authenticated access on TLS port
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          cert_dir="${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}"
+          rc=0
+          result=$(docker run --rm --network "$network" \
+            -v "$cert_dir:/certs:ro" "$tools_image" \
+            asinfo -h "aerospike-1:aerospike-tls" -p 4333 \
+            --tls-enable --tls-cafile /certs/ca.crt \
+            -U admin -P admin -v status 2>&1) || rc=$?
+          echo "Exit code: $rc"
+          echo "asinfo status (auth, TLS): $result"
+          [[ $rc -eq 0 && "$result" == *"ok"* ]] || { echo "Expected status=ok with auth on TLS port"; exit 1; }
+
+      - name: Verify unauthenticated access is rejected
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          rc=0
+          result=$(docker run --rm --network "$network" "$tools_image" \
+            asinfo -h aerospike-1 -p 3000 -v status 2>&1) || rc=$?
+          echo "Exit code: $rc"
+          echo "Unauthenticated result: $result"
+          [[ "$result" == *"ERROR"* || "$result" == *"not authenticated"* || "$result" == *"error"* ]] \
+            || { echo "Expected unauthenticated access to be rejected"; exit 1; }
+
+      - name: Verify TLS handshake
+        run: |
+          cert_dir="${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}"
+          echo | openssl s_client -connect 127.0.0.1:4333 -CAfile "$cert_dir/ca.crt" 2>&1 | grep -q "Verify return code: 0"
+          echo "TLS handshake verified"
+
+  test-tls-with-security-multi-node:
+    name: Multi-node with TLS and security (3 nodes)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Aerospike Server with TLS and security (3 nodes)
+        id: setup-aerospike-server
+        uses: ./.github/actions/setup-aerospike-server
+        with:
+          num-nodes: "3"
+          enable-tls: "true"
+          enable-security: "true"
+          features-content: ${{ secrets.AES_FEATURES_CONF }}
+          startup-timeout: "60"
+          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+
+      - name: Verify outputs
+        run: |
+          echo "container-names: ${{ steps.setup-aerospike-server.outputs.container-names }}"
+          echo "service-ports: ${{ steps.setup-aerospike-server.outputs.service-ports }}"
+          echo "tls-service-ports: ${{ steps.setup-aerospike-server.outputs.tls-service-ports }}"
+          echo "tls-cert-dir: ${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}"
+
+          [[ "${{ steps.setup-aerospike-server.outputs.container-names }}" == "aerospike-1,aerospike-2,aerospike-3" ]] \
+            || { echo "Unexpected container-names"; exit 1; }
+          [[ "${{ steps.setup-aerospike-server.outputs.service-ports }}" == "3000,3001,3002" ]] \
+            || { echo "Unexpected service-ports"; exit 1; }
+          [[ "${{ steps.setup-aerospike-server.outputs.tls-service-ports }}" == "4333,4334,4335" ]] \
+            || { echo "Unexpected tls-service-ports"; exit 1; }
+          [[ -n "${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}" ]] \
+            || { echo "tls-cert-dir is empty"; exit 1; }
+
+      - name: Verify all containers are running
+        run: |
+          for i in 1 2 3; do
+            docker ps --filter "name=aerospike-${i}" --format '{{.Names}}' | grep -q "aerospike-${i}"
+          done
+
+      - name: Verify cluster formation via authenticated asinfo
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          for container in aerospike-1 aerospike-2 aerospike-3; do
+            echo "Checking cluster_size on $container..."
+            rc=0
+            stats=$(docker run --rm --network "$network" "$tools_image" \
+              asinfo -h "$container" -p 3000 -U admin -P admin -v "statistics" 2>&1) || rc=$?
+            cluster_size=$(echo "$stats" | tr ';' '\n' | grep -oP 'cluster_size=\K\d+' || echo "N/A")
+            echo "$container cluster_size: $cluster_size (exit code: $rc)"
+            [[ $rc -eq 0 && "$cluster_size" == "3" ]] \
+              || { echo "Expected cluster_size=3 on $container, got $cluster_size"; exit 1; }
+          done
+
+      - name: Verify authenticated TLS connection on each node
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          cert_dir="${{ steps.setup-aerospike-server.outputs.tls-cert-dir }}"
+          for container in aerospike-1 aerospike-2 aerospike-3; do
+            echo "Checking TLS on $container..."
+            rc=0
+            result=$(docker run --rm --network "$network" \
+              -v "$cert_dir:/certs:ro" "$tools_image" \
+              asinfo -h "${container}:aerospike-tls" -p 4333 \
+              --tls-enable --tls-cafile /certs/ca.crt \
+              -U admin -P admin -v status 2>&1) || rc=$?
+            echo "$container TLS status: $result (exit code: $rc)"
+            [[ $rc -eq 0 && "$result" == *"ok"* ]] \
+              || { echo "Expected status=ok with auth on TLS port for $container"; exit 1; }
+          done
+
+      - name: Verify unauthenticated access is rejected
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          rc=0
+          result=$(docker run --rm --network "$network" "$tools_image" \
+            asinfo -h aerospike-1 -p 3000 -v status 2>&1) || rc=$?
+          echo "Exit code: $rc"
+          echo "Unauthenticated result: $result"
+          [[ "$result" == *"ERROR"* || "$result" == *"not authenticated"* || "$result" == *"error"* ]] \
+            || { echo "Expected unauthenticated access to be rejected"; exit 1; }

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -417,8 +417,8 @@ jobs:
           rc=0
           result=$(docker run --rm --network "$network" \
             -v "$cert_dir:/certs:ro" "$tools_image" \
-            asinfo -h "aerospike-1:aerospike-tls" -p 4333 \
-            --tls-enable --tls-cafile /certs/ca.crt \
+            asinfo -h aerospike-1 -p 4333 \
+            --tls-enable --tls-name aerospike-tls --tls-cafile /certs/ca.crt \
             -U admin -P admin -v status 2>&1) || rc=$?
           echo "Exit code: $rc"
           echo "asinfo status (auth, TLS): $result"
@@ -513,8 +513,8 @@ jobs:
             rc=0
             result=$(docker run --rm --network "$network" \
               -v "$cert_dir:/certs:ro" "$tools_image" \
-              asinfo -h "${container}:aerospike-tls" -p 4333 \
-              --tls-enable --tls-cafile /certs/ca.crt \
+              asinfo -h "$container" -p 4333 \
+              --tls-enable --tls-name aerospike-tls --tls-cafile /certs/ca.crt \
               -U admin -P admin -v status 2>&1) || rc=$?
             echo "$container TLS status: $result (exit code: $rc)"
             [[ $rc -eq 0 && "$result" == *"ok"* ]] \


### PR DESCRIPTION
## Summary
- Make `feature-key-file` conditional in config templates so security-only setups (no features file) render a valid config.
- Fix TLS config: move `tls aerospike-tls` inside the `network {}` stanza and add `docker` to cert SANs.
- Add integration tests covering TLS + security on single node and a 3-node cluster.

## Jira
[CLIENT-4616](https://aerospike.atlassian.net/browse/CLIENT-4616)

## Changes
### `setup-aerospike-server` action
- Export `FEATURE_KEY_FILE` only when a features file / content is provided; templates reference `${FEATURE_KEY_FILE}` instead of hardcoding the directive.
- Add `docker` to TLS cert SAN DNS entries so in-network hostname verification works.
- Bypass the Docker entrypoint whenever TLS is enabled (entrypoint would regenerate the mounted config).
- Relax the security-only bypass condition: no longer requires a features file.
- Pass `DEFAULT_TTL=2592000` to the container.

### Templates (`default.conf`, `multi-node.conf`, `tls.conf`)
- Replace hardcoded `feature-key-file` with `${FEATURE_KEY_FILE}` placeholder.
- In `tls.conf`, relocate `tls aerospike-tls { ... }` inside the `network {}` block.

### CI workflow `test_setup-aerospike-server.yaml`
- Scope `pull_request` trigger to changes in the action or the test workflow itself (prevents runs on unrelated PRs, including Dependabot).
- Add `test-tls-with-security` job: single node with TLS + security, asserts cert files, TLS handshake, authenticated asinfo over both service and TLS ports, and rejection of unauthenticated access.
- Add `test-tls-with-security-multi-node` job: 3-node cluster with TLS + security, asserts container presence, `cluster_size=3` via authenticated asinfo, authenticated TLS per node, and rejection of unauthenticated access.

## Test plan
- [ ] `test-tls-with-security` passes on this PR.
- [ ] `test-tls-with-security-multi-node` passes on this PR.
- [ ] Existing `setup-aerospike-server` jobs still pass (regression check for template changes).


[CLIENT-4616]: https://aerospike.atlassian.net/browse/CLIENT-4616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ