### PR TITLE
refactor(deploy-artifacts): move detect artifacts, new action

### DIFF
--- a/.github/actions/detect-artifacts/README.md
+++ b/.github/actions/detect-artifacts/README.md
@@ -1,0 +1,50 @@
+# Detect artifact types
+
+Runs [`detect_types.sh`](../../workflows/deploy-artifacts/detect_types.sh): content-based detection for ambiguous archives (npm tarballs, PyPI sdists, Go module zips) and writes `structured_build_artifacts/` plus a manifest, matching the deploy entrypoint’s detection phase.
+
+## Prerequisites
+
+- Merged build tree on disk (for example from [`collect-build-artifacts`](../collect-build-artifacts) or a `download-artifact` step with the same layout).
+- `detect_types.sh` and sibling scripts (`package_utils.sh`, `type_registry.sh`, `upload_utils.sh`, `type_detection.sh`) available. Checkout **shared-workflows** at `gh-workflows-ref` (full or sparse-checkout including `.github/workflows/deploy-artifacts/`).
+
+Runner tools used by detectors: `jq`, `tar`, `unzip` (typical GitHub-hosted Ubuntu images include these).
+
+## Inputs
+
+| Input           | Required | Default                                              | Description                            |
+| --------------- | -------- | ---------------------------------------------------- | -------------------------------------- |
+| `jf-project`    | Yes      |                                                      | JFrog project                          |
+| `jf-build-name` | Yes      |                                                      | JFrog build name                       |
+| `version`       | Yes      |                                                      | Artifact version                       |
+| `jf-build-id`   | Yes      |                                                      | Build ID / number for structuring      |
+| `script-path`   | No       | `.github/workflows/deploy-artifacts/detect_types.sh` | Path to `detect_types.sh`              |
+| `artifacts-dir` | No       | `build-artifacts`                                    | Root directory to scan                 |
+| `working-dir`   | No       | _(empty)_                                            | If set, `--working-dir` for the script |
+| `jar-group-id`  | No       | _(empty)_                                            | Maven group ID fallback                |
+| `build-type`    | No       | _(empty)_                                            | `build.type` target-prop label         |
+| `internal`      | No       | `false`                                              | Set `true` to pass `--internal`        |
+| `dry-run`       | No       | `false`                                              | Pass `--dry-run`                       |
+
+## Example (after collect, before release bundle)
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      repository: aerospike/shared-workflows
+      ref: ${{ inputs.gh-workflows-ref }}
+      path: shared-workflows
+  - uses: actions/download-artifact@v4
+    with:
+      name: build-artifacts
+      path: build-artifacts
+  - uses: aerospike/shared-workflows/.github/actions/detect-artifacts@v3
+    with:
+      jf-project: my-project
+      jf-build-name: my-build
+      version: 1.2.3
+      jf-build-id: ${{ github.run_id }}
+      script-path: shared-workflows/.github/workflows/deploy-artifacts/detect_types.sh
+```
+
+See [`reusable_artifacts-cicd.yaml`](../../workflows/reusable_artifacts-cicd.yaml) for an integrated job between matrix collect and sign.

--- a/.github/actions/detect-artifacts/action.yaml
+++ b/.github/actions/detect-artifacts/action.yaml
@@ -1,0 +1,93 @@
+name: Detect artifact types
+description: |
+  Run content-based artifact type detection (npm / PyPI sdist / Go module archives) via
+  deploy-artifacts/detect_types.sh. Intended after merged build artifacts are available
+  (e.g. collect-build-artifacts) and before downstream packaging such as create-release-bundle.
+inputs:
+  jf-project:
+    description: JFrog Artifactory project name (maps to --jf-project)
+    required: true
+  jf-build-name:
+    description: JFrog build name (maps to --jf-build-name)
+    required: true
+  version:
+    description: Artifact version string (maps to --version)
+    required: true
+  jf-build-id:
+    description: JFrog build ID / number used for structuring metadata (maps to --jf-build-id)
+    required: true
+  script-path:
+    description: Path to detect_types.sh (relative to workspace unless absolute)
+    required: false
+    default: .github/workflows/deploy-artifacts/detect_types.sh
+  artifacts-dir:
+    description: Directory containing merged build artifacts to scan (default matches collect-build-artifacts output)
+    required: false
+    default: build-artifacts
+  working-dir:
+    description: If set, passed as --working-dir (script runs after cd here)
+    required: false
+    default: ""
+  jar-group-id:
+    description: Maven group ID fallback for JAR metadata
+    required: false
+    default: ""
+  build-type:
+    description: Freeform build type label (target-props), maps to --build-type
+    required: false
+    default: ""
+  internal:
+    description: When true, passes --internal (internal-only target-props)
+    required: false
+    default: "false"
+  dry-run:
+    description: When true, passes --dry-run (structuring still uses cp; parity with deploy entrypoint)
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Detect content-based artifact types
+      shell: bash
+      run: |
+        set -euo pipefail
+        script="${{ inputs.script-path }}"
+        if [[ ! -f "$script" ]]; then
+          echo "Error: detect_types script not found at $script" >&2
+          echo "Checkout shared-workflows (or sparse-checkout deploy-artifacts) before this action." >&2
+          exit 1
+        fi
+        chmod +x "$script"
+
+        dry_run_arg=""
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          dry_run_arg="--dry-run"
+        fi
+        internal_arg=""
+        if [ "${{ inputs.internal }}" = "true" ]; then
+          internal_arg="--internal"
+        fi
+        jar_arg=()
+        if [[ -n "${{ inputs.jar-group-id }}" ]]; then
+          jar_arg=(--jar-group-id "${{ inputs.jar-group-id }}")
+        fi
+        build_type_arg=()
+        if [[ -n "${{ inputs.build-type }}" ]]; then
+          build_type_arg=(--build-type "${{ inputs.build-type }}")
+        fi
+        workdir_arg=()
+        if [[ -n "${{ inputs.working-dir }}" ]]; then
+          workdir_arg=(--working-dir "${{ inputs.working-dir }}")
+        fi
+
+        "$script" \
+          --jf-project "${{ inputs.jf-project }}" \
+          --jf-build-name "${{ inputs.jf-build-name }}" \
+          --version "${{ inputs.version }}" \
+          --jf-build-id "${{ inputs.jf-build-id }}" \
+          --artifacts-dir "${{ inputs.artifacts-dir }}" \
+          "${jar_arg[@]}" \
+          "${build_type_arg[@]}" \
+          $internal_arg \
+          $dry_run_arg \
+          "${workdir_arg[@]}"

--- a/.github/workflows/deploy-artifacts/detect_types.sh
+++ b/.github/workflows/deploy-artifacts/detect_types.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Standalone helper: run content-based type detection and structuring only
+# (structure_content_detected_files). Mirrors deploy entrypoint / workflow inputs.
+
+set -euo pipefail
+export PS4='+($LINENO): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+trap 'handle_error ${LINENO}' ERR
+# shellcheck disable=SC2317
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    echo "Error: Command failed with exit code $exit_code at line $line_number" >&2
+    exit 1
+}
+error() {
+    local reason="${1-}"
+    if [[ -n $reason ]]; then
+        echo "Error: $reason" >&2
+    else
+        echo "Error" >&2
+    fi
+    exit 1
+}
+
+DRY_RUN="false"
+BUILD_TYPE=""
+INTERNAL="false"
+BUILD_ARTIFACTS_DIR="build-artifacts"
+WORKING_DIR=""
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  detect_types.sh <project> <build-name> <version> <build-number> [OPTIONS]
+
+Or set the same values with options (can mix with positionals; unfilled slots use positionals in order):
+
+  detect_types.sh --jf-project <project> --jf-build-name <name> --version <ver> --jf-build-id <id> [OPTIONS]
+
+Runs content-based artifact detection (npm / PyPI sdist / Go module archives under
+ambiguous extensions) and copies matches into ./structured_build_artifacts/, with
+a .manifest file like the deploy entrypoint.
+
+Options (align with reusable_deploy-artifacts / entrypoint.sh):
+  --jf-project, --project <name>     JFrog project (required)
+  --jf-build-name, --build-name <n> Build name (required)
+  --version <ver>                    Artifact version (required)
+  --jf-build-id, --build-number <id> Build ID / number (required)
+  --jar-group-id <group-id>          Maven group ID fallback for JAR metadata
+  --build-type <label>               Target-prop build.type (e.g. release, nightly)
+  --internal                         Set internal=true style metadata path (registry)
+  --artifacts-dir <path>             Input tree root to scan (default: build-artifacts).
+                                     Must match paths returned by find (same as BUILD_ARTIFACTS_DIR).
+  --working-dir <path>               cd here before reading artifacts / writing output
+  --dry-run                          Accepted for parity with entrypoint (structuring uses cp)
+  --help, -h                         This help
+
+Environment:
+  BUILD_ARTIFACTS_DIR                Same as --artifacts-dir if set before invocation
+EOF
+}
+
+echo "Command line: $0 $*" >&2
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+    --jar-group-id)
+        JAR_GROUP_ID="$2"
+        shift 2
+        ;;
+    --build-type)
+        # shellcheck disable=SC2034
+        BUILD_TYPE="$2"
+        shift 2
+        ;;
+    --internal)
+        # shellcheck disable=SC2034
+        INTERNAL="true"
+        shift
+        ;;
+    --artifacts-dir)
+        BUILD_ARTIFACTS_DIR="$2"
+        shift 2
+        ;;
+    --working-dir)
+        WORKING_DIR="$2"
+        shift 2
+        ;;
+    --jf-project | --project)
+        PROJECT="$2"
+        shift 2
+        ;;
+    --jf-build-name | --build-name)
+        BUILD_NAME="$2"
+        shift 2
+        ;;
+    --version)
+        VERSION="$2"
+        shift 2
+        ;;
+    --jf-build-id | --build-number)
+        BUILD_NUMBER="$2"
+        shift 2
+        ;;
+    --help | -h)
+        usage
+        exit 0
+        ;;
+    -*)
+        echo "Unknown option: $1" >&2
+        usage
+        exit 1
+        ;;
+    *)
+        if [[ -z ${PROJECT-} ]]; then
+            PROJECT="$1"
+        elif [[ -z ${BUILD_NAME-} ]]; then
+            BUILD_NAME="$1"
+        elif [[ -z ${VERSION-} ]]; then
+            VERSION="$1"
+        elif [[ -z ${BUILD_NUMBER-} ]]; then
+            BUILD_NUMBER="$1"
+        else
+            echo "Unexpected argument: $1" >&2
+            usage
+            exit 1
+        fi
+        shift
+        ;;
+    esac
+done
+
+if [[ -z ${PROJECT-} ]]; then
+    error "project is required (positional or --jf-project / --project)
+Use --help for usage"
+fi
+if [[ -z ${BUILD_NAME-} ]]; then
+    error "build-name is required (positional or --jf-build-name / --build-name)
+Use --help for usage"
+fi
+if [[ -z ${VERSION-} ]]; then
+    error "version is required (positional or --version)
+Use --help for usage"
+fi
+if [[ -z ${BUILD_NUMBER-} ]]; then
+    error "build-number is required (positional or --jf-build-id / --build-number)
+Use --help for usage"
+fi
+
+export JAR_GROUP_ID
+export ARTIFACT_BUILD_NUMBER="$BUILD_NUMBER-artifacts"
+export BUILD_ARTIFACTS_DIR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n $WORKING_DIR ]]; then
+    cd "$WORKING_DIR" || error "cannot cd to --working-dir: $WORKING_DIR"
+fi
+[[ -d $BUILD_ARTIFACTS_DIR ]] || error "artifacts directory not found: $BUILD_ARTIFACTS_DIR (cwd: $(pwd))"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/package_utils.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/type_registry.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/upload_utils.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/type_detection.sh"
+
+run() {
+    if [[ $DRY_RUN == "true" ]]; then
+        local green='\033[0;32m'
+        local reset='\033[0m'
+        echo -e "${green}   $*${reset}" >&2
+    else
+        "$@"
+    fi
+}
+
+echo "Content-based type detection (artifacts root: $BUILD_ARTIFACTS_DIR)..." >&2
+init_manifest
+for dir in "${TYPE_STRUCT_DIR[@]}"; do
+    mkdir -p "structured_build_artifacts/$dir"
+done
+structure_content_detected_files
+echo "Done. Structured tree: $(pwd)/structured_build_artifacts" >&2

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -126,6 +126,8 @@ source "$SCRIPT_DIR/package_utils.sh"
 source "$SCRIPT_DIR/type_registry.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/upload_utils.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/type_detection.sh"
 
 # Wrapper function that either executes or echoes commands
 run() {
@@ -170,45 +172,6 @@ structure_standalone_poms() {
             cp "$pom.asc" "$target/"
         fi
     done < <(find build-artifacts -name "*.pom" -print0)
-}
-
-structure_content_detected_files() {
-    # Build the find pattern from CONTENT_DETECT_EXTENSIONS
-    local -a find_args=()
-    for i in "${!CONTENT_DETECT_EXTENSIONS[@]}"; do
-        ((i > 0)) && find_args+=(-o)
-        find_args+=(-name "${CONTENT_DETECT_EXTENSIONS[$i]}")
-    done
-
-    while IFS= read -r -d '' file; do
-        [[ -f $file ]] || continue
-        local matched=false
-        for type in "${CONTENT_DETECT_ORDER[@]}"; do
-            local detector="${TYPE_CONTENT_DETECT[$type]}"
-            if "$detector" "$file"; then
-                echo "Processing ${type^^}: $file" >&2
-                local dest="./structured_build_artifacts/${TYPE_STRUCT_DIR[$type]}"
-                local processor="process_${type}"
-                local target_path
-                target_path=$("$processor" "$file" "$dest")
-                if [[ -n $target_path ]]; then
-                    gather_companions "$file" "$(dirname "$target_path")" "$type"
-                    manifest_add "$target_path" "$type"
-                fi
-                matched=true
-                break
-            fi
-        done
-        if [[ $matched == false ]]; then
-            echo "Processing generic tarball: $file" >&2
-            local target_path
-            target_path=$(process_generic "$file" "./structured_build_artifacts/generic")
-            if [[ -n $target_path ]]; then
-                gather_companions "$file" "$(dirname "$target_path")" "generic"
-                manifest_add "$target_path" "generic"
-            fi
-        fi
-    done < <(find build-artifacts \( "${find_args[@]}" \) -print0)
 }
 
 structure_generic_files() {

--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -207,17 +207,20 @@ get_nupkg_metadata() {
     echo "$pkgname $version"
 }
 
-# Copy a file to dest_dir, preserving its relative path within build-artifacts/.
+# Copy a file to dest_dir, preserving its relative path within the artifacts tree.
+# BUILD_ARTIFACTS_DIR (default: build-artifacts) must match the directory find uses as root.
 # Additional prefixes (e.g. "unsigned-artifacts") can be stripped via extra arguments.
 # Usage: copy_to_structured <file> <dest_dir> [prefix_to_strip ...]
 copy_to_structured() {
     local file="$1" dest_dir="$2"
     shift 2
 
+    local artifacts_root="${BUILD_ARTIFACTS_DIR:-build-artifacts}"
     local dir
     dir=$(dirname "$file")
-    dir="${dir#build-artifacts/}"
-    dir="${dir#build-artifacts}"
+    # TODO: mistake? Why are we stripping the artifacts_root twice?
+    dir="${dir#"$artifacts_root"/}"
+    dir="${dir#"$artifacts_root"}"
     for prefix in "$@"; do
         dir="${dir#"$prefix"/}"
         dir="${dir#"$prefix"}"

--- a/.github/workflows/deploy-artifacts/type_detection.sh
+++ b/.github/workflows/deploy-artifacts/type_detection.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# type_detection.sh - Content-based artifact type detection during structuring
+#
+# Required (sourced by entrypoint.sh after package_utils.sh, type_registry.sh, upload_utils.sh):
+#   CONTENT_DETECT_EXTENSIONS, CONTENT_DETECT_ORDER, TYPE_CONTENT_DETECT, TYPE_STRUCT_DIR
+#   gather_companions, manifest_add, process_* helpers from package_utils.sh
+#
+# Optional: BUILD_ARTIFACTS_DIR (default build-artifacts) — must match copy_to_structured() in package_utils.sh
+
+structure_content_detected_files() {
+    local artifacts_root="${BUILD_ARTIFACTS_DIR:-build-artifacts}"
+    # Build the find pattern from CONTENT_DETECT_EXTENSIONS
+    local -a find_args=()
+    for i in "${!CONTENT_DETECT_EXTENSIONS[@]}"; do
+        ((i > 0)) && find_args+=(-o)
+        find_args+=(-name "${CONTENT_DETECT_EXTENSIONS[$i]}")
+    done
+
+    while IFS= read -r -d '' file; do
+        [[ -f $file ]] || continue
+        local matched=false
+        for type in "${CONTENT_DETECT_ORDER[@]}"; do
+            local detector="${TYPE_CONTENT_DETECT[$type]}"
+            if "$detector" "$file"; then
+                echo "Processing ${type^^}: $file" >&2
+                local dest="./structured_build_artifacts/${TYPE_STRUCT_DIR[$type]}"
+                local processor="process_${type}"
+                local target_path
+                target_path=$("$processor" "$file" "$dest")
+                if [[ -n $target_path ]]; then
+                    gather_companions "$file" "$(dirname "$target_path")" "$type"
+                    manifest_add "$target_path" "$type"
+                fi
+                matched=true
+                break
+            fi
+        done
+        if [[ $matched == false ]]; then
+            echo "Processing generic tarball: $file" >&2
+            local target_path
+            target_path=$(process_generic "$file" "./structured_build_artifacts/generic")
+            if [[ -n $target_path ]]; then
+                gather_companions "$file" "$(dirname "$target_path")" "generic"
+                manifest_add "$target_path" "generic"
+            fi
+        fi
+    done < <(find "$artifacts_root" \( "${find_args[@]}" \) -print0)
+}

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -370,9 +370,49 @@ jobs:
           path: build-artifacts
           retention-days: ${{ inputs.gh-retention-days }}
 
+  # Content-based type detection on merged artifacts (before sign / deploy and any create-release-bundle follow-up).
+  detect-artifacts:
+    needs: [resolve, collect-matrix-artifacts]
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Download merged build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-artifacts
+          path: build-artifacts
+          merge-multiple: true
+
+      - name: Checkout shared-workflows repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: aerospike/shared-workflows
+          ref: ${{ inputs.gh-workflows-ref }}
+          path: ${{ inputs.gh-checkout-path }}
+          fetch-depth: 1
+
+      - name: Detect artifact types
+        uses: ./.github/actions/detect-artifacts
+        with:
+          jf-project: ${{ inputs.jf-project }}
+          jf-build-name: ${{ inputs.jf-build-name }}
+          version: ${{ inputs.version }}
+          jf-build-id: ${{ needs.resolve.outputs.jf-build-id }}
+          script-path: ${{ inputs.gh-checkout-path }}/.github/workflows/deploy-artifacts/detect_types.sh
+          artifacts-dir: build-artifacts
+          jar-group-id: ${{ inputs.jar-group-id }}
+          build-type: ${{ inputs.build-type }}
+          internal: ${{ inputs.internal }}
+          dry-run: ${{ inputs.dry-run }}
+
+
   sign-mac:
     if: inputs.sign-mac
-    needs: [resolve, collect-matrix-artifacts]
+    needs: [resolve, collect-matrix-artifacts, detect-artifacts]
     uses: ./.github/workflows/reusable_sign-mac-artifacts.yaml
     with:
       gh-unsigned-artifacts: build-artifacts
@@ -388,7 +428,7 @@ jobs:
     secrets: inherit
 
   sign:
-    needs: [resolve, collect-matrix-artifacts, sign-mac]
+    needs: [resolve, collect-matrix-artifacts, sign-mac, detect-artifacts]
     if: always() && !cancelled() && needs.collect-matrix-artifacts.result == 'success' && needs.sign-mac.result != 'failure'
     uses: ./.github/workflows/reusable_sign-artifacts.yaml
     with:


### PR DESCRIPTION
[INFRA-426](https://aerospike.atlassian.net/browse/INFRA-426)

Goal is to make detection reusable inside different workflows along with the same deploy-artifacts activity.

[INFRA-426]: https://aerospike.atlassian.net/browse/INFRA-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ