### PR TITLE
fix(deploy-artifacts): [INFRA-426] let detect-artifacts checkout use default path

### DIFF
--- a/.github/workflows/deploy-artifacts/detect_types.sh
+++ b/.github/workflows/deploy-artifacts/detect_types.sh
@@ -181,6 +181,7 @@ run() {
 }
 
 echo "Content-based type detection (artifacts root: $BUILD_ARTIFACTS_DIR)..." >&2
+mkdir -p structured_build_artifacts
 init_manifest
 for dir in "${TYPE_STRUCT_DIR[@]}"; do
     mkdir -p "structured_build_artifacts/$dir"

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -396,18 +396,25 @@ jobs:
           fetch-depth: 1
 
       - name: Detect artifact types
-        uses: ./.github/actions/detect-artifacts
-        with:
-          jf-project: ${{ inputs.jf-project }}
-          jf-build-name: ${{ inputs.jf-build-name }}
-          version: ${{ inputs.version }}
-          jf-build-id: ${{ needs.resolve.outputs.jf-build-id }}
-          script-path: ${{ inputs.gh-checkout-path }}/.github/workflows/deploy-artifacts/detect_types.sh
-          artifacts-dir: build-artifacts
-          jar-group-id: ${{ inputs.jar-group-id }}
-          build-type: ${{ inputs.build-type }}
-          internal: ${{ inputs.internal }}
-          dry-run: ${{ inputs.dry-run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="${{ inputs.gh-checkout-path }}/.github/workflows/deploy-artifacts/detect_types.sh"
+          chmod +x "$script"
+
+          args=(
+            --jf-project "${{ inputs.jf-project }}"
+            --jf-build-name "${{ inputs.jf-build-name }}"
+            --version "${{ inputs.version }}"
+            --jf-build-id "${{ needs.resolve.outputs.jf-build-id }}"
+            --artifacts-dir build-artifacts
+          )
+          [[ -n "${{ inputs.jar-group-id }}" ]] && args+=(--jar-group-id "${{ inputs.jar-group-id }}")
+          [[ -n "${{ inputs.build-type }}" ]] && args+=(--build-type "${{ inputs.build-type }}")
+          [[ "${{ inputs.internal }}" == "true" ]] && args+=(--internal)
+          [[ "${{ inputs.dry-run }}" == "true" ]] && args+=(--dry-run)
+
+          "$script" "${args[@]}"
 
   sign-mac:
     if: inputs.sign-mac

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -392,29 +392,20 @@ jobs:
         with:
           repository: aerospike/shared-workflows
           ref: ${{ inputs.gh-workflows-ref }}
-          path: ${{ inputs.gh-checkout-path }}
           fetch-depth: 1
 
       - name: Detect artifact types
-        shell: bash
-        run: |
-          set -euo pipefail
-          script="${{ inputs.gh-checkout-path }}/.github/workflows/deploy-artifacts/detect_types.sh"
-          chmod +x "$script"
-
-          args=(
-            --jf-project "${{ inputs.jf-project }}"
-            --jf-build-name "${{ inputs.jf-build-name }}"
-            --version "${{ inputs.version }}"
-            --jf-build-id "${{ needs.resolve.outputs.jf-build-id }}"
-            --artifacts-dir build-artifacts
-          )
-          [[ -n "${{ inputs.jar-group-id }}" ]] && args+=(--jar-group-id "${{ inputs.jar-group-id }}")
-          [[ -n "${{ inputs.build-type }}" ]] && args+=(--build-type "${{ inputs.build-type }}")
-          [[ "${{ inputs.internal }}" == "true" ]] && args+=(--internal)
-          [[ "${{ inputs.dry-run }}" == "true" ]] && args+=(--dry-run)
-
-          "$script" "${args[@]}"
+        uses: ./.github/actions/detect-artifacts
+        with:
+          jf-project: ${{ inputs.jf-project }}
+          jf-build-name: ${{ inputs.jf-build-name }}
+          version: ${{ inputs.version }}
+          jf-build-id: ${{ needs.resolve.outputs.jf-build-id }}
+          artifacts-dir: build-artifacts
+          jar-group-id: ${{ inputs.jar-group-id }}
+          build-type: ${{ inputs.build-type }}
+          internal: ${{ inputs.internal }}
+          dry-run: ${{ inputs.dry-run }}
 
   sign-mac:
     if: inputs.sign-mac

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -380,19 +380,19 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Download merged build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: build-artifacts
-          path: build-artifacts
-          merge-multiple: true
-
       - name: Checkout shared-workflows repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: aerospike/shared-workflows
           ref: ${{ inputs.gh-workflows-ref }}
           fetch-depth: 1
+
+      - name: Download merged build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-artifacts
+          path: build-artifacts
+          merge-multiple: true
 
       - name: Detect artifact types
         uses: ./.github/actions/detect-artifacts


### PR DESCRIPTION
## Summary

The `detect-artifacts` composite action added in PR 211 never resolved because the shared-workflows checkout was placed in a subdir, and `uses: ./...` is only found at `$GITHUB_WORKSPACE` root. Letting that one checkout fall back to its default path makes the action load. The job touches no consumer source, so no subdir isolation is needed.

## Changes

- `reusable_artifacts-cicd.yaml`: drop `path:` on the detect-artifacts checkout so shared-workflows lands at workspace root.
- `reusable_artifacts-cicd.yaml`: swap step order so checkout runs before `download-artifact` (checkout's default `clean: true` was wiping `build-artifacts/`).
- `detect_types.sh`: `mkdir -p structured_build_artifacts` before `init_manifest` (preexisting bug, only exposed now that this script runs standalone).

## Test plan

- Test: Artifacts CI/CD run on this branch passes end to end.
- No input-surface changes; external consumers are unaffected.