### PR TITLE
feat(deploy-artifacts): [INFRA-475] add ubuntu26.04 (resolute) codename mapping

### DIFF
--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -137,6 +137,7 @@ get_codename_for_deb() {
     *ubuntu20.04*) echo "focal" ;;
     *ubuntu22.04*) echo "jammy" ;;
     *ubuntu24.04*) echo "noble" ;;
+    *ubuntu26.04*) echo "resolute" ;;
     *debian11*) echo "bullseye" ;;
     *debian12*) echo "bookworm" ;;
     *debian13*) echo "trixie" ;;

--- a/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
@@ -24,6 +24,11 @@ setup() {
     [[ "$result" == "noble" ]]
 }
 
+@test "get_codename_for_deb maps ubuntu26.04 to resolute" {
+    result=$(get_codename_for_deb "test-ubuntu26.04.deb")
+    [[ "$result" == "resolute" ]]
+}
+
 @test "get_codename_for_deb maps ubuntu20.04 to focal" {
     result=$(get_codename_for_deb "test-ubuntu20.04.deb")
     [[ "$result" == "focal" ]]


### PR DESCRIPTION
## Summary

- Add `ubuntu26.04 → resolute` to `get_codename_for_deb` in `package_utils.sh`.
- Without this mapping, `deploy-artifacts` fails with `distro ... not supported` when uploading ubuntu26.04 DEB packages. Observed in [citrusleaf/voyager run 24747922194](https://github.com/citrusleaf/voyager/actions/runs/24747922194), where the release workflow builds ubuntu26.04 packages but the shared deploy entrypoint rejects them.

## Jira

https://aerospike.atlassian.net/browse/INFRA-475

## Changes

### `deploy-artifacts/package_utils.sh`
- Add `*ubuntu26.04*) echo "resolute" ;;` case to `get_codename_for_deb`, between ubuntu24.04 (noble) and debian11 (bullseye).

### `deploy-artifacts/tests/bats/test_metadata.bats`
- Add `get_codename_for_deb maps ubuntu26.04 to resolute` test case.

## Test plan

- [x] All 38 metadata bats tests pass locally (including the new ubuntu26.04 test)
- [x] No changes to upload logic, structuring, or any other entrypoint code