### PR TITLE
docs(pr-hygiene): [INFRA-481] clarify jira enforcement, skip label, and consumer usage

### DIFF
--- a/.github/workflows/pr-hygiene/README.md
+++ b/.github/workflows/pr-hygiene/README.md
@@ -12,13 +12,33 @@ type(scope): [JIRA-123] description
 
 - **type**: `feat|fix|refactor|docs|test|ci|chore|build|perf` (validated by commitlint)
 - **scope**: optional, lowercase (e.g., `workflows`, `deploy`, `actions`)
-- **JIRA**: uppercase project key in brackets, required for certain types (see `types-requiring-jira`)
+- **JIRA**: uppercase project key in brackets, required for certain types (see [Types and Jira enforcement](#types-and-jira-enforcement))
 
 Examples:
 
 - `feat(workflows): [INFRA-370] add artifacts-cicd integration tests`
 - `fix(deploy): [ENG-123] correct artifact routing logic`
-- `chore: [INFRA-400] update dependencies`
+- `chore: update dependencies`
+
+## Types and Jira enforcement
+
+Not every commit type needs a Jira ticket. The defaults split `feat|fix|refactor|docs|test|ci|chore|build|perf` into two groups, based on whether the change should be traceable back to a planned work item.
+
+| Commit type                             | Jira ticket  |
+| --------------------------------------- | ------------ |
+| `feat`, `fix`, `refactor`, `docs`, `ci` | **Required** |
+| `chore`, `build`, `test`, `perf`        | Optional     |
+
+Required types correspond to user-visible or traceable work: new features, bug fixes, meaningful refactors, published docs, and CI changes that affect how the project is built or released. Optional types cover housekeeping, dependency bumps, internal tests, and performance tuning that often lacks a dedicated ticket.
+
+Override with the `types-requiring-jira` input to narrow, expand, or disable Jira enforcement for your repo. Setting it to the empty string disables Jira enforcement entirely.
+
+## Bypassing Jira enforcement
+
+Sometimes a required-type PR legitimately has no Jira ticket (an urgent fix, an externally driven change, a cleanup merged during a freeze). Two bypass mechanisms are available, in priority order:
+
+1. **The `skip-jira` label.** Add the `skip-jira` label to the PR (name configurable via `skip-jira-label`). Commitlint still runs, but the Jira ticket requirement is skipped. The caller must also pass the PR's labels via `pr-labels` for the label check to work. See the [example](#example-usage) below.
+2. **The [allowlist](#allowlist-for-automated-prs).** If the PR title matches one of the `allowed-patterns` regexes, both commitlint and Jira validation are skipped. Use this for bot-generated PRs and other predictable title shapes, not for one-off human overrides.
 
 ## Allowlist for Automated PRs
 
@@ -43,7 +63,7 @@ To add patterns while keeping the defaults, include them alongside the built-in 
 ```yaml
 jobs:
   validate:
-    uses: aerospike/shared-workflows/.github/workflows/reusable_pr-hygiene.yml@<sha>
+    uses: aerospike/shared-workflows/.github/workflows/reusable_pr-hygiene.yml@<sha> # vX.Y.Z
     with:
       pr_title: ${{ github.event.pull_request.title }}
       allowed-patterns: |
@@ -76,6 +96,8 @@ with:
 
 ## Example Usage
 
+Consumer repos call the reusable workflow via the fully-qualified path with a pinned SHA and semver comment:
+
 ```yaml
 name: PR Hygiene
 
@@ -88,11 +110,13 @@ permissions:
 
 jobs:
   validate:
-    uses: ./.github/workflows/reusable_pr-hygiene.yml
+    uses: aerospike/shared-workflows/.github/workflows/reusable_pr-hygiene.yml@<sha> # vX.Y.Z
     with:
       pr_title: ${{ github.event.pull_request.title }}
       pr-labels: ${{ toJSON(github.event.pull_request.labels.*.name) }}
 ```
+
+Passing `pr-labels` is what lets the `skip-jira` label bypass work. Without it, the label check has no data and falls through.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Add a "Types and Jira enforcement" section that surfaces which commit types require a Jira ticket, with rationale. Today this information is buried in the inputs table and the split (feat/fix/refactor/docs/ci vs chore/build/test/perf) is easy to miss.
- Add a "Bypassing Jira enforcement" section documenting the `skip-jira` label (and cross-referencing the existing allowlist).
- Fix the Example Usage block to use the fully-qualified external form (`aerospike/shared-workflows/.github/workflows/reusable_pr-hygiene.yml@<sha> # vX.Y.Z`) and include `pr-labels`. The old example used `./.github/workflows/reusable_pr-hygiene.yml`, which only works inside this repo and would silently break for external consumers who copy it.
- Simplify one misleading example (`chore: [INFRA-400] update dependencies` to `chore: update dependencies`) so the optional-Jira case is visible.

## Why
Surfaced while onboarding [aerospike/aerospike-langgraph](https://github.com/aerospike/aerospike-langgraph) in [INFRA-481](https://aerospike.atlassian.net/browse/INFRA-481). Two real gaps:

1. The `skip-jira` label bypass is implemented but undocumented, and consumers who copy the template end up without `pr-labels` so the label check silently has no effect.
2. The types-requiring-jira default is easy to overlook, producing red X on PRs that a reader can't puzzle out without reading the workflow source.

## Test plan
- [x] Render the README on GitHub and confirm both new sections link correctly (`#types-and-jira-enforcement`, `#bypassing-jira-enforcement`).
- [x] Confirm PR Hygiene check passes on this PR (title contains [INFRA-481], type is `docs` which requires Jira, and we're providing it).
- [x] Confirm Trunk Check passes.

[INFRA-400]: https://aerospike.atlassian.net/browse/INFRA-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-481]: https://aerospike.atlassian.net/browse/INFRA-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ