### PR TITLE
fix(docker): [INFRA-481] sanitize semver '+' build metadata in image tags

### DIFF
--- a/.github/workflows/reusable_docker-build-deploy.yaml
+++ b/.github/workflows/reusable_docker-build-deploy.yaml
@@ -190,6 +190,9 @@ jobs:
           # Extract major version (handle 'v' prefix, take first number before first dot)
           app_version="${{ inputs.app-version }}"
           app_version="${app_version#v}"  # Strip 'v' prefix if present
+          # OCI tags forbid '+' but SemVer build metadata uses it (e.g. 1.2.3+abc).
+          # Replace with '-' so SemVer inputs still produce valid image tags.
+          app_version="${app_version//+/-}"
           major_version="${app_version%%.*}"  # Extract first number before first dot
 
           # Build immutable tag (always included)


### PR DESCRIPTION
## Summary
- In the Compute tags step of [reusable_docker-build-deploy.yaml](https://github.com/aerospike/shared-workflows/blob/fix/docker-tag-strip-semver-build-metadata/.github/workflows/reusable_docker-build-deploy.yaml), replace `+` with `-` in `app_version` after the existing `v` prefix strip.

## Why
OCI image tags only allow `[A-Za-z0-9_.-]` and cannot start with `.` or `-`. SemVer build metadata legitimately uses `+` (e.g. `0.0.0-dev+abc1234`), which is a valid version string but an invalid tag. When `extract-version-from-tag` falls back to `0.0.0-dev+<sha>` and passes it to the docker workflow, buildx rejects every tag that contains the version, failing the whole build even though `latest` and the major tag (`0`) would be fine.

Surfaced on [this failed Publish All Types run](https://github.com/citrusleaf/shared-workflows-test/actions/runs/24794297582/job/72559907771) under [INFRA-481](https://aerospike.atlassian.net/browse/INFRA-481). The corresponding consumer-side fix (fetch full history so `git describe --tags` resolves real tags instead of the 0.0.0 fallback) has already landed in shared-workflows-test. This is the defense-in-depth fix so a SemVer input with build metadata never explodes the docker build again.

## Test plan
- [ ] PR Hygiene check passes (title contains [INFRA-481]).
- [ ] Trunk Check passes.
- [ ] Confirm bash substitution behavior: `v0.0.0-dev+abc` becomes `0.0.0-dev-abc`, producing valid OCI tags like `registry/image:0.0.0-dev-abc_20260422T180250Z`.

[INFRA-481]: https://aerospike.atlassian.net/browse/INFRA-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-481]: https://aerospike.atlassian.net/browse/INFRA-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ