### PR TITLE
refactor: [INFRA-427] Consolidate type detection methods

### DIFF
--- a/.github/workflows/deploy-artifacts/README.md
+++ b/.github/workflows/deploy-artifacts/README.md
@@ -33,7 +33,7 @@ The deploy pipeline uses a centralized type registry (`type_registry.sh`). To ad
 
 **Types with ambiguous extensions** (like npm and PyPI, which share `.tgz`/`.tar.gz` with generic tarballs) also need:
 
-- A content-detection function (e.g., `is_npm_package`, `is_pypi_sdist`) in `package_utils.sh`
+- A content-detection function (e.g., `is_npm_package`, `is_pypi_package`) in `type_detection.sh` (after `package_utils.sh` for shared helpers)
 - A detector entry in the unified tarball content-detection block in `entrypoint.sh`'s `structure_build_artifacts()`
 - The ambiguous extension added to `get_known_extensions()` if not already covered by `TYPE_EXTENSIONS`
 

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -163,6 +163,11 @@ structure_standalone_poms() {
         group_path="${group_id//./\/}"
 
         target="./structured_build_artifacts/jar/${group_path}/${artifact_id}/${version}"
+        # Safeguard against duplicate processing
+        if [[ -f "$target/$(basename "$pom")" ]]; then
+            echo "Skipping standalone POM (already structured): $pom" >&2
+            continue
+        fi
         mkdir -p "$target"
         cp "$pom" "$target/"
         manifest_add "$target/$(basename "$pom")" "jar"

--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -261,16 +261,6 @@ _extract_npm_package_json() {
     tar -xOzf "$file" "$pkg_path" 2>/dev/null
 }
 
-# Check if a .tgz file is an npm package.
-# Validates that the tarball contains a root-level package.json with name and version fields.
-# Args: <tgz_file>
-# Returns: 0 if npm package, 1 otherwise.
-is_npm_package() {
-    local file="$1"
-    _extract_npm_package_json "$file" |
-        jq -e '.name and .version' >/dev/null 2>&1
-}
-
 # Validate an npm package name.
 # npm names must be lowercase, may be scoped (@scope/name), and contain only
 # alphanumerics, hyphens, dots, underscores, and tildes. Rejects names with
@@ -285,7 +275,7 @@ _validate_npm_name() {
 }
 
 # Extract npm package metadata (name and version).
-# Caller must ensure the file is a valid npm package (via is_npm_package).
+# Caller must ensure the file is a valid npm package (via is_npm_package in type_detection.sh).
 # Args: <tgz_file>
 # Returns: "name version" on stdout.
 get_npm_metadata() {
@@ -309,18 +299,6 @@ get_npm_metadata() {
 process_npm() { copy_to_structured "$1" "$2"; }
 
 # --- PyPI (Python) package functions ---
-
-# Check if a .tar.gz file is a Python source distribution.
-# Python sdists contain a root-level PKG-INFO file (mandatory per PEP 625).
-# Args: <tar_gz_file>
-# Returns: 0 if the tarball is an sdist, 1 otherwise.
-is_pypi_sdist() {
-    local file="$1"
-    # Capture full listing to avoid SIGPIPE from tar when grep matches early.
-    local listing
-    listing=$(tar -tzf "$file" 2>/dev/null) || return 1
-    echo "$listing" | grep -qE '^[^/]+/PKG-INFO$'
-}
 
 # Validate a Python package name against PEP 508 naming rules.
 # Rejects names that could inject JFrog target-props (semicolons, etc.).
@@ -434,17 +412,6 @@ process_pypi() { copy_to_structured "$1" "$2"; }
 
 # --- Go module functions ---
 
-# Check if a .zip file is a Go module archive.
-# Go module zips have files prefixed with module@version/ and contain go.mod.
-# Args: <zip_file>
-# Returns: 0 if Go module, 1 otherwise.
-is_go_module() {
-    local file="$1"
-    local listing
-    listing=$(unzip -Z1 "$file" 2>/dev/null) || return 1
-    echo "$listing" | grep -qE '^[^@]+@v[^/]+/go\.mod$'
-}
-
 # Validate a Go module path.
 # Go module paths are slash-separated, each element matching [a-zA-Z0-9._~-]+.
 # The first element must contain a dot (domain name). Rejects semicolons and other
@@ -464,6 +431,7 @@ _validate_go_module_path() {
 
 # Extract Go module metadata (module path and version) from a Go module zip.
 # Go module zips have entries prefixed with module@version/.
+# Use is_go_module (type_detection.sh) before treating a zip as a Go module for routing.
 # Args: <zip_file>
 # Returns: "module_path version" on stdout.
 get_go_metadata() {

--- a/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
@@ -7,6 +7,7 @@ DEPLOY_DIR="$GIT_ROOT/.github/workflows/deploy-artifacts"
 
 setup() {
     source "$DEPLOY_DIR/package_utils.sh"
+    source "$DEPLOY_DIR/type_detection.sh"
     # package_utils.sh sets strict mode and an ERR trap that interferes with bats assertions
     set +eu
     trap - ERR
@@ -184,26 +185,26 @@ setup() {
     _validate_npm_name "@aerospike/client"
 }
 
-# --- is_pypi_sdist ---
+# --- is_pypi_package (type_detection.sh; metadata-based sdist / wheel) ---
 
-@test "is_pypi_sdist returns true for sdist tarball" {
+@test "is_pypi_package returns true for sdist tarball with PKG-INFO Name/Version" {
     local test_dir
     test_dir=$(mktemp -d)
     mkdir -p "$test_dir/mypackage-1.0.0"
     echo -e "Metadata-Version: 2.1\nName: mypackage\nVersion: 1.0.0" > "$test_dir/mypackage-1.0.0/PKG-INFO"
     tar -czf "$test_dir/mypackage-1.0.0.tar.gz" -C "$test_dir" mypackage-1.0.0/
     rm -rf "$test_dir/mypackage-1.0.0"
-    is_pypi_sdist "$test_dir/mypackage-1.0.0.tar.gz"
+    is_pypi_package "$test_dir/mypackage-1.0.0.tar.gz"
     rm -rf "$test_dir"
 }
 
-@test "is_pypi_sdist returns false for non-sdist tarball" {
+@test "is_pypi_package returns false for tarball without Python package metadata" {
     local test_dir
     test_dir=$(mktemp -d)
     echo "not a python package" > "$test_dir/data.txt"
     tar -czf "$test_dir/plain.tar.gz" -C "$test_dir" data.txt
     rm -f "$test_dir/data.txt"
-    run is_pypi_sdist "$test_dir/plain.tar.gz"
+    run is_pypi_package "$test_dir/plain.tar.gz"
     [[ $status -ne 0 ]]
     rm -rf "$test_dir"
 }
@@ -274,7 +275,7 @@ setup() {
     [[ "$result" == "aerospike-hello" ]]
 }
 
-# --- is_go_module ---
+# --- is_go_module (type_detection.sh) ---
 
 @test "is_go_module returns true for Go module zip" {
     local test_dir

--- a/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
@@ -57,7 +57,7 @@ setup() {
 
 @test "TYPE_CONTENT_DETECT maps types to detection functions" {
     [[ "${TYPE_CONTENT_DETECT[npm]}" == "is_npm_package" ]]
-    [[ "${TYPE_CONTENT_DETECT[pypi]}" == "is_pypi_sdist" ]]
+    [[ "${TYPE_CONTENT_DETECT[pypi]}" == "is_pypi_package" ]]
     [[ "${TYPE_CONTENT_DETECT[go]}" == "is_go_module" ]]
 }
 

--- a/.github/workflows/deploy-artifacts/type_detection.sh
+++ b/.github/workflows/deploy-artifacts/type_detection.sh
@@ -54,37 +54,37 @@ _require_nonempty_name_version() {
 }
 
 _identify_python_wheel() {
-    local f="$1"
-    [[ -n $f && -f $f && -r $f ]] || return 1
+    local file="$1"
+    [[ -n $file && -f $file && -r $file ]] || return 1
 
     local metadata_member
-    metadata_member=$(unzip -Z1 "$f" 2>/dev/null | awk '/\.dist-info\/METADATA$/ {print; exit}') || return 1
+    metadata_member=$(unzip -Z1 "$file" 2>/dev/null | awk '/\.dist-info\/METADATA$/ {print; exit}') || return 1
     if [[ -z $metadata_member ]]; then
-        echo "Not a Python wheel: $f (missing .dist-info/METADATA)" >&2
+        echo "Not a Python wheel: $file (missing .dist-info/METADATA)" >&2
         return 1
     fi
 
     local metadata
-    metadata=$(unzip -p "$f" "$metadata_member" 2>/dev/null) || return 1
+    metadata=$(unzip -p "$file" "$metadata_member" 2>/dev/null) || return 1
     if ! _require_nonempty_name_version "$metadata"; then
-        echo "Not a Python wheel: $f (METADATA missing Name/Version)" >&2
+        echo "Not a Python wheel: $file (METADATA missing Name/Version)" >&2
         return 1
     fi
     return 0
 }
 
 _identify_python_sdist() {
-    local f="$1"
-    [[ -n $f && -f $f && -r $f ]] || return 1
+    local file="$1"
+    [[ -n $file && -f $file && -r $file ]] || return 1
 
     local listing
-    listing=$(tar -tzf "$f" 2>/dev/null) || return 1
+    listing=$(tar -tzf "$file" 2>/dev/null) || return 1
 
     local metadata_member
     metadata_member=$(awk '/(^|\/)\.dist-info\/METADATA\r?$/ {print; exit}' <<<"$listing")
     if [[ -n $metadata_member ]]; then
         local metadata
-        metadata=$(tar -xzf "$f" -O "$metadata_member" 2>/dev/null) || return 1
+        metadata=$(tar -xzf "$file" -O "$metadata_member" 2>/dev/null) || return 1
         if _require_nonempty_name_version "$metadata"; then
             return 0
         fi
@@ -94,13 +94,13 @@ _identify_python_sdist() {
     pkg_info_member=$(awk '/(^|\/)PKG-INFO\r?$/ {print; exit}' <<<"$listing")
     if [[ -n $pkg_info_member ]]; then
         local pkg_info
-        pkg_info=$(tar -xzf "$f" -O "$pkg_info_member" 2>/dev/null) || return 1
+        pkg_info=$(tar -xzf "$file" -O "$pkg_info_member" 2>/dev/null) || return 1
         if _require_nonempty_name_version "$pkg_info"; then
             return 0
         fi
     fi
 
-    echo "Not a Python source dist: $f (PKG-INFO/METADATA missing Name/Version)" >&2
+    echo "Not a Python source dist: $file (PKG-INFO/METADATA missing Name/Version)" >&2
     return 1
 }
 
@@ -108,12 +108,12 @@ _identify_python_sdist() {
 # Returns 0 if the file is a Python package acceptable for PyPI publish (*.whl or *.tar.gz)
 # with non-empty Name/Version in metadata (artifact-publisher approach; replaces PKG-INFO-only sdist sniff).
 is_pypi_package() {
-    local f="$1"
-    case "${f,,}" in
-    *.whl) _identify_python_wheel "$f" ;;
-    *.tar.gz | *.tgz) _identify_python_sdist "$f" ;;
+    local file="$1"
+    case "${file,,}" in
+    *.whl) _identify_python_wheel "$file" ;;
+    *.tar.gz | *.tgz) _identify_python_sdist "$file" ;;
     *)
-        echo "Not a PyPI package: $f (expected *.whl or *.tar.gz / *.tgz)" >&2
+        echo "Not a PyPI package: $file (expected *.whl or *.tar.gz / *.tgz)" >&2
         return 1
         ;;
     esac
@@ -123,31 +123,31 @@ is_pypi_package() {
 # Returns 0 if the POM has resolvable coordinates (artifactId, groupId, version; parent fallbacks).
 # Uses xmllint (same stack as deploy entrypoint) instead of yq.
 is_maven_package() {
-    local f="$1"
-    [[ -n $f && -f $f && -r $f ]] || return 1
-    case "${f,,}" in
+    local file="$1"
+    [[ -n $file && -f $file && -r $file ]] || return 1
+    case "${file,,}" in
     *.pom) ;;
     *)
-        echo "Not a Maven POM: $f (expected *.pom)" >&2
+        echo "Not a Maven POM: $file (expected *.pom)" >&2
         return 1
         ;;
     esac
 
     local artifact_id group_id version
-    artifact_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='artifactId'])" "$f" 2>/dev/null || true)
-    group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='groupId'])" "$f" 2>/dev/null || true)
+    artifact_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='artifactId'])" "$file" 2>/dev/null || true)
+    group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='groupId'])" "$file" 2>/dev/null || true)
     if [[ -z $group_id ]]; then
-        group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='groupId'])" "$f" 2>/dev/null || true)
+        group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='groupId'])" "$file" 2>/dev/null || true)
     fi
-    version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='version'])" "$f" 2>/dev/null || true)
+    version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='version'])" "$file" 2>/dev/null || true)
     if [[ -z $version ]]; then
-        version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='version'])" "$f" 2>/dev/null || true)
+        version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='version'])" "$file" 2>/dev/null || true)
     fi
 
     if [[ -n $artifact_id && -n $group_id && -n $version ]]; then
         return 0
     fi
-    echo "Not a Maven POM: $f (missing coordinates)" >&2
+    echo "Not a Maven POM: $file (missing coordinates)" >&2
     return 1
 }
 
@@ -210,12 +210,12 @@ _detect_structure_maven_poms() {
 _detect_structure_docker_bundle_metadata() {
     local artifacts_root="$1"
     local dest="./structured_build_artifacts/generic/docker"
-    while IFS= read -r -d '' f; do
-        [[ -f $f ]] || continue
-        echo "Processing DOCKER (bundle metadata): $f" >&2
+    while IFS= read -r -d '' file; do
+        [[ -f $file ]] || continue
+        echo "Processing DOCKER (bundle metadata): $file" >&2
         mkdir -p "$dest"
-        cp -a "$f" "$dest/"
-        manifest_add "$dest/$(basename "$f")" "generic"
+        cp -a "$file" "$dest/"
+        manifest_add "$dest/$(basename "$file")" "generic"
     done < <(find "$artifacts_root" -name "docker-images.json" -type f -print0 2>/dev/null)
 }
 

--- a/.github/workflows/deploy-artifacts/type_detection.sh
+++ b/.github/workflows/deploy-artifacts/type_detection.sh
@@ -1,13 +1,223 @@
 #!/usr/bin/env bash
 # type_detection.sh - Content-based artifact type detection during structuring
 #
-# Required (sourced by entrypoint.sh after package_utils.sh, type_registry.sh, upload_utils.sh):
+# Required sourcing order (see detect_types.sh): package_utils.sh first, then type_registry.sh,
+# upload_utils.sh, then this file. package_utils provides _extract_npm_package_json for is_npm_package.
+#
+# Required globals / helpers:
 #   CONTENT_DETECT_EXTENSIONS, CONTENT_DETECT_ORDER, TYPE_CONTENT_DETECT, TYPE_STRUCT_DIR
-#   gather_companions, manifest_add, process_* helpers from package_utils.sh
+#   gather_companions, manifest_add, process_* from package_utils.sh / upload_utils.sh
 #
 # structure_content_detected_files only reads BUILD_ARTIFACTS_DIR and the registry/helpers above
 # (no JFrog globals). Optional: BUILD_ARTIFACTS_DIR (default build-artifacts) — must match
 # copy_to_structured() in package_utils.sh
+#
+# PyPI ambiguous archives use the artifact-publisher style detector (wheel METADATA + sdist
+# PKG-INFO / .dist-info METADATA with non-empty Name/Version). Additional passes mirror
+# jfrog-fetch "Detect *" steps: wheels under the artifacts root, Maven POM coordinate checks,
+# and docker-images.json bundle metadata into generic/docker/.
+#
+# Content predicates (is_npm_package, is_pypi_package, is_go_module, is_maven_package) live here;
+# package_utils keeps metadata extractors (e.g. _extract_npm_package_json, get_go_metadata).
+
+# --- npm --------------------------------------------------------------------------------------
+
+# Check if a .tgz/.tar.gz is an npm package (package.json with name and version).
+# Uses _extract_npm_package_json from package_utils.sh.
+is_npm_package() {
+    local file="$1"
+    _extract_npm_package_json "$file" |
+        jq -e '.name and .version' >/dev/null 2>&1
+}
+
+# --- Go ---------------------------------------------------------------------------------------
+
+# Check if a .zip file is a Go module archive.
+# Go module zips have files prefixed with module@version/ and contain go.mod.
+# Args: <zip_file>
+# Returns: 0 if Go module, 1 otherwise.
+is_go_module() {
+    local file="$1"
+    local listing
+    listing=$(unzip -Z1 "$file" 2>/dev/null) || return 1
+    echo "$listing" | grep -qE '^[^@]+@v[^/]+/go\.mod$'
+}
+
+# --- PyPI (artifact-publisher / artifact-identification.sh style) -----------------------------
+
+_require_nonempty_name_version() {
+    local metadata="$1"
+    local name version
+    name=$(awk -F': *' 'tolower($1)=="name" {print $2; exit}' <<<"$metadata")
+    version=$(awk -F': *' 'tolower($1)=="version" {print $2; exit}' <<<"$metadata")
+    [[ -n $name && -n $version ]]
+}
+
+_identify_python_wheel() {
+    local f="$1"
+    [[ -n $f && -f $f && -r $f ]] || return 1
+
+    local metadata_member
+    metadata_member=$(unzip -Z1 "$f" 2>/dev/null | awk '/\.dist-info\/METADATA$/ {print; exit}') || return 1
+    if [[ -z $metadata_member ]]; then
+        echo "Not a Python wheel: $f (missing .dist-info/METADATA)" >&2
+        return 1
+    fi
+
+    local metadata
+    metadata=$(unzip -p "$f" "$metadata_member" 2>/dev/null) || return 1
+    if ! _require_nonempty_name_version "$metadata"; then
+        echo "Not a Python wheel: $f (METADATA missing Name/Version)" >&2
+        return 1
+    fi
+    return 0
+}
+
+_identify_python_sdist() {
+    local f="$1"
+    [[ -n $f && -f $f && -r $f ]] || return 1
+
+    local listing
+    listing=$(tar -tzf "$f" 2>/dev/null) || return 1
+
+    local metadata_member
+    metadata_member=$(awk '/(^|\/)\.dist-info\/METADATA\r?$/ {print; exit}' <<<"$listing")
+    if [[ -n $metadata_member ]]; then
+        local metadata
+        metadata=$(tar -xzf "$f" -O "$metadata_member" 2>/dev/null) || return 1
+        if _require_nonempty_name_version "$metadata"; then
+            return 0
+        fi
+    fi
+
+    local pkg_info_member
+    pkg_info_member=$(awk '/(^|\/)PKG-INFO\r?$/ {print; exit}' <<<"$listing")
+    if [[ -n $pkg_info_member ]]; then
+        local pkg_info
+        pkg_info=$(tar -xzf "$f" -O "$pkg_info_member" 2>/dev/null) || return 1
+        if _require_nonempty_name_version "$pkg_info"; then
+            return 0
+        fi
+    fi
+
+    echo "Not a Python source dist: $f (PKG-INFO/METADATA missing Name/Version)" >&2
+    return 1
+}
+
+# is_pypi_package <path>
+# Returns 0 if the file is a Python package acceptable for PyPI publish (*.whl or *.tar.gz)
+# with non-empty Name/Version in metadata (artifact-publisher approach; replaces PKG-INFO-only sdist sniff).
+is_pypi_package() {
+    local f="$1"
+    case "${f,,}" in
+    *.whl) _identify_python_wheel "$f" ;;
+    *.tar.gz | *.tgz) _identify_python_sdist "$f" ;;
+    *)
+        echo "Not a PyPI package: $f (expected *.whl or *.tar.gz / *.tgz)" >&2
+        return 1
+        ;;
+    esac
+}
+
+# is_maven_package <path>
+# Returns 0 if the POM has resolvable coordinates (artifactId, groupId, version; parent fallbacks).
+# Uses xmllint (same stack as deploy entrypoint) instead of yq.
+is_maven_package() {
+    local f="$1"
+    [[ -n $f && -f $f && -r $f ]] || return 1
+    case "${f,,}" in
+    *.pom) ;;
+    *)
+        echo "Not a Maven POM: $f (expected *.pom)" >&2
+        return 1
+        ;;
+    esac
+
+    local artifact_id group_id version
+    artifact_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='artifactId'])" "$f" 2>/dev/null || true)
+    group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='groupId'])" "$f" 2>/dev/null || true)
+    if [[ -z $group_id ]]; then
+        group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='groupId'])" "$f" 2>/dev/null || true)
+    fi
+    version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='version'])" "$f" 2>/dev/null || true)
+    if [[ -z $version ]]; then
+        version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='version'])" "$f" 2>/dev/null || true)
+    fi
+
+    if [[ -n $artifact_id && -n $group_id && -n $version ]]; then
+        return 0
+    fi
+    echo "Not a Maven POM: $f (missing coordinates)" >&2
+    return 1
+}
+
+# Detect npm: handled by existing CONTENT_DETECT_ORDER + is_npm_package (no extra pass).
+
+# Detect PyPI wheels: jfrog-fetch stages *.whl with is_pypi_package; the main content loop only
+# scans ambiguous extensions, so wheels are picked up here when structuring runs standalone.
+_detect_structure_pypi_wheels() {
+    local artifacts_root="$1"
+    local dest="./structured_build_artifacts/${TYPE_STRUCT_DIR[pypi]}"
+    while IFS= read -r -d '' file; do
+        [[ -f $file ]] || continue
+        if is_pypi_package "$file"; then
+            echo "Processing PYPI (wheel): $file" >&2
+            local target_path
+            target_path=$(process_pypi "$file" "$dest")
+            if [[ -n $target_path ]]; then
+                gather_companions "$file" "$(dirname "$target_path")" "pypi"
+                manifest_add "$target_path" "pypi"
+            fi
+        fi
+    done < <(find "$artifacts_root" -name "*.whl" -type f -print0 2>/dev/null)
+}
+
+# Detect Maven POMs: coordinate validation then same jar/ layout as structure_standalone_poms.
+_detect_structure_maven_poms() {
+    local artifacts_root="$1"
+    while IFS= read -r -d '' pom; do
+        [[ -f $pom ]] || continue
+        local base_name jar_file
+        base_name=$(basename "$pom" .pom)
+        jar_file="$(dirname "$pom")/$base_name.jar"
+        [[ -f $jar_file ]] && continue
+
+        is_maven_package "$pom" || continue
+
+        echo "Processing MAVEN (standalone POM): $pom" >&2
+        local group_id artifact_id version group_path target
+        group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='groupId'])" "$pom" 2>/dev/null || true)
+        artifact_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='artifactId'])" "$pom" 2>/dev/null || true)
+        version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='version'])" "$pom" 2>/dev/null || true)
+        if [[ -z $group_id ]]; then
+            group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='groupId'])" "$pom" 2>/dev/null || true)
+        fi
+        if [[ -z $version ]]; then
+            version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='parent']/*[local-name()='version'])" "$pom" 2>/dev/null || true)
+        fi
+        group_path="${group_id//./\/}"
+        target="./structured_build_artifacts/jar/${group_path}/${artifact_id}/${version}"
+        mkdir -p "$target"
+        cp -a "$pom" "$target/"
+        manifest_add "$target/$(basename "$pom")" "jar"
+        if [[ -f "${pom}.asc" ]]; then
+            cp -a "${pom}.asc" "$target/"
+        fi
+    done < <(find "$artifacts_root" -name "*.pom" -type f -print0 2>/dev/null)
+}
+
+# Detect Docker: jfrog-fetch writes docker-images.json from the Lifecycle API; stage copies for downstream.
+_detect_structure_docker_bundle_metadata() {
+    local artifacts_root="$1"
+    local dest="./structured_build_artifacts/generic/docker"
+    while IFS= read -r -d '' f; do
+        [[ -f $f ]] || continue
+        echo "Processing DOCKER (bundle metadata): $f" >&2
+        mkdir -p "$dest"
+        cp -a "$f" "$dest/"
+        manifest_add "$dest/$(basename "$f")" "generic"
+    done < <(find "$artifacts_root" -name "docker-images.json" -type f -print0 2>/dev/null)
+}
 
 structure_content_detected_files() {
     local artifacts_root="${BUILD_ARTIFACTS_DIR:-build-artifacts}"
@@ -47,4 +257,8 @@ structure_content_detected_files() {
             fi
         fi
     done < <(find "$artifacts_root" \( "${find_args[@]}" \) -print0)
+
+    _detect_structure_pypi_wheels "$artifacts_root"
+    _detect_structure_maven_poms "$artifacts_root"
+    _detect_structure_docker_bundle_metadata "$artifacts_root"
 }

--- a/.github/workflows/deploy-artifacts/type_registry.sh
+++ b/.github/workflows/deploy-artifacts/type_registry.sh
@@ -76,8 +76,11 @@ register_type rpm --extension "*.rpm" --repo "rpm-dev-local"
 register_type jar --extension "*.jar" --repo "maven-dev-local" --companions ".pom .asc .pom.asc"
 register_type nupkg --extension "*.nupkg" --repo "nuget-dev-local"
 register_type snupkg --extension "*.snupkg" --repo "nuget-dev-local" --struct-dir "nupkg"
+# is_npm_package is defined in type_detection.sh
 register_type npm --repo "npm-dev-local" --detect "is_npm_package"
-register_type pypi --extension "*.whl" --repo "pypi-dev-local" --detect "is_pypi_sdist"
+# Ambiguous archives: is_pypi_package is defined in type_detection.sh (wheel + sdist metadata checks).
+register_type pypi --extension "*.whl" --repo "pypi-dev-local" --detect "is_pypi_package"
+# is_go_module is defined in type_detection.sh
 register_type go --repo "go-dev-local" --detect "is_go_module"
 register_type generic --repo "generic-dev-local"
 
@@ -102,7 +105,7 @@ get_known_extensions() {
     # Content-detected extensions (ambiguous types like .tgz/.tar.gz)
     exts+=("${CONTENT_DETECT_EXTENSIONS[@]}")
     # Companion and build file extensions
-    exts+=("*.asc" "*.pom" "*.csproj")
+    exts+=("*.asc" "*.pom" "*.csproj" "docker-images.json")
     printf '%s\n' "${exts[@]}"
 }
 

--- a/.github/workflows/deploy-artifacts/upload_utils.sh
+++ b/.github/workflows/deploy-artifacts/upload_utils.sh
@@ -22,9 +22,13 @@ init_manifest() {
 }
 
 # Add a file to the manifest. Paths are stored as-is (as returned by process functions).
+# Skips duplicate path+type lines (e.g. detect_types.sh then entrypoint both structure the same wheel).
 manifest_add() {
     local path="$1"
     local type="$2"
+    if [[ -f ${MANIFEST_FILE-} ]] && grep -Fxq "${path}"$'\t'"${type}" "$MANIFEST_FILE" 2>/dev/null; then
+        return 0
+    fi
     printf '%s\t%s\n' "$path" "$type" >>"$MANIFEST_FILE"
 }
 

--- a/.github/workflows/reusable_deploy-artifacts.yaml
+++ b/.github/workflows/reusable_deploy-artifacts.yaml
@@ -182,16 +182,16 @@ jobs:
         run: |
           set -euo pipefail
           echo "Structured dir: ${{ steps.detect-artifacts.outputs.structured-artifacts-dir }}"
-          mf="${{ steps.detect-artifacts.outputs.manifest-path }}"
-          echo "Manifest: $mf"
-          if [[ -f "$mf" ]]; then
+          manifest_path="${{ steps.detect-artifacts.outputs.manifest-path }}"
+          echo "Manifest: $manifest_path"
+          if [[ -f "$manifest_path" ]]; then
             echo "Manifest packages (type: path):"
             while IFS=$'\t' read -r path type || [[ -n "$path" ]]; do
               [[ -z "${path:-}" && -z "${type:-}" ]] && continue
               printf '%s: %s\n' "$type" "$path"
-            done <"$mf"
+            done <"$manifest_path"
           else
-            echo "No manifest file at $mf" >&2
+            echo "No manifest file at $manifest_path" >&2
           fi
 
       - name: Deploy Artifacts

--- a/.github/workflows/reusable_deploy-artifacts.yaml
+++ b/.github/workflows/reusable_deploy-artifacts.yaml
@@ -177,10 +177,22 @@ jobs:
           echo "structured-artifacts-dir=$struct_dir" >>"$GITHUB_OUTPUT"
           echo "manifest-path=$struct_dir/.manifest" >>"$GITHUB_OUTPUT"
 
-      - name: Detected artifacts
+      - name: Detected Artifacts
+        shell: bash
         run: |
+          set -euo pipefail
           echo "Structured dir: ${{ steps.detect-artifacts.outputs.structured-artifacts-dir }}"
-          echo "Manifest: ${{ steps.detect-artifacts.outputs.manifest-path }}"
+          mf="${{ steps.detect-artifacts.outputs.manifest-path }}"
+          echo "Manifest: $mf"
+          if [[ -f "$mf" ]]; then
+            echo "Manifest packages (type: path):"
+            while IFS=$'\t' read -r path type || [[ -n "$path" ]]; do
+              [[ -z "${path:-}" && -z "${type:-}" ]] && continue
+              printf '%s: %s\n' "$type" "$path"
+            done <"$mf"
+          else
+            echo "No manifest file at $mf" >&2
+          fi
 
       - name: Deploy Artifacts
         id: deploy


### PR DESCRIPTION
To properly integrate detect-detect artifacts action into artifact publisher, it is needed to consolidate various type detection methods to single place.

- Added a Detected Artifacts step that prints each manifest line as "type: path"
- type_detection.sh now defines all content checks (is_npm_package, is_pypi_package, is_go_module, is_maven_package), uses metadata-based PyPI detection (artifact-publisher style), and adds passes for .whl, validated standalone .pom → jar/ layout, and docker-images.json → generic/docker/
- Removed is_pypi_sdist. package_utils.sh keeps extractors/metadata only. manifest_add dedupes path+type
- Entrypoint skips standalone POMs already laid out
- get_known_extensions includes docker-images.json so generic discovery skips it
- Registry strings, bats (test_metadata, test_type_registry), and README were updated accordingly