### PR TITLE
fix(deploy-artifacts): case-encode Go module path for GOPROXY uploads

### DIFF
--- a/.github/workflows/deploy-artifacts/create-test-fixtures.sh
+++ b/.github/workflows/deploy-artifacts/create-test-fixtures.sh
@@ -156,6 +156,19 @@ cd "$BUILD_ARTIFACTS_DIR/temp-gomod" && zip -q -r "../aeromod-v1.2.3.zip" "githu
 rm -rf "$BUILD_ARTIFACTS_DIR/temp-gomod"
 echo "  Created aeromod-v1.2.3.zip (Go module)"
 
+# Create a mixed-case Go module zip to exercise GOPROXY case-encoding.
+# The zip's internal root keeps the original case (github.com/Aerospike-DBaaS/api-docs@v0.1.0).
+mkdir -p "$BUILD_ARTIFACTS_DIR/temp-gomod-mixed/github.com/Aerospike-DBaaS/api-docs@v0.1.0"
+cat >"$BUILD_ARTIFACTS_DIR/temp-gomod-mixed/github.com/Aerospike-DBaaS/api-docs@v0.1.0/go.mod" <<'GOMOD'
+module github.com/Aerospike-DBaaS/api-docs
+
+go 1.21
+GOMOD
+echo 'package apidocs' >"$BUILD_ARTIFACTS_DIR/temp-gomod-mixed/github.com/Aerospike-DBaaS/api-docs@v0.1.0/doc.go"
+cd "$BUILD_ARTIFACTS_DIR/temp-gomod-mixed" && zip -q -r "../api-docs-v0.1.0.zip" "github.com/" && cd - >/dev/null
+rm -rf "$BUILD_ARTIFACTS_DIR/temp-gomod-mixed"
+echo "  Created api-docs-v0.1.0.zip (mixed-case Go module)"
+
 # Create some additional test files with valid formats
 # Create a valid JAR file (JAR is a ZIP with META-INF/MANIFEST.MF)
 mkdir -p "$BUILD_ARTIFACTS_DIR/temp-jar/META-INF"
@@ -212,6 +225,7 @@ echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/aerospike-hello-1.0.0.tar.gz.as
 echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/aerospike-utils-2.0.0.tgz.asc"
 echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/aerospike-targz-package-3.0.0.tar.gz.asc"
 echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/aeromod-v1.2.3.zip.asc"
+echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/api-docs-v0.1.0.zip.asc"
 
 # Create unsigned-artifacts/ prefix to simulate sign stage output
 # The sign stage uses cp --parents which creates: signed-artifacts/unsigned-artifacts/...

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -473,7 +473,12 @@ upload_go_packages() {
         props=$(get_go_props "$pkg")
 
         # GOPROXY layout: <module>/@v/<version>.{zip,mod,info}
-        local base_target="${module_path}/@v/${module_version}"
+        # Module path must be case-encoded for the proxy/cache layout per
+        # Go's module.EscapePath. Zip contents and the go.module target-prop
+        # keep the original case.
+        local escaped_module_path
+        escaped_module_path=$(escape_go_path "$module_path")
+        local base_target="${escaped_module_path}/@v/${module_version}"
 
         echo "  Uploading Go module: $pkg" >&2
         echo "    Module: $module_path, Version: $module_version" >&2

--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -482,6 +482,28 @@ get_go_metadata() {
 # Returns: target path on stdout.
 process_go() { copy_to_structured "$1" "$2"; }
 
+# Encode a Go module path per Go's module.EscapePath: every uppercase ASCII
+# letter becomes "!" + lowercase letter. Required for paths used in the
+# GOPROXY / module-cache layout. Module metadata and zip contents keep the
+# original case.
+# Args: <module_path>
+# Returns: encoded path on stdout.
+escape_go_path() {
+    local input="$1"
+    local output=""
+    local i char lower
+    for ((i = 0; i < ${#input}; i++)); do
+        char="${input:i:1}"
+        if [[ $char =~ [A-Z] ]]; then
+            lower=$(printf '%s' "$char" | tr '[:upper:]' '[:lower:]')
+            output+="!$lower"
+        else
+            output+="$char"
+        fi
+    done
+    printf '%s\n' "$output"
+}
+
 # Structure a generic file into the destination directory.
 # Strips the "unsigned-artifacts" prefix leaked from the sign stage's cp --parents.
 # Args: <file> <dest_dir>

--- a/.github/workflows/deploy-artifacts/tests/bats/test_go_upload.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_go_upload.bats
@@ -151,3 +151,30 @@ teardown_file() {
 
     [[ $found_in_generic == true ]] || (echo "test.zip not found in generic uploads" >&2 && return 1)
 }
+
+@test "mixed-case go module uploads use escaped GOPROXY target paths and unescaped props" {
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+    local upload_commands
+    upload_commands=$(extract_upload_commands "$output")
+
+    local escaped_base="go-dev-local/github\.com/!aerospike-!d!baa!s/api-docs/@v/v0\.1\.0"
+    local found_zip=false found_mod=false found_info=false found_asc=false found_props=false
+
+    while IFS= read -r cmd; do
+        [[ $cmd =~ ${escaped_base}\.zip[[:space:]] ]] && found_zip=true
+        [[ $cmd =~ ${escaped_base}\.mod ]] && found_mod=true
+        [[ $cmd =~ ${escaped_base}\.info ]] && found_info=true
+        [[ $cmd =~ ${escaped_base}\.zip\.asc ]] && found_asc=true
+        if [[ $cmd =~ api-docs-v0\.1\.0\.zip[[:space:]] && $cmd =~ go-dev-local ]]; then
+            [[ $cmd =~ go\.module=github\.com/Aerospike-DBaaS/api-docs ]] && found_props=true
+        fi
+    done <<< "$upload_commands"
+
+    [[ $found_zip == true ]] || (echo "Missing escaped .zip upload" >&2 && return 1)
+    [[ $found_mod == true ]] || (echo "Missing escaped .mod upload" >&2 && return 1)
+    [[ $found_info == true ]] || (echo "Missing escaped .info upload" >&2 && return 1)
+    [[ $found_asc == true ]] || (echo "Missing escaped .zip.asc upload" >&2 && return 1)
+    [[ $found_props == true ]] || (echo "go.module prop must be unescaped" >&2 && return 1)
+}

--- a/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
@@ -329,3 +329,38 @@ setup() {
 @test "_validate_go_module_path accepts valid Go module path" {
     _validate_go_module_path "github.com/aerospike/aeromod"
 }
+
+# --- escape_go_path ---
+# Note: the file's setup() does `set +eu; trap - ERR`, which disables bats'
+# default errexit-based assertion checking. Re-enable `set -e` per test so
+# `[[ ... ]]` failures actually fail the test.
+
+@test "escape_go_path leaves all-lowercase module path unchanged" {
+    set -e
+    result=$(escape_go_path "github.com/aerospike/aeromod")
+    [[ "$result" == "github.com/aerospike/aeromod" ]]
+}
+
+@test "escape_go_path encodes uppercase letters with bang prefix" {
+    set -e
+    result=$(escape_go_path "github.com/Aerospike-DBaaS/api-docs")
+    [[ "$result" == "github.com/!aerospike-!d!baa!s/api-docs" ]]
+}
+
+@test "escape_go_path handles single uppercase letter" {
+    set -e
+    result=$(escape_go_path "example.com/A")
+    [[ "$result" == "example.com/!a" ]]
+}
+
+@test "escape_go_path handles empty string" {
+    set -e
+    result=$(escape_go_path "")
+    [[ "$result" == "" ]]
+}
+
+@test "escape_go_path leaves digits and dots unchanged" {
+    set -e
+    result=$(escape_go_path "example.com/v2/pkg.name")
+    [[ "$result" == "example.com/v2/pkg.name" ]]
+}

--- a/.github/workflows/deploy-artifacts/tests/helpers/setup.bash
+++ b/.github/workflows/deploy-artifacts/tests/helpers/setup.bash
@@ -61,6 +61,8 @@ setup_test_artifacts() {
                 "$BUILD_ARTIFACTS_DIR/aerospike-hello-1.0.0.tar.gz.asc"
                 "$BUILD_ARTIFACTS_DIR/aeromod-v1.2.3.zip"
                 "$BUILD_ARTIFACTS_DIR/aeromod-v1.2.3.zip.asc"
+                "$BUILD_ARTIFACTS_DIR/api-docs-v0.1.0.zip"
+                "$BUILD_ARTIFACTS_DIR/api-docs-v0.1.0.zip.asc"
         )
 
         for file in "${TEST_FILES[@]}"; do


### PR DESCRIPTION
## Why
Go clients request case-encoded module paths from a proxy (per `module.EscapePath`: every uppercase ASCII letter becomes `!` + lowercase). Uploading to the unescaped path — e.g. `github.com/Aerospike-DBaaS/api-docs/@v/v0.0.0-...info` — means `go get` against the JFrog repo can't find mixed-case modules. The zip contents and the `go.module` target-prop keep the original case; only the JFrog/GOPROXY target path is encoded.