### PR TITLE
feat(deploy-artifacts): upload SHA alias .info for Go modules

### DIFF
--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -512,6 +512,17 @@ upload_go_packages() {
             --build-number="$ARTIFACT_BUILD_NUMBER" \
             --project="$PROJECT" \
             --target-props "$props"
+
+        # Upload SHA alias .info when workflow VERSION is a Git SHA.
+        # Reuses the same tmpfile so alias content is byte-identical to canonical.
+        if is_git_sha "$VERSION"; then
+            echo "  Uploading SHA alias .info: ${module_path}/@v/${VERSION}.info" >&2
+            run jf rt upload "$info_tmpfile" "$PROJECT-go-dev-local/${module_path}/@v/${VERSION}.info" \
+                --build-name="$BUILD_NAME" \
+                --build-number="$ARTIFACT_BUILD_NUMBER" \
+                --project="$PROJECT" \
+                --target-props "$props"
+        fi
         rm -f "$info_tmpfile"
 
         # Upload .asc companion for the zip

--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -482,6 +482,14 @@ get_go_metadata() {
 # Returns: target path on stdout.
 process_go() { copy_to_structured "$1" "$2"; }
 
+# Returns 0 if the argument is a full 40-char lowercase-hex Git commit SHA.
+# Abbreviated SHAs, pseudo-versions, semver, and branch names do not match.
+# Args: <string>
+is_git_sha() {
+    local s="$1"
+    [[ $s =~ ^[0-9a-f]{40}$ ]]
+}
+
 # Structure a generic file into the destination directory.
 # Strips the "unsigned-artifacts" prefix leaked from the sign stage's cp --parents.
 # Args: <file> <dest_dir>

--- a/.github/workflows/deploy-artifacts/tests/bats/test_go_upload.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_go_upload.bats
@@ -124,6 +124,78 @@ teardown_file() {
     [[ $found == true ]] || (echo "No .asc companion upload found for Go module" >&2 && return 1)
 }
 
+@test "40-char SHA VERSION uploads canonical and full-SHA alias .info from same tmpfile" {
+    local sha="44f28baab965982b73c12483835916c0faeebaa4"
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "$sha" "12345" "12345-metadata")
+
+    local upload_commands
+    upload_commands=$(extract_upload_commands "$output")
+
+    local canonical_file="" alias_file=""
+    while IFS= read -r cmd; do
+        [[ $cmd =~ go-dev-local ]] || continue
+        if [[ $cmd =~ go-dev-local/github\.com/aerospike/aeromod/@v/v1\.2\.3\.info[[:space:]] ]]; then
+            [[ $cmd =~ jf\ rt\ upload\ ([^[:space:]]+) ]] && canonical_file="${BASH_REMATCH[1]}"
+            [[ $cmd =~ --build-name=test-build ]] || (echo "Canonical .info missing --build-name: $cmd" >&2 && return 1)
+            [[ $cmd =~ --project=test-project ]] || (echo "Canonical .info missing --project: $cmd" >&2 && return 1)
+        elif [[ $cmd =~ go-dev-local/github\.com/aerospike/aeromod/@v/${sha}\.info ]]; then
+            [[ $cmd =~ jf\ rt\ upload\ ([^[:space:]]+) ]] && alias_file="${BASH_REMATCH[1]}"
+            [[ $cmd =~ --build-name=test-build ]] || (echo "Alias .info missing --build-name: $cmd" >&2 && return 1)
+            [[ $cmd =~ --build-number=12345-artifacts ]] || (echo "Alias .info missing --build-number: $cmd" >&2 && return 1)
+            [[ $cmd =~ --project=test-project ]] || (echo "Alias .info missing --project: $cmd" >&2 && return 1)
+            [[ $cmd =~ go\.module=github\.com/aerospike/aeromod ]] || (echo "Alias .info missing go.module prop: $cmd" >&2 && return 1)
+        fi
+    done <<< "$upload_commands"
+
+    [[ -n $canonical_file ]] || (echo "Canonical .info upload not found" >&2 && return 1)
+    [[ -n $alias_file ]] || (echo "Full-SHA alias .info upload not found" >&2 && return 1)
+    [[ $canonical_file == "$alias_file" ]] || \
+        (echo "Alias must reuse canonical tmpfile (canonical=$canonical_file, alias=$alias_file)" >&2 && return 1)
+}
+
+@test "non-full-SHA VERSION inputs produce no alias .info uploads" {
+    # Only full 40-char SHAs trigger alias; semver, pseudo-version, and 12-char hex must not.
+    local versions=("v1.0.0" "v0.0.0-20260424224855-44f28baab965" "44f28baab965")
+    for version in "${versions[@]}"; do
+        local output
+        output=$(run_entrypoint_dry_run "test-project" "test-build" "$version" "12345" "12345-metadata")
+
+        local upload_commands
+        upload_commands=$(extract_upload_commands "$output")
+
+        local info_count=0
+        while IFS= read -r cmd; do
+            if [[ $cmd =~ go-dev-local/github\.com/aerospike/aeromod/@v/.+\.info ]]; then
+                info_count=$((info_count + 1))
+            fi
+        done <<< "$upload_commands"
+
+        [[ $info_count -eq 1 ]] || \
+            (echo "Expected exactly 1 Go .info upload for VERSION=$version, got $info_count" >&2 && return 1)
+    done
+}
+
+@test "SHA VERSION input does not affect non-Go artifact uploads" {
+    local sha="44f28baab965982b73c12483835916c0faeebaa4"
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "$sha" "12345" "12345-metadata")
+
+    local upload_commands
+    upload_commands=$(extract_upload_commands "$output")
+
+    local deb_to_deb=false rpm_to_rpm=false jar_to_maven=false
+    while IFS= read -r cmd; do
+        [[ $cmd =~ \.deb[[:space:]].*deb-dev-local ]] && deb_to_deb=true
+        [[ $cmd =~ \.rpm[[:space:]].*rpm-dev-local ]] && rpm_to_rpm=true
+        [[ $cmd =~ \.jar[[:space:]].*maven-dev-local ]] && jar_to_maven=true
+    done <<< "$upload_commands"
+
+    [[ $deb_to_deb == true ]] || (echo "DEB upload missing or wrong-routed under SHA VERSION" >&2 && return 1)
+    [[ $rpm_to_rpm == true ]] || (echo "RPM upload missing or wrong-routed under SHA VERSION" >&2 && return 1)
+    [[ $jar_to_maven == true ]] || (echo "JAR upload missing or wrong-routed under SHA VERSION" >&2 && return 1)
+}
+
 @test "non-go-module .zip files are not uploaded to go repository" {
     local output
     output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")


### PR DESCRIPTION
## Why

`go get <module>@<full-sha>` against a JFrog-only GOPROXY currently fails: the proxy has no live VCS access, so a SHA-named `.info` query has nothing to resolve against. Today we only upload the canonical pseudo-version `.info`, so consumers must already know the pseudo-version — defeating the point of pasting a SHA.

This change makes the deploy stage upload an additional `<module>/@v/<sha>.info` whenever the workflow `VERSION` input is a full 40-char Git SHA. The alias reuses the canonical tmpfile, so its content is byte-identical to the pseudo-version `.info`. Once Go reads the alias, it switches to the canonical pseudo-version filenames for `.mod` / `.zip` and the rest of the flow is unchanged.

Only the 40-char form is aliased. Matching proxy.golang.org's "any abbreviated SHA" behavior would require pre-uploading every prefix length (7..40) per commit, which is wasteful — and 40 is the form CI typically passes (`github.sha`, etc.). Abbreviated SHAs and pseudo-versions are intentionally rejected by `is_git_sha`.