### PR TITLE
fix: [INFRA-426] detection skips if jar present

### DIFF
--- a/.github/workflows/deploy-artifacts/type_detection.sh
+++ b/.github/workflows/deploy-artifacts/type_detection.sh
@@ -180,7 +180,7 @@ _detect_structure_maven_poms() {
         local base_name jar_file
         base_name=$(basename "$pom" .pom)
         jar_file="$(dirname "$pom")/$base_name.jar"
-        [[ -f $jar_file ]] && continue
+        [[ -f $jar_file ]] || continue
 
         is_maven_package "$pom" || continue
 


### PR DESCRIPTION
Mistype on variable check causes detection to not happen at all if jar file present