### PR TITLE
feat(workflows): [INFRA-493] Add windows artifact signing workflow

### DIFF
--- a/.github/workflows/artifacts-cicd/README.md
+++ b/.github/workflows/artifacts-cicd/README.md
@@ -71,6 +71,7 @@ Chart linting and unit testing are the user's responsibility. Suggestion is to r
 
 ## Notes
 
+- When **`sign-windows: true`**, pass **`es_ov_username`**, **`es_ov_password`**, **`es_ov_credential_id`**, and **`es_ov_totp_secret`** into this workflow (for example from repository secrets **`ES_OV_USERNAME`**, **`ES_OV_PASSWORD`**, **`ES_OV_CREDENTIAL_ID`**, **`ES_OV_TOTP_SECRET`**). NuGet signing in the same pipeline still uses **`es-username`**, **`es-password`**, **`credential_id`**, and **`es-totp_secret`**.
 - The workflow generates a parent build-id automatically.
 - All artifacts get `version` and `package_name` target-props. Use `build-type` and `internal` for additional categorization.
 - **Java/Maven:** Set `setup-java: true` and optionally `java-version` (e.g. `"8"`, `"17"`), `java-distribution` (default `temurin`), and `java-cache` (default `maven`). These are passed through to the build step so Java is set up before your `build-script` runs. Matrix entries can override them per build (e.g. `setup-java: true`, `java-version: "17"`).

--- a/.github/workflows/artifacts-cicd/tests/test_artifacts_cicd.bats
+++ b/.github/workflows/artifacts-cicd/tests/test_artifacts_cicd.bats
@@ -128,6 +128,27 @@ setup() {
   find "$ARTIFACTS_DIR" -name "*.pkg" | grep -q .
 }
 
+@test "Windows .exe from matrix job upload-artifact (build-artifacts-win10-x64) survives pipeline" {
+  if [ "${LOCAL_SIGNING:-}" = "true" ]; then
+    skip "CI-only: win10 matrix produces ci-win-upload-artifact.exe"
+  fi
+  find "$ARTIFACTS_DIR" -name "ci-win-upload-artifact.exe" | grep -q .
+}
+
+@test "Windows .msi from matrix job upload-artifact (build-artifacts-win10-x64) survives pipeline" {
+  if [ "${LOCAL_SIGNING:-}" = "true" ]; then
+    skip "CI-only: win10 matrix produces ci-win-upload-artifact.msi"
+  fi
+  find "$ARTIFACTS_DIR" -name "ci-win-upload-artifact.msi" | grep -q .
+}
+
+@test "Windows .msix from matrix job upload-artifact (build-artifacts-win10-x64) survives pipeline" {
+  if [ "${LOCAL_SIGNING:-}" = "true" ]; then
+    skip "CI-only: win10 matrix produces ci-win-upload-artifact.msix"
+  fi
+  find "$ARTIFACTS_DIR" -name "ci-win-upload-artifact.msix" | grep -q .
+}
+
 # --- Signing verification ---
 
 @test "All DEB packages have corresponding .asc signature files" {
@@ -224,7 +245,7 @@ setup() {
     if [ "$size" -lt "$min_size" ]; then
       issues="$issues\n  Too small: $(basename "$artifact") ($size bytes)"
     fi
-  done < <(find "$ARTIFACTS_DIR" \( -name "*.deb" -o -name "*.rpm" -o -name "*.nupkg" -o -name "*.pkg" \))
+  done < <(find "$ARTIFACTS_DIR" \( -name "*.deb" -o -name "*.rpm" -o -name "*.nupkg" -o -name "*.pkg" -o -name "*.exe" -o -name "*.msi" -o -name "*.msix" \))
 
   if [ -n "$issues" ]; then
     echo -e "Size issues:$issues"
@@ -234,7 +255,7 @@ setup() {
 
 @test "No duplicate basenames across all artifacts" {
   local all_names
-  all_names=$(find "$ARTIFACTS_DIR" \( -name "*.deb" -o -name "*.rpm" -o -name "*.nupkg" -o -name "*.pkg" \) -exec basename {} \; | sort)
+  all_names=$(find "$ARTIFACTS_DIR" \( -name "*.deb" -o -name "*.rpm" -o -name "*.nupkg" -o -name "*.pkg" -o -name "*.exe" -o -name "*.msi" -o -name "*.msix" \) -exec basename {} \; | sort)
 
   local duplicates
   duplicates=$(echo "$all_names" | uniq -d)

--- a/.github/workflows/deploy-artifacts/README.md
+++ b/.github/workflows/deploy-artifacts/README.md
@@ -23,7 +23,7 @@ All types also include `build.type` and `internal` properties when those inputs 
 
 The deploy pipeline uses a centralized type registry (`type_registry.sh`). To add a new type:
 
-1. Add entries to the config arrays in `type_registry.sh` (`TYPE_EXTENSIONS`, `TYPE_REPO`, `TYPE_COMPANIONS`, `TYPE_STRUCT_DIR`)
+1. Call `register_type` in `type_registry.sh` with `--extension` (single `find -name` glob) or `--extensions` (comma-separated globs, e.g. `*.whl,*.tar.gz`), plus `--repo`, companions, etc.
 2. Add `type` to `UPLOAD_ORDER` (before `generic`)
 3. Add a `get_TYPE_props()` function in `type_registry.sh`
 4. Add a `process_TYPE()` function in `package_utils.sh` (or reuse `process_generic`)

--- a/.github/workflows/deploy-artifacts/README.md
+++ b/.github/workflows/deploy-artifacts/README.md
@@ -15,6 +15,7 @@ A reusable GitHub Actions workflow for uploading build artifacts to JFrog Artifa
 | npm (.tgz)                | `{project}-npm-dev-local`     | `.asc`                     | `version`, `package_name`                                                          |
 | PyPI (.whl/.tar.gz sdist) | `{project}-pypi-dev-local`    | `.asc`                     | `version`, `package_name`, `pypi.name`, `pypi.version`                             |
 | Go module (.zip)          | `{project}-go-dev-local`      | `.asc`                     | `version`, `package_name`, `go.module`, `go.version`                               |
+| Windows (.exe/.msi/.msix) | `{project}-generic-dev-local` | `.asc`                     | `version`, `package_name` (same repo as generic)                                   |
 | Generic (everything else) | `{project}-generic-dev-local` | `.asc`                     | `version`, `package_name`                                                          |
 
 All types also include `build.type` and `internal` properties when those inputs are set.
@@ -73,7 +74,7 @@ The deploy pipeline uses a centralized type registry (`type_registry.sh`). To ad
 
 Artifacts arrive in `build-artifacts/` as a flat collection from the sign stage. The structuring phase categorizes them by type and gathers companion files:
 
-- Types with unique extensions (DEB, RPM, JAR, NuGet, `.whl`) are matched by extension
+- Types with unique extensions (DEB, RPM, JAR, NuGet, `.whl`, Windows `.exe`/`.msi`/`.msix`) are matched by extension
 - Gzipped tarballs (`.tgz` and `.tar.gz`) and zip archives (`.zip`) are inspected with content-based detectors to distinguish npm packages, PyPI source distributions, Go modules, and generic archives
 - Companion files (defined per type in `TYPE_COMPANIONS`) are automatically copied alongside their primary artifact
 - Generic catches everything not claimed by the above
@@ -83,7 +84,7 @@ Artifacts arrive in `build-artifacts/` as a flat collection from the sign stage.
 Each type directory is uploaded to its respective repository with appropriate properties. The upload functions are driven by the type registry:
 
 - Simple types (DEB, RPM) use the generic `upload_type()` dispatch which calls `get_TYPE_props()` and `get_TYPE_extra_flags()` by convention
-- Types with custom path layouts (JAR, NuGet, npm, PyPI, Go, generic) define `upload_TYPE_packages()` overrides
+- Types with custom path layouts (JAR, NuGet, npm, PyPI, Go, win, generic) define `upload_TYPE_*` overrides in `entrypoint.sh`
 - All uploads go through `jf_upload()` or `run jf rt upload` which adds standard flags (`--build-name`, `--build-number`, `--project`)
 
 ### 3. Build info

--- a/.github/workflows/deploy-artifacts/create-test-fixtures.sh
+++ b/.github/workflows/deploy-artifacts/create-test-fixtures.sh
@@ -281,6 +281,14 @@ echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/aeromod-v1.2.3.zip.asc"
 # charts (helm-native provenance signature), not a detached .asc. The .prov
 # fixture above is what arrives at deploy.
 
+# Windows installer payloads (win type: .exe / .msi / .msix)
+head -c 2048 /dev/zero >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.exe"
+echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.exe.asc"
+head -c 2048 /dev/zero >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.msi"
+echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.msi.asc"
+head -c 2048 /dev/zero >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix"
+echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix.asc"
+
 # Create unsigned-artifacts/ prefix to simulate sign stage output
 # The sign stage uses cp --parents which creates: signed-artifacts/unsigned-artifacts/...
 # Deploy receives this as: build-artifacts/unsigned-artifacts/...

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -239,7 +239,11 @@ structure_build_artifacts() {
         local processor="process_${type}"
         # snupkg uses process_nupkg
         [[ $type == "snupkg" ]] && processor="process_nupkg"
-        discover_and_process "${TYPE_EXTENSIONS[$type]}" "$label" "$processor" "$dest" "$type"
+        local pat
+        while IFS= read -r pat; do
+            [[ -z $pat ]] && continue
+            discover_and_process "$pat" "$label" "$processor" "$dest" "$type"
+        done < <(emit_type_extension_globs "${TYPE_EXTENSIONS[$type]}")
     done
 
     # Content-detected types: ambiguous extensions need inspection to determine type

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -624,7 +624,7 @@ upload_helm_packages() {
             --build-name="$BUILD_NAME" \
             --build-number="$ARTIFACT_BUILD_NUMBER" \
             --project="$PROJECT" \
-            --target-props "$props"
+            --target-props "$props"        
 
         # Upload companions (.prov, helm-native provenance signature) alongside the chart.
         local companions="${TYPE_COMPANIONS[helm]-}"
@@ -637,9 +637,44 @@ upload_helm_packages() {
                     --project="$PROJECT"
             fi
         done
-    }
-
     manifest_for_type "helm" _upload_helm_entry
+}
+
+upload_win_files() {
+    echo "Uploading Windows artifacts..." >&2
+
+    # shellcheck disable=SC2329  # invoked indirectly via manifest_for_type
+    _upload_win_entry() {
+        local file="$1"
+        [[ -f $file ]] || return 0
+
+        local filename
+        filename=$(basename "$file")
+        local props
+        props=$(get_win_props "$file")
+
+        local target_path="${BUILD_NAME}/${VERSION}/${filename}"
+
+        echo "  Uploading Windows file: $file" >&2
+        echo "    Target: $target_path" >&2
+        run jf rt upload "$file" "$PROJECT-generic-dev-local/${target_path}" \
+            --build-name="$BUILD_NAME" \
+            --build-number="$ARTIFACT_BUILD_NUMBER" \
+            --project="$PROJECT" \
+            --target-props "$props"
+
+        local companions="${TYPE_COMPANIONS[win]-}"
+        for suffix in $companions; do
+            if [[ -f "$file$suffix" ]]; then
+                echo "  Uploading companion: $file$suffix" >&2
+                run jf rt upload "$file$suffix" "$PROJECT-generic-dev-local/${target_path}${suffix}" \
+                    --build-name="$BUILD_NAME" \
+                    --build-number="$ARTIFACT_BUILD_NUMBER" \
+                    --project="$PROJECT"
+            fi
+        done
+    }
+    manifest_for_type "win" _upload_win_entry
 }
 
 upload_generic_files() {

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -624,7 +624,7 @@ upload_helm_packages() {
             --build-name="$BUILD_NAME" \
             --build-number="$ARTIFACT_BUILD_NUMBER" \
             --project="$PROJECT" \
-            --target-props "$props"        
+            --target-props "$props"
 
         # Upload companions (.prov, helm-native provenance signature) alongside the chart.
         local companions="${TYPE_COMPANIONS[helm]-}"
@@ -637,6 +637,8 @@ upload_helm_packages() {
                     --project="$PROJECT"
             fi
         done
+    }
+
     manifest_for_type "helm" _upload_helm_entry
 }
 

--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -532,3 +532,6 @@ process_helm() { copy_to_structured "$1" "$2"; }
 # Args: <file> <dest_dir>
 # Returns: target path on stdout.
 process_generic() { copy_to_structured "$1" "$2" "unsigned-artifacts"; }
+
+# Structure Windows artifacts (exe, msi, msix); same path rules as generic.
+process_win() { process_generic "$1" "$2"; }

--- a/.github/workflows/deploy-artifacts/tests/README.md
+++ b/.github/workflows/deploy-artifacts/tests/README.md
@@ -43,10 +43,11 @@ bats .github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
 
 - `test_metadata.bats` - Metadata extraction: codename mapping, nupkg/rpm parsing
 - `test_type_registry.bats` - Registry config, base/per-type props, known extensions
+- `test_command_parsers.bats` - `extract_upload_commands` / `extract_nuget_commands` on dry-run-shaped lines (leading ANSI + spaces + `jf`, per `run()` in entrypoint)
 
 ### Structuring tests (verify file routing and companion co-location)
 
-- `test_structuring.bats` - Artifact routing to correct dirs, companion gathering, prefix stripping
+- `test_structuring.bats` - Artifact routing to correct dirs, companion gathering, prefix stripping, Windows → `win/` + `generic-dev-local` uploads
 
 ### Integration tests (dry-run entrypoint, parse upload commands)
 

--- a/.github/workflows/deploy-artifacts/tests/bats/test_all_files_upload.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_all_files_upload.bats
@@ -65,6 +65,11 @@ teardown_file() {
   # Python sdist should go to pypi repo, not generic
   [[ "$upload_commands" == *"aerospike-hello-1.0.0.tar.gz"*"pypi-dev-local"* ]]
 
+  # Windows win type uploads via generic-dev-local (not a separate win-dev-local repo)
+  [[ "$upload_commands" == *"ci-win-fixture.exe"*"generic-dev-local"* ]]
+  [[ "$upload_commands" == *"ci-win-fixture.msi"*"generic-dev-local"* ]]
+  [[ "$upload_commands" == *"ci-win-fixture.msix"*"generic-dev-local"* ]]
+
   # NuGet packages should ONLY go to nuget-dev-local, never generic-dev-local
   local nupkg_in_generic_found=false
   mapfile -t upload_cmd_array < <(echo "$upload_commands")

--- a/.github/workflows/deploy-artifacts/tests/bats/test_command_parsers.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_command_parsers.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# Tests extract_* helpers against lines shaped like entrypoint dry-run (stderr via 2>&1):
+# run() prints echo -e "${green}   $*${reset}" — leading ANSI, spaces, then jf …
+
+load '../helpers/command_parsers'
+
+@test "extract_upload_commands finds jf rt upload after ANSI wrapper like dry-run" {
+    local line=$'\033[0;32m   jf rt upload ./app.exe test-project-generic-dev-local/p --flat=false --build-name=b --project=p\033[0m'
+    local cmds
+    cmds=$(extract_upload_commands "$line")
+    echo "$cmds" | grep -qF "jf rt upload ./app.exe"
+    echo "$cmds" | grep -qF "generic-dev-local"
+}
+
+@test "extract_upload_commands finds jf nuget push after ANSI wrapper like dry-run" {
+    local line=$'\033[0;32m   jf nuget push ./pkg.nupkg -Source https://example.local/nuget\033[0m'
+    local cmds
+    cmds=$(extract_upload_commands "$line")
+    echo "$cmds" | grep -qF "jf nuget push ./pkg.nupkg"
+}
+
+@test "extract_nuget_commands finds nupkg jf rt upload after ANSI wrapper like dry-run" {
+    local line=$'\033[0;32m   jf rt upload ./Aerospike.Client.8.0.2.nupkg test-project-nuget-dev-local/A/8/8.0.2/file.nupkg --build-name=b --project=p\033[0m'
+    local cmds
+    cmds=$(extract_nuget_commands "$line")
+    echo "$cmds" | grep -qF "jf rt upload ./Aerospike.Client.8.0.2.nupkg"
+    echo "$cmds" | grep -qF "nuget-dev-local"
+}
+
+@test "extract_nuget_commands ignores jf rt upload that is not nuget repo" {
+    local line="   jf rt upload ./tool.exe test-project-generic-dev-local/x --project=p"
+    local cmds
+    cmds=$(extract_nuget_commands "$line")
+    [[ -z "$cmds" ]]
+}

--- a/.github/workflows/deploy-artifacts/tests/bats/test_structured_artifacts.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_structured_artifacts.bats
@@ -40,6 +40,7 @@ teardown_file() {
   # this list will grow as we have more types such as nupkg, etc.
   [[ -d "$TEST_DIR/structured_build_artifacts/deb" ]]
   [[ -d "$TEST_DIR/structured_build_artifacts/rpm" ]]
+  [[ -d "$TEST_DIR/structured_build_artifacts/win" ]]
   [[ -d "$TEST_DIR/structured_build_artifacts/generic" ]]
 }
 

--- a/.github/workflows/deploy-artifacts/tests/bats/test_structured_artifacts.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_structured_artifacts.bats
@@ -32,6 +32,23 @@ teardown_file() {
   assert_processing_message "$output" "RPM"
 }
 
+@test "WIN processing messages appear" {
+  local output
+  output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+  assert_processing_message "$output" "WIN"
+}
+
+@test "Deploy dry-run logs Windows upload for win type (generic-dev-local)" {
+  local output
+  output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+  [[ "$output" == *"Uploading Windows artifacts"* ]]
+  [[ "$output" == *"Uploading Windows file:"*"ci-win-fixture.exe"* ]]
+  [[ "$output" == *"Uploading Windows file:"*"ci-win-fixture.msi"* ]]
+  [[ "$output" == *"Uploading Windows file:"*"ci-win-fixture.msix"* ]]
+}
+
 @test "Structured artifact directories are created" {
   local output
   output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")

--- a/.github/workflows/deploy-artifacts/tests/bats/test_structuring.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_structuring.bats
@@ -69,19 +69,22 @@ teardown() {
     [[ "$nupkg_count" -eq 0 ]]
 }
 
-@test "Windows .exe routes to win dir not generic; dry-run upload targets generic-dev-local" {
-    echo "fake-exe-payload" >"$BUILD_ARTIFACTS_DIR/ci-win-routing-test.exe"
+@test "Windows .exe .msi .msix route to win dir not generic; dry-run upload targets generic-dev-local" {
     local output
     output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
 
-    [[ -f "structured_build_artifacts/win/ci-win-routing-test.exe" ]]
-    local generic_exe_count
-    generic_exe_count=$(find structured_build_artifacts/generic -name "*.exe" 2>/dev/null | wc -l | tr -d ' ')
-    [[ "$generic_exe_count" -eq 0 ]]
+    [[ -f "structured_build_artifacts/win/ci-win-fixture.exe" ]]
+    [[ -f "structured_build_artifacts/win/ci-win-fixture.msi" ]]
+    [[ -f "structured_build_artifacts/win/ci-win-fixture.msix" ]]
+    local generic_win_count
+    generic_win_count=$(find structured_build_artifacts/generic \( -name "*.exe" -o -name "*.msi" -o -name "*.msix" \) 2>/dev/null | wc -l | tr -d ' ')
+    [[ "$generic_win_count" -eq 0 ]]
 
     local cmds
     cmds=$(extract_upload_commands "$output")
-    echo "$cmds" | grep -qF "ci-win-routing-test.exe"
+    echo "$cmds" | grep -qF "ci-win-fixture.exe"
+    echo "$cmds" | grep -qF "ci-win-fixture.msi"
+    echo "$cmds" | grep -qF "ci-win-fixture.msix"
     echo "$cmds" | grep -qF "generic-dev-local"
     [[ "$cmds" != *win-dev-local* ]]
 }

--- a/.github/workflows/deploy-artifacts/tests/bats/test_structuring.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_structuring.bats
@@ -2,6 +2,7 @@
 # Tests for artifact structuring: correct routing, companion gathering, path handling.
 
 load '../helpers/setup'
+load '../helpers/command_parsers'
 
 setup() {
     setup_test_artifacts
@@ -68,6 +69,23 @@ teardown() {
     [[ "$nupkg_count" -eq 0 ]]
 }
 
+@test "Windows .exe routes to win dir not generic; dry-run upload targets generic-dev-local" {
+    echo "fake-exe-payload" >"$BUILD_ARTIFACTS_DIR/ci-win-routing-test.exe"
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+    [[ -f "structured_build_artifacts/win/ci-win-routing-test.exe" ]]
+    local generic_exe_count
+    generic_exe_count=$(find structured_build_artifacts/generic -name "*.exe" 2>/dev/null | wc -l | tr -d ' ')
+    [[ "$generic_exe_count" -eq 0 ]]
+
+    local cmds
+    cmds=$(extract_upload_commands "$output")
+    echo "$cmds" | grep -qF "ci-win-routing-test.exe"
+    echo "$cmds" | grep -qF "generic-dev-local"
+    [[ "$cmds" != *win-dev-local* ]]
+}
+
 @test "All standard type directories are created" {
     run_entrypoint_dry_run >/dev/null 2>&1 || true
     [[ -d "structured_build_artifacts/deb" ]]
@@ -76,6 +94,7 @@ teardown() {
     [[ -d "structured_build_artifacts/nupkg" ]]
     [[ -d "structured_build_artifacts/npm" ]]
     [[ -d "structured_build_artifacts/pypi" ]]
+    [[ -d "structured_build_artifacts/win" ]]
     [[ -d "structured_build_artifacts/generic" ]]
 }
 

--- a/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
@@ -24,6 +24,7 @@ setup() {
     [[ "${TYPE_EXTENSIONS[nupkg]}" == "*.nupkg" ]]
     [[ "${TYPE_EXTENSIONS[snupkg]}" == "*.snupkg" ]]
     [[ "${TYPE_EXTENSIONS[pypi]}" == "*.whl" ]]
+    [[ "${TYPE_EXTENSIONS[win]}" == "*.exe,*.msi,*.msix" ]]
     # npm uses content detection (*.tgz is ambiguous), not in TYPE_EXTENSIONS
     [[ -z "${TYPE_EXTENSIONS[npm]}" ]]
     # Generic is NOT in TYPE_EXTENSIONS -- it's the catch-all
@@ -39,6 +40,7 @@ setup() {
     [[ "${TYPE_REPO[pypi]}" == "pypi-dev-local" ]]
     [[ "${TYPE_REPO[go]}" == "go-dev-local" ]]
     [[ "${TYPE_REPO[helm]}" == "helm-dev-local" ]]
+    [[ "${TYPE_REPO[win]}" == "generic-dev-local" ]]
     [[ "${TYPE_REPO[generic]}" == "generic-dev-local" ]]
 }
 
@@ -49,6 +51,7 @@ setup() {
     [[ "${TYPE_COMPANIONS[npm]}" == ".asc" ]]
     [[ "${TYPE_COMPANIONS[pypi]}" == ".asc" ]]
     [[ "${TYPE_COMPANIONS[helm]}" == ".prov" ]]
+    [[ "${TYPE_COMPANIONS[win]}" == ".asc" ]]
     [[ "${TYPE_COMPANIONS[generic]}" == ".asc" ]]
 }
 
@@ -72,23 +75,26 @@ setup() {
     [[ "${CONTENT_DETECT_ORDER[3]}" == "helm" ]]
 }
 
-@test "UPLOAD_ORDER has jar, pypi, go, and helm before generic" {
+@test "UPLOAD_ORDER has jar, pypi, go, win and helm before generic" {
     local jar_idx=-1
     local pypi_idx=-1
     local go_idx=-1
     local helm_idx=-1
+    local win_idx=-1
     local generic_idx=-1
     for i in "${!UPLOAD_ORDER[@]}"; do
         [[ "${UPLOAD_ORDER[$i]}" == "jar" ]] && jar_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "pypi" ]] && pypi_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "go" ]] && go_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "helm" ]] && helm_idx=$i
+        [[ "${UPLOAD_ORDER[$i]}" == "win" ]] && win_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "generic" ]] && generic_idx=$i
     done
     [[ $jar_idx -lt $generic_idx ]]
     [[ $pypi_idx -lt $generic_idx ]]
-    [[ $go_idx -lt $generic_idx ]]
     [[ $helm_idx -lt $generic_idx ]]
+    [[ $win_idx -lt $generic_idx ]]
+    [[ $go_idx -lt $win_idx ]]
     [[ $pypi_idx -gt 0 ]]
 }
 
@@ -104,6 +110,9 @@ setup() {
     [[ "$exts" == *"*.snupkg"* ]]
     [[ "$exts" == *"*.tgz"* ]]
     [[ "$exts" == *"*.whl"* ]]
+    [[ "$exts" == *"*.exe"* ]]
+    [[ "$exts" == *"*.msi"* ]]
+    [[ "$exts" == *"*.msix"* ]]
 }
 
 @test "emit_type_extension_globs splits on comma and trims spaces" {
@@ -212,6 +221,16 @@ setup() {
     props=$(get_generic_props "/some/path/myfile.tar.gz")
     [[ "$props" == *"version=3.0.0"* ]]
     [[ "$props" == *"package_name=myfile.tar.gz"* ]]
+}
+
+@test "get_win_props matches get_generic_props shape" {
+    VERSION="2.1.0"
+    BUILD_TYPE=""
+    INTERNAL="false"
+    local props
+    props=$(get_win_props "/some/path/installer.msi")
+    [[ "$props" == *"version=2.1.0"* ]]
+    [[ "$props" == *"package_name=installer.msi"* ]]
 }
 
 # --- get_deb_props ---

--- a/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
@@ -106,6 +106,23 @@ setup() {
     [[ "$exts" == *"*.whl"* ]]
 }
 
+@test "emit_type_extension_globs splits on comma and trims spaces" {
+    local out
+    out=$(emit_type_extension_globs "*.a, *.b ,*.c")
+    [[ $(echo "$out" | wc -l | tr -d ' ') -eq 3 ]]
+    echo "$out" | grep -qxF '*.a'
+    echo "$out" | grep -qxF '*.b'
+    echo "$out" | grep -qxF '*.c'
+}
+
+@test "get_known_extensions emits one line per glob for comma-separated TYPE_EXTENSIONS" {
+    TYPE_EXTENSIONS[multitype]="*.one, *.two"
+    local exts
+    exts=$(get_known_extensions)
+    [[ $(echo "$exts" | grep -cF '*.one') -eq 1 ]]
+    echo "$exts" | grep -qF '*.two'
+}
+
 @test "get_known_extensions includes content-detected, companion, and build file extensions" {
     local exts
     exts=$(get_known_extensions)

--- a/.github/workflows/deploy-artifacts/tests/helpers/setup.bash
+++ b/.github/workflows/deploy-artifacts/tests/helpers/setup.bash
@@ -77,6 +77,12 @@ setup_test_artifacts() {
                 "$BUILD_ARTIFACTS_DIR/aeromod-v1.2.3.zip.asc"
                 "$BUILD_ARTIFACTS_DIR/aerospike-hello-0.4.2.tgz"
                 "$BUILD_ARTIFACTS_DIR/aerospike-hello-0.4.2.tgz.prov"
+                "$BUILD_ARTIFACTS_DIR/ci-win-fixture.exe"
+                "$BUILD_ARTIFACTS_DIR/ci-win-fixture.exe.asc"
+                "$BUILD_ARTIFACTS_DIR/ci-win-fixture.msi"
+                "$BUILD_ARTIFACTS_DIR/ci-win-fixture.msi.asc"
+                "$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix"
+                "$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix.asc"
         )
 
         for file in "${TEST_FILES[@]}"; do

--- a/.github/workflows/deploy-artifacts/type_registry.sh
+++ b/.github/workflows/deploy-artifacts/type_registry.sh
@@ -7,6 +7,9 @@
 #   3. Add a process_TYPE() function in package_utils.sh (or reuse process_generic)
 #   4. Add tests
 #
+# Extension globs: use --extension for a single find -name pattern, or --extensions for
+# several comma-separated patterns (e.g. "*.whl,*.tar.gz"). Spaces after commas are trimmed.
+#
 # Required globals (set by entrypoint.sh before sourcing):
 #   VERSION, BUILD_NAME, PROJECT, BUILD_TYPE, INTERNAL
 
@@ -25,11 +28,16 @@ CONTENT_DETECT_ORDER=()
 register_type() {
     local type="$1"
     shift
+    # extension: single glob (--extension) or comma-separated globs (--extensions); stored in TYPE_EXTENSIONS
     local extension="" repo="" companions=".asc" struct_dir="$type" detect=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
         --extension)
+            extension="$2"
+            shift 2
+            ;;
+        --extensions)
             extension="$2"
             shift 2
             ;;
@@ -99,12 +107,29 @@ UPLOAD_ORDER=(rpm deb jar nupkg npm pypi go helm generic)
 
 # --- helpers ---
 
+# Emit one line per find -name glob. TYPE_EXTENSIONS values may be comma-separated (--extensions).
+emit_type_extension_globs() {
+    local csv="$1"
+    [[ -z $csv ]] && return 0
+    local IFS=,
+    read -ra parts <<<"$csv" || true
+    local p
+    for p in "${parts[@]}"; do
+        p="${p#"${p%%[![:space:]]*}"}"
+        p="${p%"${p##*[![:space:]]}"}"
+        [[ -n $p ]] && printf '%s\n' "$p"
+    done
+}
+
 # Returns the list of all known file extensions (primary + content-detected + companion + build).
 # Used to build the negated find pattern for generic file discovery.
 get_known_extensions() {
     local -a exts=()
-    for ext_pattern in "${TYPE_EXTENSIONS[@]}"; do
-        exts+=("$ext_pattern")
+    local ext_group line
+    for ext_group in "${TYPE_EXTENSIONS[@]}"; do
+        while IFS= read -r line; do
+            [[ -n $line ]] && exts+=("$line")
+        done < <(emit_type_extension_globs "$ext_group")
     done
     # Content-detected extensions (ambiguous types like .tgz/.tar.gz)
     exts+=("${CONTENT_DETECT_EXTENSIONS[@]}")

--- a/.github/workflows/deploy-artifacts/type_registry.sh
+++ b/.github/workflows/deploy-artifacts/type_registry.sh
@@ -94,6 +94,8 @@ register_type go --repo "go-dev-local" --detect "is_go_module"
 # companions=".prov" carries the helm-native provenance signature
 # (GPG-clearsigned Chart.yaml + sha256) produced by sign-artifacts.
 register_type helm --repo "helm-dev-local" --detect "is_helm_chart" --companions ".prov"
+# Windows installers / packages (exe, msi, msix); structured and uploaded like generic.
+register_type win --extensions "*.exe,*.msi,*.msix" --repo "generic-dev-local"
 register_type generic --repo "generic-dev-local"
 
 # Ambiguous extensions that trigger content-based detection.
@@ -103,7 +105,7 @@ register_type generic --repo "generic-dev-local"
 CONTENT_DETECT_EXTENSIONS=("*.tgz" "*.tar.gz" "*.zip")
 
 # Upload order matters: jar before generic (jar can move files to generic)
-UPLOAD_ORDER=(rpm deb jar nupkg npm pypi go helm generic)
+UPLOAD_ORDER=(rpm deb jar nupkg npm pypi go win helm generic)
 
 # --- helpers ---
 
@@ -249,4 +251,8 @@ get_generic_props() {
     local filename
     filename=$(basename "$file")
     echo "$(get_base_props);package_name=$filename"
+}
+
+get_win_props() {
+    get_generic_props "$1"
 }

--- a/.github/workflows/deploy-artifacts/upload_utils.sh
+++ b/.github/workflows/deploy-artifacts/upload_utils.sh
@@ -149,7 +149,7 @@ discover_and_process() {
 # --- Upload dispatch ---
 
 # Default upload loop for simple types (deb, rpm).
-# Complex types (jar, nupkg, generic) provide their own upload function override.
+# Complex types (jar, nupkg, win, generic) provide their own upload function override.
 # The convention is: if upload_TYPE_packages() exists, it is called instead.
 # Otherwise this generic loop handles find -> props -> upload -> companions.
 # Usage: upload_type <type>

--- a/.github/workflows/example_artifacts-cicd.yaml
+++ b/.github/workflows/example_artifacts-cicd.yaml
@@ -118,6 +118,14 @@ jobs:
             "gh-artifact-directory":"dist",
             "build-env":"VERSION=${{ needs.extract-version.outputs.version }}",
             "build-script":"make clean build DISTRO=darwin ARCH=arm64 && mkdir -p dist && pkgbuild --root build/darwin/arm64 --identifier com.aerospike.test --version $VERSION --install-location /usr/local/bin dist/test-$VERSION-darwin-arm64.pkg"
+          },
+          {
+            "runs-on":"ubuntu-22.04",
+            "distro":"win10",
+            "arch":"x64",
+            "working-directory":"repo-source/.github/workflows/execute-build/test_apps/hi",
+            "gh-artifact-directory":"packaged-artifacts",
+            "build-script":"mkdir -p packaged-artifacts && head -c 2048 /dev/zero > packaged-artifacts/example-win-ci.exe && head -c 2048 /dev/zero > packaged-artifacts/example-win-ci.msi && head -c 2048 /dev/zero > packaged-artifacts/example-win-ci.msix"
           }
         ]}
       build-script: |
@@ -145,6 +153,9 @@ jobs:
       mac-installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
       mac-artifact-glob: "*.pkg"
       mac-notarize: true
+      sign-windows: true
+      win-artifact-glob: "*.exe"
+      win-runs-on: windows-2025
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}

--- a/.github/workflows/example_artifacts-cicd.yaml
+++ b/.github/workflows/example_artifacts-cicd.yaml
@@ -154,7 +154,7 @@ jobs:
       mac-artifact-glob: "*.pkg"
       mac-notarize: true
       sign-windows: true
-      win-artifact-glob: "*.exe"
+      win-artifact-glob: "*.exe,*.msi,*.msix"
       win-runs-on: windows-2025
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}

--- a/.github/workflows/example_artifacts-cicd.yaml
+++ b/.github/workflows/example_artifacts-cicd.yaml
@@ -164,6 +164,10 @@ jobs:
       es-password: ${{ secrets.ES_PASSWORD }}
       credential_id: ${{ secrets.CREDENTIAL_ID }}
       es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+      es_ov_username: ${{ secrets.ES_OV_USERNAME }}
+      es_ov_password: ${{ secrets.ES_OV_PASSWORD }}
+      es_ov_credential_id: ${{ secrets.ES_OV_CREDENTIAL_ID }}
+      es_ov_totp_secret: ${{ secrets.ES_OV_TOTP_SECRET }}
       apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
       apple-id: ${{ secrets.APPLE_ID }}
       apple-installer-cert: ${{ secrets.APPLE_INSTALLER_CERT }}

--- a/.github/workflows/example_win-signing.yaml
+++ b/.github/workflows/example_win-signing.yaml
@@ -71,7 +71,7 @@ jobs:
 
       sign-mac: false
       sign-windows: true
-      win-artifact-glob: "*.exe"
+      win-artifact-glob: "*.exe,*.msi,*.msix"
       win-runs-on: windows-2025
 
       build-script: |

--- a/.github/workflows/example_win-signing.yaml
+++ b/.github/workflows/example_win-signing.yaml
@@ -1,11 +1,9 @@
-name: "Example: Mac Artifact Signing"
+name: "Example: Windows Artifact Signing"
 
-# Demonstrates using the artifacts-cicd orchestrator with Mac signing enabled.
-# This example builds a macOS .pkg on a Mac runner, then the orchestrator
-# handles: collect -> sign-mac (Apple) -> sign (GPG) -> deploy.
+# Demonstrates reusable_artifacts-cicd with Windows Authenticode (SSL.com eSigner / CodeSignTool).
+# Flow: collect -> sign-mac (skipped when false) -> sign-windows -> sign (GPG + NuGet) -> deploy.
 #
-# For composable usage (calling sign-mac-artifacts directly), see CICD-composable.md.
-# For Windows (SSL.com / CodeSignTool) with the same orchestrator, see example_win-signing.yaml.
+# For a direct call to reusable_sign-win-artifacts.yaml, see sign-win-artifacts/README.md.
 
 on:
   workflow_dispatch:
@@ -15,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: jfrog-test-deploy
+  group: jfrog-test-deploy-win
   cancel-in-progress: false
 
 jobs:
@@ -23,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,23 +33,21 @@ jobs:
     outputs:
       version: ${{ steps.extract.outputs.version }}
 
-  artifacts-cicd-with-mac:
+  artifacts-cicd-with-win:
     needs: extract-version
     uses: ./.github/workflows/reusable_artifacts-cicd.yaml
     with:
       gh-workflows-ref: ${{ github.sha }}
       jf-project: test
-      jf-build-name: test-mac-build
+      jf-build-name: test-win-build
       version: ${{ needs.extract-version.outputs.version }}
       gh-source-path: repo-source
-      gh-artifact-directory: dist
+      gh-artifact-directory: packaged-artifacts
       oidc-provider-name: gh-dev-test
       oidc-audience: aerospike/testing
-
+      dry-run: true
       build-env: VERSION=${{ needs.extract-version.outputs.version }}
 
-      # The matrix includes a macOS build alongside Linux builds.
-      # The macOS entry produces a .pkg; Linux entries produce deb/rpm.
       matrix-json: >-
         {"include":[
           {
@@ -64,22 +60,19 @@ jobs:
             "build-env":"EMULATED=false"
           },
           {
-            "runs-on":"macos-14",
-            "distro":"darwin",
-            "arch":"arm64",
+            "runs-on":"ubuntu-22.04",
+            "distro":"win10",
+            "arch":"x64",
             "working-directory":"repo-source/.github/workflows/execute-build/test_apps/hi",
-            "gh-artifact-directory":"dist",
-            "build-script":"make clean build DISTRO=darwin ARCH=arm64 && mkdir -p dist && pkgbuild --root build/darwin/arm64 --identifier com.aerospike.test --version $VERSION --install-location /usr/local/bin dist/test-$VERSION-darwin-arm64.pkg"
+            "gh-artifact-directory":"packaged-artifacts",
+            "build-script":"mkdir -p packaged-artifacts && head -c 2048 /dev/zero > packaged-artifacts/example-win-test.exe && head -c 2048 /dev/zero > packaged-artifacts/example-win-test.msi && head -c 2048 /dev/zero > packaged-artifacts/example-win-test.msix"
           }
         ]}
 
-      # Mac signing configuration
-      sign-mac: true
-      mac-signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"
-      mac-installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
-      mac-artifact-glob: "*.pkg"
-      mac-notarize: true
-      mac-runs-on: macos-14
+      sign-mac: false
+      sign-windows: true
+      win-artifact-glob: "*.exe"
+      win-runs-on: windows-2025
 
       build-script: |
         echo "Default build script (overridden per matrix entry)"
@@ -88,9 +81,7 @@ jobs:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
       gpg-key-pass: ${{ secrets.GPG_PASS }}
-      apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
-      apple-id: ${{ secrets.APPLE_ID }}
-      apple-installer-cert: ${{ secrets.APPLE_INSTALLER_CERT }}
-      apple-cert-password: ${{ secrets.APPLE_CERT_PASSWORD }}
-      apple-notarization-password: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-      apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+      es-username: ${{ secrets.ES_USERNAME }}
+      es-password: ${{ secrets.ES_PASSWORD }}
+      credential_id: ${{ secrets.CREDENTIAL_ID }}
+      es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}

--- a/.github/workflows/example_win-signing.yaml
+++ b/.github/workflows/example_win-signing.yaml
@@ -85,3 +85,7 @@ jobs:
       es-password: ${{ secrets.ES_PASSWORD }}
       credential_id: ${{ secrets.CREDENTIAL_ID }}
       es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+      es_ov_username: ${{ secrets.ES_OV_USERNAME }}
+      es_ov_password: ${{ secrets.ES_OV_PASSWORD }}
+      es_ov_credential_id: ${{ secrets.ES_OV_CREDENTIAL_ID }}
+      es_ov_totp_secret: ${{ secrets.ES_OV_TOTP_SECRET }}

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -267,6 +267,18 @@ on:
         required: false
       es-totp_secret:
         required: false
+      es_ov_credential_id:
+        description: eSigner credential ID for Windows Authenticode (OV signing)
+        required: false
+      es_ov_password:
+        description: SSL.com account password for Windows Authenticode (OV signing)
+        required: false
+      es_ov_totp_secret:
+        description: TOTP secret for Windows Authenticode (OV signing)
+        required: false
+      es_ov_username:
+        description: SSL.com account username for Windows Authenticode (OV signing)
+        required: false
       apple-application-cert:
         required: false
       apple-id:
@@ -437,7 +449,11 @@ jobs:
       gh-workflows-ref: ${{ inputs.gh-workflows-ref }}
       runs-on: ${{ inputs.win-runs-on }}
       signing-identity: ${{ inputs.win-signing-identity }}
-    secrets: inherit
+    secrets:
+      es_ov_username: ${{ secrets.es_ov_username }}
+      es_ov_password: ${{ secrets.es_ov_password }}
+      es_ov_credential_id: ${{ secrets.es_ov_credential_id }}
+      es_ov_totp_secret: ${{ secrets.es_ov_totp_secret }}
 
   sign:
     needs: [resolve, collect-matrix-artifacts, sign-mac, sign-windows]

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -235,7 +235,9 @@ on:
         type: boolean
         default: false
       win-artifact-glob:
-        description: Glob for Windows signing scope (passed to sign-win-artifacts)
+        description: |
+          Glob(s) for Windows signing scope (passed to sign-win-artifacts artifact-glob). One pattern or comma-separated,
+          e.g. "*.exe,*.msi,*.msix". Default **/*
         required: false
         type: string
         default: "**/*"

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -234,6 +234,21 @@ on:
         required: false
         type: boolean
         default: false
+      win-artifact-glob:
+        description: Glob for Windows signing scope (passed to sign-win-artifacts)
+        required: false
+        type: string
+        default: "**/*"
+      win-runs-on:
+        description: Runner for the sign-windows job
+        required: false
+        type: string
+        default: windows-2025
+      win-signing-identity:
+        description: Optional display name for signed installers (CodeSignTool -program_name)
+        required: false
+        type: string
+        default: ""
 
     secrets:
       gpg-private-key:
@@ -412,11 +427,14 @@ jobs:
     needs: [resolve, collect-matrix-artifacts, sign-mac]
     uses: ./.github/workflows/reusable_sign-win-artifacts.yaml
     with:
+      artifact-glob: ${{ inputs.win-artifact-glob }}
       dry-run: ${{ inputs.dry-run }}
       gh-checkout-path: ${{ inputs.gh-checkout-path }}
       gh-retention-days: ${{ inputs.gh-retention-days }}
       gh-unsigned-artifacts: build-artifacts
       gh-workflows-ref: ${{ inputs.gh-workflows-ref }}
+      runs-on: ${{ inputs.win-runs-on }}
+      signing-identity: ${{ inputs.win-signing-identity }}
     secrets: inherit
 
   sign:

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -228,6 +228,13 @@ on:
         type: string
         default: ""
 
+      # Windows signing (optional; runs after sign-mac; uses SSL.com eSigner / CodeSignTool)
+      sign-windows:
+        description: Enable Windows code signing (.exe, .msi, .msix)
+        required: false
+        type: boolean
+        default: false
+
     secrets:
       gpg-private-key:
         required: true
@@ -400,9 +407,21 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
     secrets: inherit
 
-  sign:
+  sign-windows:
+    if: inputs.sign-windows && always() && !cancelled() && needs.collect-matrix-artifacts.result == 'success' && needs.sign-mac.result != 'failure'
     needs: [resolve, collect-matrix-artifacts, sign-mac]
-    if: always() && !cancelled() && needs.collect-matrix-artifacts.result == 'success' && needs.sign-mac.result != 'failure'
+    uses: ./.github/workflows/reusable_sign-win-artifacts.yaml
+    with:
+      dry-run: ${{ inputs.dry-run }}
+      gh-checkout-path: ${{ inputs.gh-checkout-path }}
+      gh-retention-days: ${{ inputs.gh-retention-days }}
+      gh-unsigned-artifacts: build-artifacts
+      gh-workflows-ref: ${{ inputs.gh-workflows-ref }}
+    secrets: inherit
+
+  sign:
+    needs: [resolve, collect-matrix-artifacts, sign-mac, sign-windows]
+    if: always() && !cancelled() && needs.collect-matrix-artifacts.result == 'success' && needs.sign-mac.result != 'failure' && needs.sign-windows.result != 'failure'
     uses: ./.github/workflows/reusable_sign-artifacts.yaml
     with:
       gh-artifact-name: signed-artifacts

--- a/.github/workflows/reusable_sign-artifacts.yaml
+++ b/.github/workflows/reusable_sign-artifacts.yaml
@@ -91,6 +91,24 @@ jobs:
           find unsigned-artifacts -name "*.nupkg" -exec mv {} unsigned-nuget-packages/ \;
           echo "Found nuget packages: $(ls unsigned-nuget-packages/)"
           echo "count=$(ls unsigned-nuget-packages/ | wc -l)" >> $GITHUB_OUTPUT
+      - name: Isolate Windows Authenticode binaries (skip GPG)
+        id: windows-binaries
+        run: |
+          set -euo pipefail
+          mkdir -p unsigned-windows-staging
+          count=0
+          while IFS= read -r -d '' f; do
+            rel="${f#unsigned-artifacts/}"
+            dest_dir="unsigned-windows-staging/unsigned-artifacts/$(dirname "$rel")"
+            mkdir -p "$dest_dir"
+            if [[ -f "${f}.asc" ]]; then
+              mv "${f}.asc" "unsigned-windows-staging/unsigned-artifacts/${rel}.asc"
+            fi
+            mv "$f" "unsigned-windows-staging/unsigned-artifacts/$rel"
+            count=$((count + 1))
+          done < <(find unsigned-artifacts -type f \( -name '*.exe' -o -name '*.msi' -o -name '*.msix' \) -print0 2>/dev/null || true)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Isolated $count Windows installer file(s) from GPG (Authenticode-only, mirrors NuGet isolation)"
       - name: Checkout shared-workflows repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -137,6 +155,14 @@ jobs:
           entrypoint="${{ inputs.gh-checkout-path }}/.github/workflows/sign-artifacts/entrypoint.sh"
           chmod +x "$entrypoint"
           "$entrypoint" 'unsigned-artifacts/**/*' '${{ inputs.gh-artifact-name }}'
+      - name: Restore Windows Authenticode binaries into signed output
+        if: steps.windows-binaries.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          dest='${{ inputs.gh-artifact-name }}'
+          mkdir -p "$dest"
+          cp -a unsigned-windows-staging/. "$dest/"
+          echo "Restored ${{ steps.windows-binaries.outputs.count }} Windows file(s) under $dest"
       - name: Upload Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/reusable_sign-win-artifacts.yaml
+++ b/.github/workflows/reusable_sign-win-artifacts.yaml
@@ -62,13 +62,13 @@ on:
       es_credential_ov_id:
         description: eSigner credential ID (SSL.com)
         required: false
-      es-password:
+      es_ov_password:
         description: SSL.com account password
         required: false
-      es-totp_ov_secret:
+      es_totp_ov_secret:
         description: TOTP secret for automated OTP (same as NuGet signing in reusable_sign-artifacts)
         required: false
-      es-username:
+      es_ov_username:
         description: SSL.com account username
         required: false
 
@@ -114,10 +114,10 @@ jobs:
         if: ${{ !inputs.dry-run }}
         run: |
           missing=()
-          [ -z "${{ secrets.es-username }}" ] && missing+=("es-username")
-          [ -z "${{ secrets.es-password }}" ] && missing+=("es-password")
+          [ -z "${{ secrets.es_ov_username }}" ] && missing+=("es_ov_username")
+          [ -z "${{ secrets.es_ov_password }}" ] && missing+=("es_ov_password")
           [ -z "${{ secrets.es_credential_ov_id }}" ] && missing+=("es_credential_ov_id")
-          [ -z "${{ secrets.es-totp_ov_secret }}" ] && missing+=("es-totp_ov_secret")
+          [ -z "${{ secrets.es_totp_ov_secret }}" ] && missing+=("es_totp_ov_secret")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "Error: Windows signing requires SSL.com eSigner secrets: ${missing[*]}" >&2
             echo "Use the same secrets as NuGet signing (reusable_sign-artifacts), or pass --dry-run." >&2
@@ -160,10 +160,10 @@ jobs:
 
       - name: Sign Windows Artifacts
         env:
-          ES_USERNAME: ${{ secrets.es-username }}
-          ES_PASSWORD: ${{ secrets.es-password }}
+          ES_USERNAME: ${{ secrets.es_ov_username }}
+          ES_PASSWORD: ${{ secrets.es_ov_password }}
           CREDENTIAL_ID: ${{ secrets.es_credential_ov_id }}
-          ES_TOTP_SECRET: ${{ secrets.es-totp_ov_secret }}
+          ES_TOTP_SECRET: ${{ secrets.es_totp_ov_secret }}
           ESIGNER_PROGRAM_NAME: ${{ inputs.signing-identity }}
         run: |
           entrypoint="${{ inputs.gh-checkout-path }}/.github/workflows/sign-win-artifacts/entrypoint.sh"

--- a/.github/workflows/reusable_sign-win-artifacts.yaml
+++ b/.github/workflows/reusable_sign-win-artifacts.yaml
@@ -59,13 +59,13 @@ on:
         default: ""
 
     secrets:
-      credential_id:
+      es_credential_ov_id:
         description: eSigner credential ID (SSL.com)
         required: false
       es-password:
         description: SSL.com account password
         required: false
-      es-totp_secret:
+      es-totp_ov_secret:
         description: TOTP secret for automated OTP (same as NuGet signing in reusable_sign-artifacts)
         required: false
       es-username:
@@ -116,8 +116,8 @@ jobs:
           missing=()
           [ -z "${{ secrets.es-username }}" ] && missing+=("es-username")
           [ -z "${{ secrets.es-password }}" ] && missing+=("es-password")
-          [ -z "${{ secrets.credential_id }}" ] && missing+=("credential_id")
-          [ -z "${{ secrets.es-totp_secret }}" ] && missing+=("es-totp_secret")
+          [ -z "${{ secrets.es_credential_ov_id }}" ] && missing+=("es_credential_ov_id")
+          [ -z "${{ secrets.es-totp_ov_secret }}" ] && missing+=("es-totp_ov_secret")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "Error: Windows signing requires SSL.com eSigner secrets: ${missing[*]}" >&2
             echo "Use the same secrets as NuGet signing (reusable_sign-artifacts), or pass --dry-run." >&2
@@ -162,8 +162,8 @@ jobs:
         env:
           ES_USERNAME: ${{ secrets.es-username }}
           ES_PASSWORD: ${{ secrets.es-password }}
-          CREDENTIAL_ID: ${{ secrets.credential_id }}
-          ES_TOTP_SECRET: ${{ secrets.es-totp_secret }}
+          CREDENTIAL_ID: ${{ secrets.es_credential_ov_id }}
+          ES_TOTP_SECRET: ${{ secrets.es-totp_ov_secret }}
           ESIGNER_PROGRAM_NAME: ${{ inputs.signing-identity }}
         run: |
           entrypoint="${{ inputs.gh-checkout-path }}/.github/workflows/sign-win-artifacts/entrypoint.sh"

--- a/.github/workflows/reusable_sign-win-artifacts.yaml
+++ b/.github/workflows/reusable_sign-win-artifacts.yaml
@@ -14,7 +14,9 @@ on:
 
       # Optional inputs
       artifact-glob:
-        description: Glob pattern to select which files CodeSignTool may sign (.exe, .msi, .msix; controls signing scope, not download scope)
+        description: |
+          Glob pattern(s) for files CodeSignTool may sign (.exe, .msi, .msix). Single pattern or comma-separated
+          list (optional spaces), e.g. "*.exe,*.msi,*.msix". Default **/* signs all supported extensions under the tree.
         required: false
         type: string
         default: "**/*"

--- a/.github/workflows/reusable_sign-win-artifacts.yaml
+++ b/.github/workflows/reusable_sign-win-artifacts.yaml
@@ -59,13 +59,13 @@ on:
         default: ""
 
     secrets:
-      es_credential_ov_id:
+      es_ov_credential_id:
         description: eSigner credential ID (SSL.com)
         required: false
       es_ov_password:
         description: SSL.com account password
         required: false
-      es_totp_ov_secret:
+      es_ov_totp_secret:
         description: TOTP secret for automated OTP (same as NuGet signing in reusable_sign-artifacts)
         required: false
       es_ov_username:
@@ -116,11 +116,11 @@ jobs:
           missing=()
           [ -z "${{ secrets.es_ov_username }}" ] && missing+=("es_ov_username")
           [ -z "${{ secrets.es_ov_password }}" ] && missing+=("es_ov_password")
-          [ -z "${{ secrets.es_credential_ov_id }}" ] && missing+=("es_credential_ov_id")
-          [ -z "${{ secrets.es_totp_ov_secret }}" ] && missing+=("es_totp_ov_secret")
+          [ -z "${{ secrets.es_ov_credential_id }}" ] && missing+=("es_ov_credential_id")
+          [ -z "${{ secrets.es_ov_totp_secret }}" ] && missing+=("es_ov_totp_secret")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "Error: Windows signing requires SSL.com eSigner secrets: ${missing[*]}" >&2
-            echo "Use the same secrets as NuGet signing (reusable_sign-artifacts), or pass --dry-run." >&2
+            echo "Pass workflow_call secrets es_ov_username, es_ov_password, es_ov_credential_id, es_ov_totp_secret (typically from repo secrets ES_OV_USERNAME, ES_OV_PASSWORD, ES_OV_CREDENTIAL_ID, ES_OV_TOTP_SECRET), or use dry-run." >&2
             exit 1
           fi
 
@@ -160,10 +160,10 @@ jobs:
 
       - name: Sign Windows Artifacts
         env:
-          ES_USERNAME: ${{ secrets.es_ov_username }}
-          ES_PASSWORD: ${{ secrets.es_ov_password }}
-          CREDENTIAL_ID: ${{ secrets.es_credential_ov_id }}
-          ES_TOTP_SECRET: ${{ secrets.es_totp_ov_secret }}
+          ES_OV_USERNAME: ${{ secrets.es_ov_username }}
+          ES_OV_PASSWORD: ${{ secrets.es_ov_password }}
+          ES_OV_CREDENTIAL_ID: ${{ secrets.es_ov_credential_id }}
+          ES_OV_TOTP_SECRET: ${{ secrets.es_ov_totp_secret }}
           ESIGNER_PROGRAM_NAME: ${{ inputs.signing-identity }}
         run: |
           entrypoint="${{ inputs.gh-checkout-path }}/.github/workflows/sign-win-artifacts/entrypoint.sh"

--- a/.github/workflows/reusable_sign-win-artifacts.yaml
+++ b/.github/workflows/reusable_sign-win-artifacts.yaml
@@ -1,0 +1,186 @@
+name: Sign Windows Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      # Required inputs
+      gh-workflows-ref:
+        description: |
+          Git reference for shared-workflows checkout. Should match the version in your 'uses:' line.
+          GitHub Actions doesn't expose the called workflow's ref, so this is required.
+          See: .github/workflows/docs/why-gh-workflows-ref.md
+        required: true
+        type: string
+
+      # Optional inputs
+      artifact-glob:
+        description: Glob pattern to select which files CodeSignTool may sign (.exe, .msi, .msix; controls signing scope, not download scope)
+        required: false
+        type: string
+        default: "**/*"
+      codesigntool-version:
+        description: SSL.com CodeSignTool release to install from SSLcom/CodeSignTool (Windows zip on Windows runners, Linux/mac zip elsewhere)
+        required: false
+        type: string
+        default: 1.3.2
+      dry-run:
+        description: Run in dry-run mode (skip CodeSignTool and secret requirements)
+        required: false
+        type: boolean
+        default: false
+      gh-checkout-path:
+        description: Directory to checkout the shared-workflows repository into
+        required: false
+        type: string
+        default: shared-workflows
+      gh-retention-days:
+        description: Retention days for the artifacts
+        required: false
+        type: number
+        default: 1
+      gh-unsigned-artifacts:
+        description: GitHub artifact name to download, sign, and overwrite
+        required: false
+        type: string
+        default: build-artifacts
+      runs-on:
+        description: Runner label (default windows-2025 for .msix and Windows CodeSignTool.bat; Linux runners use CodeSignTool.sh)
+        required: false
+        type: string
+        default: windows-2025
+      signing-identity:
+        description: |
+          Optional display name for MSI installs (CodeSignTool -program_name).
+          Often matches your product line; analogous to passing a human-readable identity alongside Mac signing.
+        required: false
+        type: string
+        default: ""
+
+    secrets:
+      credential_id:
+        description: eSigner credential ID (SSL.com)
+        required: false
+      es-password:
+        description: SSL.com account password
+        required: false
+      es-totp_secret:
+        description: TOTP secret for automated OTP (same as NuGet signing in reusable_sign-artifacts)
+        required: false
+      es-username:
+        description: SSL.com account username
+        required: false
+
+    outputs:
+      gh-artifact-name:
+        description: The name of the uploaded signed artifacts on GitHub
+        value: ${{ jobs.sign-win.outputs.gh-artifact-name }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sign-win:
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      gh-artifact-name: ${{ steps.sign-outputs.outputs.gh-artifact-name }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Download Unsigned Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.gh-unsigned-artifacts }}
+          path: unsigned-artifacts
+          merge-multiple: true
+
+      - name: Checkout shared-workflows repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: aerospike/shared-workflows
+          ref: ${{ inputs.gh-workflows-ref }}
+          path: ${{ inputs.gh-checkout-path }}
+          fetch-depth: 1
+
+      - name: Validate eSigner secrets
+        if: ${{ !inputs.dry-run }}
+        run: |
+          missing=()
+          [ -z "${{ secrets.es-username }}" ] && missing+=("es-username")
+          [ -z "${{ secrets.es-password }}" ] && missing+=("es-password")
+          [ -z "${{ secrets.credential_id }}" ] && missing+=("credential_id")
+          [ -z "${{ secrets.es-totp_secret }}" ] && missing+=("es-totp_secret")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "Error: Windows signing requires SSL.com eSigner secrets: ${missing[*]}" >&2
+            echo "Use the same secrets as NuGet signing (reusable_sign-artifacts), or pass --dry-run." >&2
+            exit 1
+          fi
+
+      - name: Install CodeSignTool
+        if: ${{ !inputs.dry-run }}
+        env:
+          CST_VER: ${{ inputs.codesigntool-version }}
+        run: |
+          set -euo pipefail
+          os=$(uname -s)
+          dest="${RUNNER_TEMP}/codesigntool"
+          rm -rf "$dest"
+          mkdir -p "$dest"
+          if [[ "$os" == MINGW* || "$os" == MSYS* || "$os" == CYGWIN* ]]; then
+            curl -fsSL -o "$RUNNER_TEMP/cst.zip" \
+              "https://github.com/SSLcom/CodeSignTool/releases/download/v${CST_VER}/CodeSignTool-v${CST_VER}-windows.zip"
+            unzip -qo "$RUNNER_TEMP/cst.zip" -d "$dest"
+            cst=$(find "$dest" -name 'CodeSignTool.bat' -type f | head -1)
+            if [[ -z "$cst" ]]; then
+              echo "ERROR: CodeSignTool.bat not found in zip" >&2
+              exit 1
+            fi
+          else
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq default-jre-headless curl unzip
+            curl -fsSL -o "$RUNNER_TEMP/cst.zip" \
+              "https://github.com/SSLcom/CodeSignTool/releases/download/v${CST_VER}/CodeSignTool-v${CST_VER}.zip"
+            unzip -qo "$RUNNER_TEMP/cst.zip" -d "$dest"
+            cst=$(find "$dest" -name 'CodeSignTool.sh' -type f | head -1)
+            if [[ -z "$cst" ]]; then
+              echo "ERROR: CodeSignTool.sh not found in zip" >&2
+              exit 1
+            fi
+            chmod +x "$cst"
+          fi
+          echo "CODESIGNTOOL=$cst" >> "$GITHUB_ENV"
+
+      - name: Sign Windows Artifacts
+        env:
+          ES_USERNAME: ${{ secrets.es-username }}
+          ES_PASSWORD: ${{ secrets.es-password }}
+          CREDENTIAL_ID: ${{ secrets.credential_id }}
+          ES_TOTP_SECRET: ${{ secrets.es-totp_secret }}
+          ESIGNER_PROGRAM_NAME: ${{ inputs.signing-identity }}
+        run: |
+          entrypoint="${{ inputs.gh-checkout-path }}/.github/workflows/sign-win-artifacts/entrypoint.sh"
+          chmod +x "$entrypoint"
+          "$entrypoint" \
+            --source-dir unsigned-artifacts \
+            --target-dir signed-win-output \
+            --artifact-glob '${{ inputs.artifact-glob }}' \
+            ${{ inputs.dry-run && '--dry-run' || '' }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.gh-unsigned-artifacts }}
+          path: signed-win-output
+          overwrite: true
+          retention-days: ${{ inputs.gh-retention-days }}
+
+      - name: Set Outputs
+        id: sign-outputs
+        run: |
+          echo "gh-artifact-name=${{ inputs.gh-unsigned-artifacts }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/sign-artifacts/README.md
+++ b/.github/workflows/sign-artifacts/README.md
@@ -10,7 +10,7 @@ This is a reusable GitHub Actions workflow that signs binary artifacts using GPG
 **Not** GPG-signed here (same pattern as NuGet, which is moved out before GPG):
 
 - **`.nupkg`** — handled only by SSL.com eSigner in this workflow
-- **`.exe`, `.msi`, `.msix`** — reserved for **Windows Authenticode** (e.g. `reusable_sign-win-artifacts` in the orchestrator). They are moved aside before GPG and copied back into the signed artifact tree afterward so deploy still sees the same paths. Optional existing `*.asc` sidecars next to those files move with them.
+- **`.exe`, `.msi`, `.msix`** — reserved for **Windows Authenticode** (e.g. `reusable_sign-win-artifacts` in the orchestrator), which uses SSL.com secrets **`ES_OV_USERNAME`**, **`ES_OV_PASSWORD`**, **`ES_OV_CREDENTIAL_ID`**, and **`ES_OV_TOTP_SECRET`** (see [`sign-win-artifacts/README.md`](../sign-win-artifacts/README.md)). They are moved aside before GPG and copied back into the signed artifact tree afterward so deploy still sees the same paths. Optional existing `*.asc` sidecars next to those files move with them.
 
 ---
 

--- a/.github/workflows/sign-artifacts/README.md
+++ b/.github/workflows/sign-artifacts/README.md
@@ -2,10 +2,15 @@
 
 > **Note:** This workflow is used internally by [`reusable_artifacts-cicd.yaml`](../artifacts-cicd/README.md). Most consumers should use the orchestrator rather than calling this directly.
 
-This is a reusable GitHub Actions workflow that signs binary artifacts using GPG. It supports `.deb`, `.rpm`, `.nupkg` (NuGet via SSL.com), and any other file type passed via a glob pattern. It produces:
+This is a reusable GitHub Actions workflow that signs binary artifacts using GPG. It supports `.deb`, `.rpm`, `.nupkg` (NuGet via SSL.com), and other file types passed via a glob pattern. It produces:
 
-- GPG detached signature (`.asc`) for any file
+- GPG detached signature (`.asc`) for files that pass through the GPG stage
 - Native signing for `.deb` and `.rpm` using `dpkg-sig` and `rpm --addsign`
+
+**Not** GPG-signed here (same pattern as NuGet, which is moved out before GPG):
+
+- **`.nupkg`** — handled only by SSL.com eSigner in this workflow
+- **`.exe`, `.msi`, `.msix`** — reserved for **Windows Authenticode** (e.g. `reusable_sign-win-artifacts` in the orchestrator). They are moved aside before GPG and copied back into the signed artifact tree afterward so deploy still sees the same paths. Optional existing `*.asc` sidecars next to those files move with them.
 
 ---
 
@@ -37,6 +42,7 @@ Notes:
 
 - NuGet signing runs only if `.nupkg` files are present in the unsigned artifacts.
 - If `.nupkg` files are found, all four SSL.com secrets above must be provided or the workflow fails.
+- **macOS `.pkg` / `.dmg`** are not isolated by this workflow; they still receive GPG detached signatures if present under `unsigned-artifacts`. Use the orchestrator’s `sign-mac` job for Apple signing before this job when you need Apple-only treatment.
 
 ---
 

--- a/.github/workflows/sign-win-artifacts/README.md
+++ b/.github/workflows/sign-win-artifacts/README.md
@@ -6,6 +6,8 @@ Apple certificates and identities from Mac signing **do not apply** here. Use th
 
 The default runner is **`windows-2025`** (Git Bash) so **CodeSignTool.bat** from the official Windows bundle is used. If CodeSignTool rejects a specific MSIX payload, SSL.com also documents **eSigner CKA + Microsoft SignTool** as an alternative.
 
+When this job runs **before** [`reusable_sign-artifacts.yaml`](../reusable_sign-artifacts.yaml) in [`reusable_artifacts-cicd.yaml`](../reusable_artifacts-cicd.yaml), the **Sign Artifacts** step **does not** GPG-sign `.exe`, `.msi`, or `.msix` (they are moved aside and merged back, same idea as `.nupkg` vs SSL.com-only).
+
 ---
 
 ## Inputs

--- a/.github/workflows/sign-win-artifacts/README.md
+++ b/.github/workflows/sign-win-artifacts/README.md
@@ -2,7 +2,7 @@
 
 This reusable workflow signs **Windows Authenticode** artifacts (`.exe`, `.msi`, `.msix`) using **SSL.com eSigner CodeSignTool**, mirroring the layout of [`reusable_sign-mac-artifacts.yaml`](../reusable_sign-mac-artifacts.yaml): download artifact tree, sign selected files, re-upload with `overwrite: true`.
 
-Apple certificates and identities from Mac signing **do not apply** here. Use the **same SSL.com eSigner secrets** as [`reusable_sign-artifacts.yaml`](../reusable_sign-artifacts.yaml) NuGet signing (`es-username`, `es-password`, `credential_id`, `es-totp_secret`) so one account can cover NuGet and Windows binaries.
+Apple certificates and identities from Mac signing **do not apply** here. Windows signing uses **OV**-scoped workflow secrets (`es_ov_username`, `es_ov_password`, `es_ov_credential_id`, `es_ov_totp_secret`), typically mapped from repository secrets **`ES_OV_USERNAME`**, **`ES_OV_PASSWORD`**, **`ES_OV_CREDENTIAL_ID`**, and **`ES_OV_TOTP_SECRET`**. NuGet signing in [`reusable_sign-artifacts.yaml`](../reusable_sign-artifacts.yaml) still uses the separate `es-username` / `es-password` / `credential_id` / `es-totp_secret` inputs (often backed by different repo secret names); you can map both sets from the same SSL.com account if you choose.
 
 The default runner is **`windows-2025`** (Git Bash) so **CodeSignTool.bat** from the official Windows bundle is used. If CodeSignTool rejects a specific MSIX payload, SSL.com also documents **eSigner CKA + Microsoft SignTool** as an alternative.
 
@@ -26,12 +26,14 @@ When this job runs **before** [`reusable_sign-artifacts.yaml`](../reusable_sign-
 
 ## Secrets
 
-| Name             | Required     | Description                   |
-| ---------------- | ------------ | ----------------------------- |
-| `es-username`    | When signing | SSL.com account username      |
-| `es-password`    | When signing | SSL.com account password      |
-| `credential_id`  | When signing | eSigner credential ID         |
-| `es-totp_secret` | When signing | TOTP secret for automated OTP |
+| Name                  | Required     | Description                   |
+| --------------------- | ------------ | ----------------------------- |
+| `es_ov_username`      | When signing | SSL.com account username      |
+| `es_ov_password`      | When signing | SSL.com account password      |
+| `es_ov_credential_id` | When signing | eSigner credential ID         |
+| `es_ov_totp_secret`   | When signing | TOTP secret for automated OTP |
+
+The signing step sets environment variables **`ES_OV_USERNAME`**, **`ES_OV_PASSWORD`**, **`ES_OV_CREDENTIAL_ID`**, and **`ES_OV_TOTP_SECRET`** for [`entrypoint.sh`](./entrypoint.sh).
 
 When `dry-run: true`, these secrets may be omitted.
 
@@ -51,10 +53,10 @@ jobs:
       signing-identity: "My Product Installer"
       artifact-glob: "*.exe,*.msi,*.msix"
     secrets:
-      es-username: ${{ secrets.ES_USERNAME }}
-      es-password: ${{ secrets.ES_PASSWORD }}
-      credential_id: ${{ secrets.CREDENTIAL_ID }}
-      es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+      es_ov_username: ${{ secrets.ES_OV_USERNAME }}
+      es_ov_password: ${{ secrets.ES_OV_PASSWORD }}
+      es_ov_credential_id: ${{ secrets.ES_OV_CREDENTIAL_ID }}
+      es_ov_totp_secret: ${{ secrets.ES_OV_TOTP_SECRET }}
 ```
 
 ## Required: gh-workflows-ref

--- a/.github/workflows/sign-win-artifacts/README.md
+++ b/.github/workflows/sign-win-artifacts/README.md
@@ -10,17 +10,17 @@ The default runner is **`windows-2025`** (Git Bash) so **CodeSignTool.bat** from
 
 ## Inputs
 
-| Name                    | Type      | Required | Description                                                                                    |
-| ----------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `gh-workflows-ref`      | `string`  | Yes      | Git ref for shared-workflows (**must match your `uses:` version**)                             |
-| `artifact-glob`         | `string`  | No       | Glob for files considered for signing (default: `**/*`). Full tree is always copied.           |
-| `codesigntool-version`  | `string`  | No       | CodeSignTool release to install from GitHub (default: `1.3.2`). Ignored when `dry-run: true`.  |
-| `dry-run`               | `boolean` | No       | Skip CodeSignTool and eSigner secret requirements. Default: `false`                            |
-| `gh-checkout-path`      | `string`  | No       | Checkout path for shared-workflows. Default: `shared-workflows`                                |
-| `gh-retention-days`     | `number`  | No       | Artifact retention days. Default: `1`                                                          |
-| `gh-unsigned-artifacts` | `string`  | No       | GitHub artifact name to download and overwrite. Default: `build-artifacts`                     |
-| `runs-on`               | `string`  | No       | Runner label. Default: `windows-2025` (Git Bash; Linux values still install `CodeSignTool.sh`) |
-| `signing-identity`      | `string`  | No       | Optional MSI display name (CodeSignTool `-program_name`). Often your product name.             |
+| Name                    | Type      | Required | Description                                                                                                                                                         |
+| ----------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gh-workflows-ref`      | `string`  | Yes      | Git ref for shared-workflows (**must match your `uses:` version**)                                                                                                  |
+| `artifact-glob`         | `string`  | No       | Glob for signing scope (default: `**/*`). Use one pattern or **comma-separated** patterns (spaces optional), e.g. `*.exe,*.msi,*.msix`. Full tree is always copied. |
+| `codesigntool-version`  | `string`  | No       | CodeSignTool release to install from GitHub (default: `1.3.2`). Ignored when `dry-run: true`.                                                                       |
+| `dry-run`               | `boolean` | No       | Skip CodeSignTool and eSigner secret requirements. Default: `false`                                                                                                 |
+| `gh-checkout-path`      | `string`  | No       | Checkout path for shared-workflows. Default: `shared-workflows`                                                                                                     |
+| `gh-retention-days`     | `number`  | No       | Artifact retention days. Default: `1`                                                                                                                               |
+| `gh-unsigned-artifacts` | `string`  | No       | GitHub artifact name to download and overwrite. Default: `build-artifacts`                                                                                          |
+| `runs-on`               | `string`  | No       | Runner label. Default: `windows-2025` (Git Bash; Linux values still install `CodeSignTool.sh`)                                                                      |
+| `signing-identity`      | `string`  | No       | Optional MSI display name (CodeSignTool `-program_name`). Often your product name.                                                                                  |
 
 ## Secrets
 
@@ -47,7 +47,7 @@ jobs:
       gh-unsigned-artifacts: build-artifacts
       gh-workflows-ref: v4.0.0
       signing-identity: "My Product Installer"
-      artifact-glob: "*.msi"
+      artifact-glob: "*.exe,*.msi,*.msix"
     secrets:
       es-username: ${{ secrets.ES_USERNAME }}
       es-password: ${{ secrets.ES_PASSWORD }}

--- a/.github/workflows/sign-win-artifacts/README.md
+++ b/.github/workflows/sign-win-artifacts/README.md
@@ -1,0 +1,71 @@
+# Sign Windows Artifacts Workflow
+
+This reusable workflow signs **Windows Authenticode** artifacts (`.exe`, `.msi`, `.msix`) using **SSL.com eSigner CodeSignTool**, mirroring the layout of [`reusable_sign-mac-artifacts.yaml`](../reusable_sign-mac-artifacts.yaml): download artifact tree, sign selected files, re-upload with `overwrite: true`.
+
+Apple certificates and identities from Mac signing **do not apply** here. Use the **same SSL.com eSigner secrets** as [`reusable_sign-artifacts.yaml`](../reusable_sign-artifacts.yaml) NuGet signing (`es-username`, `es-password`, `credential_id`, `es-totp_secret`) so one account can cover NuGet and Windows binaries.
+
+The default runner is **`windows-2025`** (Git Bash) so **CodeSignTool.bat** from the official Windows bundle is used. If CodeSignTool rejects a specific MSIX payload, SSL.com also documents **eSigner CKA + Microsoft SignTool** as an alternative.
+
+---
+
+## Inputs
+
+| Name                    | Type      | Required | Description                                                                                    |
+| ----------------------- | --------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `gh-workflows-ref`      | `string`  | Yes      | Git ref for shared-workflows (**must match your `uses:` version**)                             |
+| `artifact-glob`         | `string`  | No       | Glob for files considered for signing (default: `**/*`). Full tree is always copied.           |
+| `codesigntool-version`  | `string`  | No       | CodeSignTool release to install from GitHub (default: `1.3.2`). Ignored when `dry-run: true`.  |
+| `dry-run`               | `boolean` | No       | Skip CodeSignTool and eSigner secret requirements. Default: `false`                            |
+| `gh-checkout-path`      | `string`  | No       | Checkout path for shared-workflows. Default: `shared-workflows`                                |
+| `gh-retention-days`     | `number`  | No       | Artifact retention days. Default: `1`                                                          |
+| `gh-unsigned-artifacts` | `string`  | No       | GitHub artifact name to download and overwrite. Default: `build-artifacts`                     |
+| `runs-on`               | `string`  | No       | Runner label. Default: `windows-2025` (Git Bash; Linux values still install `CodeSignTool.sh`) |
+| `signing-identity`      | `string`  | No       | Optional MSI display name (CodeSignTool `-program_name`). Often your product name.             |
+
+## Secrets
+
+| Name             | Required     | Description                   |
+| ---------------- | ------------ | ----------------------------- |
+| `es-username`    | When signing | SSL.com account username      |
+| `es-password`    | When signing | SSL.com account password      |
+| `credential_id`  | When signing | eSigner credential ID         |
+| `es-totp_secret` | When signing | TOTP secret for automated OTP |
+
+When `dry-run: true`, these secrets may be omitted.
+
+---
+
+## Example Usage
+
+### Composable (direct call)
+
+```yaml
+jobs:
+  sign-win:
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-win-artifacts.yaml@v4.0.0
+    with:
+      gh-unsigned-artifacts: build-artifacts
+      gh-workflows-ref: v4.0.0
+      signing-identity: "My Product Installer"
+      artifact-glob: "*.msi"
+    secrets:
+      es-username: ${{ secrets.ES_USERNAME }}
+      es-password: ${{ secrets.ES_PASSWORD }}
+      credential_id: ${{ secrets.CREDENTIAL_ID }}
+      es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+```
+
+## Required: gh-workflows-ref
+
+Same requirement as other reusable workflows; see [Why gh-workflows-ref is required](../docs/why-gh-workflows-ref.md).
+
+## Outputs
+
+| Name               | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| `gh-artifact-name` | The name of the uploaded artifact (same as input) |
+
+## Testing
+
+- **Bats tests** (mocked CodeSignTool): `bats .github/workflows/sign-win-artifacts/tests/bats/`
+- **CI**: `test_sign-win-artifacts-workflow.yaml` runs on PRs touching these paths

--- a/.github/workflows/sign-win-artifacts/README.md
+++ b/.github/workflows/sign-win-artifacts/README.md
@@ -68,4 +68,5 @@ Same requirement as other reusable workflows; see [Why gh-workflows-ref is requi
 ## Testing
 
 - **Bats tests** (mocked CodeSignTool): `bats .github/workflows/sign-win-artifacts/tests/bats/`
-- **CI**: `test_sign-win-artifacts-workflow.yaml` runs on PRs touching these paths
+- **CI dry-run**: `test_sign-win-artifacts-workflow.yaml` runs on PRs touching `reusable_sign-win-artifacts.yaml` or `sign-win-artifacts/**`
+- **Manual smoke test**: `test_sign-win-artifacts-smoke.yaml` (`workflow_dispatch`) for end-to-end signing with real eSigner secrets; optional repo variable `WIN_SIGNING_PROGRAM_NAME` for `signing-identity`

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -43,10 +43,10 @@ Options:
   --help                 Show this help message
 
 Environment variables (required when not dry-run):
-  ES_USERNAME       SSL.com account username
-  ES_PASSWORD       SSL.com account password
-  CREDENTIAL_ID     eSigner credential ID
-  ES_TOTP_SECRET    TOTP secret for automated OTP
+  ES_OV_USERNAME       SSL.com account username (OV / Authenticode signing)
+  ES_OV_PASSWORD       SSL.com account password
+  ES_OV_CREDENTIAL_ID  eSigner credential ID
+  ES_OV_TOTP_SECRET    TOTP secret for automated OTP
 
 Environment variables (optional):
   ESIGNER_PROGRAM_NAME   Passed to CodeSignTool as -program_name for MSI (UAC display name)
@@ -105,7 +105,7 @@ if [[ ! -d $SOURCE_DIR ]]; then
 fi
 
 if [[ $DRY_RUN != "true" ]]; then
-    for var in ES_USERNAME ES_PASSWORD CREDENTIAL_ID ES_TOTP_SECRET; do
+    for var in ES_OV_USERNAME ES_OV_PASSWORD ES_OV_CREDENTIAL_ID ES_OV_TOTP_SECRET; do
         if [[ -z ${!var-} ]]; then
             echo "ERROR: $var environment variable is required (or use --dry-run)" >&2
             exit 1
@@ -215,11 +215,11 @@ sign_one_file() {
     local -a cmd
     cmd=(
         "$cst" sign
-        "-username=$ES_USERNAME"
-        "-password=$ES_PASSWORD"
-        "-credential_id=$CREDENTIAL_ID"
+        "-username=$ES_OV_USERNAME"
+        "-password=$ES_OV_PASSWORD"
+        "-credential_id=$ES_OV_CREDENTIAL_ID"
         "-input_file_path=$file"
-        "-totp_secret=$ES_TOTP_SECRET"
+        "-totp_secret=$ES_OV_TOTP_SECRET"
     )
     if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
         cmd+=("-program_name=$ESIGNER_PROGRAM_NAME")

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -178,9 +178,14 @@ sign_one_file() {
             *) cst="CodeSignTool.sh" ;;
             esac
         fi
-    else
-        cst=$(resolve_codesigntool)
+        echo "[DRY-RUN] $cst sign -username=*** -password=*** -credential_id=*** -input_file_path=$file -totp_secret=*** -output_dir_path=<tmpdir>"
+        if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
+            echo "[DRY-RUN]   -program_name=$ESIGNER_PROGRAM_NAME"
+        fi
+        return 0
     fi
+
+    cst=$(resolve_codesigntool)
 
     local -a cmd
     cmd=(
@@ -193,14 +198,6 @@ sign_one_file() {
     )
     if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
         cmd+=("-program_name=$ESIGNER_PROGRAM_NAME")
-    fi
-
-    if [[ $DRY_RUN == "true" ]]; then
-        echo "[DRY-RUN] $cst sign -username=*** -password=*** -credential_id=*** -input_file_path=$file -totp_secret=*** -output_dir_path=<tmpdir>"
-        if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
-            echo "[DRY-RUN]   -program_name=$ESIGNER_PROGRAM_NAME"
-        fi
-        return 0
     fi
 
     local outdir

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Constants ---
+DRY_RUN="false"
+SOURCE_DIR=""
+TARGET_DIR=""
+ARTIFACT_GLOB="**/*"
+
+# --- Error handling ---
+handle_error() {
+    local line_no=$1
+    local command=$2
+    echo "ERROR: Command '$command' failed at line $line_no" >&2
+    exit 1
+}
+trap 'handle_error ${LINENO} "$BASH_COMMAND"' ERR
+
+# --- Dry-run wrapper ---
+run() {
+    if [[ $DRY_RUN == "true" ]]; then
+        echo "[DRY-RUN] $*"
+        return 0
+    fi
+    "$@"
+}
+
+# --- Usage ---
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Sign Windows artifacts (.exe, .msi, .msix) with SSL.com eSigner CodeSignTool.
+Non-Windows files are copied through unchanged.
+
+Options:
+  --source-dir DIR       Directory containing unsigned artifacts (required)
+  --target-dir DIR       Output directory for signed artifacts (required)
+  --artifact-glob GLOB   Glob pattern for files to consider for signing (default: **/*).
+                         Controls signing scope only; the full tree is always copied.
+  --dry-run              Print commands without executing
+  --help                 Show this help message
+
+Environment variables (required when not dry-run):
+  ES_USERNAME       SSL.com account username
+  ES_PASSWORD       SSL.com account password
+  CREDENTIAL_ID     eSigner credential ID
+  ES_TOTP_SECRET    TOTP secret for automated OTP
+
+Environment variables (optional):
+  ESIGNER_PROGRAM_NAME   Passed to CodeSignTool as -program_name for MSI (UAC display name)
+  CODESIGNTOOL           Path to CodeSignTool (CodeSignTool.bat on Windows, CodeSignTool.sh on Linux/macOS)
+
+Examples:
+  entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output
+  entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output --artifact-glob '*.exe'
+  entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output --dry-run
+EOF
+}
+
+# --- Argument parsing ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --source-dir)
+        SOURCE_DIR="$2"
+        shift 2
+        ;;
+    --target-dir)
+        TARGET_DIR="$2"
+        shift 2
+        ;;
+    --artifact-glob)
+        ARTIFACT_GLOB="$2"
+        shift 2
+        ;;
+    --dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+    --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+done
+
+# --- Validation ---
+if [[ -z $SOURCE_DIR ]]; then
+    echo "ERROR: --source-dir is required" >&2
+    exit 1
+fi
+if [[ -z $TARGET_DIR ]]; then
+    echo "ERROR: --target-dir is required" >&2
+    exit 1
+fi
+if [[ ! -d $SOURCE_DIR ]]; then
+    echo "ERROR: Source directory does not exist: $SOURCE_DIR" >&2
+    exit 1
+fi
+
+if [[ $DRY_RUN != "true" ]]; then
+    for var in ES_USERNAME ES_PASSWORD CREDENTIAL_ID ES_TOTP_SECRET; do
+        if [[ -z ${!var-} ]]; then
+            echo "ERROR: $var environment variable is required (or use --dry-run)" >&2
+            exit 1
+        fi
+    done
+fi
+
+resolve_codesigntool() {
+    if [[ -n ${CODESIGNTOOL-} ]]; then
+        echo "$CODESIGNTOOL"
+        return
+    fi
+    if command -v CodeSignTool.bat >/dev/null 2>&1; then
+        command -v CodeSignTool.bat
+        return
+    fi
+    if command -v CodeSignTool.sh >/dev/null 2>&1; then
+        command -v CodeSignTool.sh
+        return
+    fi
+    echo "ERROR: CodeSignTool not found. Set CODESIGNTOOL or install CodeSignTool.bat / CodeSignTool.sh on PATH." >&2
+    exit 1
+}
+
+# --- Glob matching (same semantics as sign-mac-artifacts) ---
+matches_glob() {
+    local file="$1"
+    local pattern="$2"
+
+    if [[ $pattern == "**/*" ]]; then
+        return 0
+    fi
+
+    local filename
+    filename=$(basename "$file")
+
+    # shellcheck disable=SC2254
+    case "$filename" in
+    $pattern) return 0 ;;
+    esac
+
+    # shellcheck disable=SC2254
+    case "$file" in
+    $pattern) return 0 ;;
+    esac
+
+    return 1
+}
+
+lower_ext() {
+    local f="$1"
+    local ext="${f##*.}"
+    if [[ $ext == "$f" ]]; then
+        echo ""
+        return
+    fi
+    echo "$ext" | tr '[:upper:]' '[:lower:]'
+}
+
+sign_one_file() {
+    local file="$1"
+    local ext
+    ext=$(lower_ext "$file")
+
+    local cst
+    if [[ $DRY_RUN == "true" ]]; then
+        cst="${CODESIGNTOOL-}"
+        if [[ -z $cst ]]; then
+            case "$(uname -s 2>/dev/null)" in
+            MINGW* | MSYS* | CYGWIN*) cst="CodeSignTool.bat" ;;
+            *) cst="CodeSignTool.sh" ;;
+            esac
+        fi
+    else
+        cst=$(resolve_codesigntool)
+    fi
+
+    local -a cmd
+    cmd=(
+        "$cst" sign
+        "-username=$ES_USERNAME"
+        "-password=$ES_PASSWORD"
+        "-credential_id=$CREDENTIAL_ID"
+        "-input_file_path=$file"
+        "-totp_secret=$ES_TOTP_SECRET"
+    )
+    if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
+        cmd+=("-program_name=$ESIGNER_PROGRAM_NAME")
+    fi
+
+    if [[ $DRY_RUN == "true" ]]; then
+        echo "[DRY-RUN] $cst sign -username=*** -password=*** -credential_id=*** -input_file_path=$file -totp_secret=*** -output_dir_path=<tmpdir>"
+        if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
+            echo "[DRY-RUN]   -program_name=$ESIGNER_PROGRAM_NAME"
+        fi
+        return 0
+    fi
+
+    local outdir
+    outdir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$outdir'" RETURN
+    cmd+=("-output_dir_path=$outdir")
+
+    echo "  Running CodeSignTool sign for: $file"
+    run "${cmd[@]}"
+
+    local base outpath
+    base=$(basename "$file")
+    outpath="$outdir/$base"
+    if [[ ! -f $outpath ]]; then
+        echo "ERROR: Expected signed output not found: $outpath" >&2
+        exit 1
+    fi
+    mv -f "$outpath" "$file"
+}
+
+# --- Main ---
+main() {
+    local cst_display
+    cst_display="${CODESIGNTOOL-}"
+    if [[ -z $cst_display ]]; then
+        case "$(uname -s 2>/dev/null)" in
+        MINGW* | MSYS* | CYGWIN*) cst_display="CodeSignTool.bat (PATH)" ;;
+        *) cst_display="CodeSignTool.sh (PATH)" ;;
+        esac
+    fi
+
+    echo "============================================"
+    echo "Windows Artifact Signing (eSigner)"
+    echo "============================================"
+    echo "Source directory: $SOURCE_DIR"
+    echo "Target directory: $TARGET_DIR"
+    echo "Artifact glob:   $ARTIFACT_GLOB"
+    echo "Dry run:         $DRY_RUN"
+    echo "CodeSignTool:    $cst_display"
+    echo "MSI program name: ${ESIGNER_PROGRAM_NAME:-<not set>}"
+    echo "============================================"
+
+    echo "==> Copying full artifact tree to $TARGET_DIR"
+    mkdir -p "$TARGET_DIR"
+    if [[ -n "$(ls -A "$SOURCE_DIR" 2>/dev/null)" ]]; then
+        cp -R "$SOURCE_DIR"/* "$TARGET_DIR/"
+    else
+        echo "WARNING: Source directory is empty: $SOURCE_DIR" >&2
+        return 0
+    fi
+
+    echo "==> Artifact tree contents:"
+    find "$TARGET_DIR" -type f | sort
+
+    local signed_count=0
+    local skipped_count=0
+
+    echo "==> Processing artifacts for signing"
+    while IFS= read -r file; do
+        if [[ $file =~ \.(asc|sha256)$ ]]; then
+            continue
+        fi
+
+        local relative_path="${file#"$TARGET_DIR"/}"
+        if ! matches_glob "$relative_path" "$ARTIFACT_GLOB"; then
+            ((skipped_count++)) || true
+            continue
+        fi
+
+        local ext
+        ext=$(lower_ext "$file")
+
+        case "$ext" in
+        exe | msi | msix)
+            echo ""
+            echo "--- Processing .$ext: $relative_path ---"
+            sign_one_file "$file"
+            ((signed_count++)) || true
+            ;;
+        *)
+            ((skipped_count++)) || true
+            ;;
+        esac
+    done < <(find "$TARGET_DIR" -type f | sort)
+
+    echo ""
+    echo "============================================"
+    echo "Signing complete"
+    echo "  Files signed:       $signed_count"
+    echo "  Files skipped:      $skipped_count (glob mismatch or non-Windows types)"
+    echo "============================================"
+}
+
+main

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -37,7 +37,8 @@ Options:
   --source-dir DIR       Directory containing unsigned artifacts (required)
   --target-dir DIR       Output directory for signed artifacts (required)
   --artifact-glob GLOB   Glob pattern for files to consider for signing (default: **/*).
-                         Controls signing scope only; the full tree is always copied.
+                         Use a single pattern, or several comma-separated patterns (optional spaces),
+                         e.g. '*.exe,*.msi,*.msix'. Controls signing scope only; the full tree is always copied.
   --dry-run              Print commands without executing
   --help                 Show this help message
 
@@ -53,7 +54,7 @@ Environment variables (optional):
 
 Examples:
   entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output
-  entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output --artifact-glob '*.exe'
+  entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output --artifact-glob '*.exe,*.msi,*.msix'
   entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output --dry-run
 EOF
 }
@@ -129,14 +130,10 @@ resolve_codesigntool() {
     exit 1
 }
 
-# --- Glob matching (same semantics as sign-mac-artifacts) ---
-matches_glob() {
+# --- Glob matching (same semantics as sign-mac-artifacts, plus comma-separated alternates) ---
+_matches_single_glob() {
     local file="$1"
     local pattern="$2"
-
-    if [[ $pattern == "**/*" ]]; then
-        return 0
-    fi
 
     local filename
     filename=$(basename "$file")
@@ -152,6 +149,34 @@ matches_glob() {
     esac
 
     return 1
+}
+
+matches_glob() {
+    local file="$1"
+    local pattern="$2"
+
+    if [[ $pattern == "**/*" ]]; then
+        return 0
+    fi
+
+    # Multiple patterns: comma-separated (e.g. "*.exe,*.msi,*.msix")
+    if [[ $pattern == *","* ]]; then
+        local IFS=,
+        local -a parts
+        read -ra parts <<<"$pattern"
+        local p trimmed
+        for p in "${parts[@]}"; do
+            trimmed="${p#"${p%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+            [[ -z $trimmed ]] && continue
+            if matches_glob "$file" "$trimmed"; then
+                return 0
+            fi
+        done
+        return 1
+    fi
+
+    _matches_single_glob "$file" "$pattern"
 }
 
 lower_ext() {

--- a/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
+++ b/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
@@ -1,0 +1,236 @@
+#!/usr/bin/env bats
+# Tests for sign-win-artifacts entrypoint.sh
+#
+# Mocks CodeSignTool.sh for Linux CI. Covers argument validation, tree copy,
+# glob filtering, .exe/.msi/.msix signing, and dry-run behavior.
+
+setup_file() {
+  GIT_ROOT="$(git rev-parse --show-toplevel)"
+  export GIT_ROOT
+  ENTRYPOINT="$GIT_ROOT/.github/workflows/sign-win-artifacts/entrypoint.sh"
+  export ENTRYPOINT
+
+  TEST_TMPDIR="$(mktemp -d)"
+  export TEST_TMPDIR
+
+  MOCK_BIN="$TEST_TMPDIR/mock-bin"
+  mkdir -p "$MOCK_BIN"
+  export MOCK_BIN
+
+  cat > "$MOCK_BIN/CodeSignTool.sh" <<'MOCK'
+#!/usr/bin/env bash
+echo "CodeSignTool $*" >> "$TEST_TMPDIR/commands.log"
+infile=""
+outdir=""
+for arg in "$@"; do
+  case "$arg" in
+  sign) ;;
+  -input_file_path=*) infile="${arg#-input_file_path=}" ;;
+  -output_dir_path=*) outdir="${arg#-output_dir_path=}" ;;
+  esac
+done
+if [[ -z "$infile" || -z "$outdir" ]]; then
+  echo "mock: missing input or output dir" >&2
+  exit 1
+fi
+mkdir -p "$outdir"
+cp "$infile" "$outdir/$(basename "$infile")"
+MOCK
+  chmod +x "$MOCK_BIN/CodeSignTool.sh"
+
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown_file() {
+  if [ -d "${TEST_TMPDIR:-}" ]; then
+    rm -rf "$TEST_TMPDIR"
+  fi
+}
+
+setup() {
+  > "$TEST_TMPDIR/commands.log"
+
+  SOURCE_DIR="$TEST_TMPDIR/source-$$-$BATS_TEST_NUMBER"
+  TARGET_DIR="$TEST_TMPDIR/target-$$-$BATS_TEST_NUMBER"
+  mkdir -p "$SOURCE_DIR"
+
+  export ES_USERNAME="user@example.com"
+  export ES_PASSWORD="secret-pass"
+  export CREDENTIAL_ID="cred-uuid-test"
+  export ES_TOTP_SECRET="totp-secret-test"
+  export CODESIGNTOOL="$MOCK_BIN/CodeSignTool.sh"
+}
+
+# --- Argument parsing tests ---
+
+@test "entrypoint fails without --source-dir" {
+  run "$ENTRYPOINT" --target-dir "$TARGET_DIR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--source-dir is required"* ]]
+}
+
+@test "entrypoint fails without --target-dir" {
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--target-dir is required"* ]]
+}
+
+@test "entrypoint fails with nonexistent source directory" {
+  run "$ENTRYPOINT" --source-dir /nonexistent --target-dir "$TARGET_DIR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Source directory does not exist"* ]]
+}
+
+@test "entrypoint shows help with --help" {
+  run "$ENTRYPOINT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sign Windows artifacts"* ]]
+}
+
+@test "entrypoint fails without eSigner secrets when not dry-run" {
+  unset ES_USERNAME
+  touch "$SOURCE_DIR/app.exe"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ES_USERNAME"* ]]
+}
+
+# --- Full tree copy tests ---
+
+@test "full artifact tree is copied even when glob is narrow" {
+  touch "$SOURCE_DIR/app.exe"
+  touch "$SOURCE_DIR/app.deb"
+  mkdir -p "$SOURCE_DIR/subdir"
+  touch "$SOURCE_DIR/subdir/lib.jar"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" \
+    --artifact-glob '*.exe' --dry-run
+
+  [ "$status" -eq 0 ]
+  [ -f "$TARGET_DIR/app.exe" ]
+  [ -f "$TARGET_DIR/app.deb" ]
+  [ -f "$TARGET_DIR/subdir/lib.jar" ]
+}
+
+@test "only glob-matched exe is signed in non-dry-run" {
+  echo "fake-exe" > "$SOURCE_DIR/app.exe"
+  echo "fake-deb" > "$SOURCE_DIR/app.deb"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" \
+    --artifact-glob '*.exe'
+
+  [ "$status" -eq 0 ]
+  grep -q "CodeSignTool.*sign" "$TEST_TMPDIR/commands.log"
+  ! grep -q "app.deb" "$TEST_TMPDIR/commands.log"
+  [[ "$(cat "$TARGET_DIR/app.exe")" == "fake-exe" ]]
+}
+
+@test ".exe is signed with CodeSignTool" {
+  echo "payload" > "$SOURCE_DIR/tool.exe"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q "CodeSignTool.*sign.*-input_file_path=.*tool.exe" "$TEST_TMPDIR/commands.log"
+}
+
+@test ".msi is signed with CodeSignTool" {
+  echo "msi-payload" > "$SOURCE_DIR/setup.msi"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q "CodeSignTool.*sign.*-input_file_path=.*setup.msi" "$TEST_TMPDIR/commands.log"
+}
+
+@test ".msi receives -program_name when ESIGNER_PROGRAM_NAME is set" {
+  echo "msi" > "$SOURCE_DIR/setup.msi"
+  export ESIGNER_PROGRAM_NAME="Contoso Setup"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q -- "-program_name=Contoso Setup" "$TEST_TMPDIR/commands.log"
+}
+
+@test ".exe does not receive -program_name when ESIGNER_PROGRAM_NAME is set" {
+  echo "bin" > "$SOURCE_DIR/app.exe"
+  export ESIGNER_PROGRAM_NAME="Contoso Setup"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "program_name" "$TEST_TMPDIR/commands.log"
+}
+
+@test ".msix is signed with CodeSignTool" {
+  echo "msix-payload" > "$SOURCE_DIR/bundle.msix"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q "CodeSignTool.*sign.*-input_file_path=.*bundle.msix" "$TEST_TMPDIR/commands.log"
+  [[ "$(cat "$TARGET_DIR/bundle.msix")" == "msix-payload" ]]
+}
+
+@test ".msix dry-run invokes redacted CodeSignTool line" {
+  echo "x" > "$SOURCE_DIR/pkg.msix"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" --dry-run
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Processing .msix"* ]]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"pkg.msix"* ]]
+}
+
+@test "non-signable files are skipped" {
+  touch "$SOURCE_DIR/readme.txt"
+  touch "$SOURCE_DIR/lib.jar"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" --dry-run
+
+  [ "$status" -eq 0 ]
+  ! grep -q "CodeSignTool" "$TEST_TMPDIR/commands.log"
+}
+
+@test "dry-run does not require eSigner secrets" {
+  unset ES_USERNAME ES_PASSWORD CREDENTIAL_ID ES_TOTP_SECRET
+  echo "x" > "$SOURCE_DIR/a.exe"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" --dry-run
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+}
+
+@test "dry-run output redacts credentials" {
+  echo "x" > "$SOURCE_DIR/a.exe"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" --dry-run
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-password=***"* ]]
+  [[ "$output" != *"secret-pass"* ]]
+}
+
+@test "uppercase extension .EXE is signed" {
+  echo "data" > "$SOURCE_DIR/TOOL.EXE"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q "TOOL.EXE" "$TEST_TMPDIR/commands.log"
+}
+
+@test ".asc files are ignored for signing" {
+  echo "sig" > "$SOURCE_DIR/file.asc"
+  echo "exe" > "$SOURCE_DIR/file.exe"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q "file.exe" "$TEST_TMPDIR/commands.log"
+  ! grep -q "file.asc" "$TEST_TMPDIR/commands.log"
+}

--- a/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
+++ b/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
@@ -126,6 +126,22 @@ setup() {
   [[ "$(cat "$TARGET_DIR/app.exe")" == "fake-exe" ]]
 }
 
+@test "comma-separated artifact-glob signs multiple Windows types" {
+  echo "fake-exe" > "$SOURCE_DIR/app.exe"
+  echo "fake-msi" > "$SOURCE_DIR/setup.msi"
+  echo "fake-msix" > "$SOURCE_DIR/bundle.msix"
+  echo "fake-deb" > "$SOURCE_DIR/app.deb"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" \
+    --artifact-glob '*.exe, *.msi, *.msix'
+
+  [ "$status" -eq 0 ]
+  grep -q "app.exe" "$TEST_TMPDIR/commands.log"
+  grep -q "setup.msi" "$TEST_TMPDIR/commands.log"
+  grep -q "bundle.msix" "$TEST_TMPDIR/commands.log"
+  ! grep -q "app.deb" "$TEST_TMPDIR/commands.log"
+}
+
 @test ".exe is signed with CodeSignTool" {
   echo "payload" > "$SOURCE_DIR/tool.exe"
 

--- a/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
+++ b/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
@@ -54,10 +54,10 @@ setup() {
   TARGET_DIR="$TEST_TMPDIR/target-$$-$BATS_TEST_NUMBER"
   mkdir -p "$SOURCE_DIR"
 
-  export ES_USERNAME="user@example.com"
-  export ES_PASSWORD="secret-pass"
-  export CREDENTIAL_ID="cred-uuid-test"
-  export ES_TOTP_SECRET="totp-secret-test"
+  export ES_OV_USERNAME="user@example.com"
+  export ES_OV_PASSWORD="secret-pass"
+  export ES_OV_CREDENTIAL_ID="cred-uuid-test"
+  export ES_OV_TOTP_SECRET="totp-secret-test"
   export CODESIGNTOOL="$MOCK_BIN/CodeSignTool.sh"
 }
 
@@ -88,12 +88,12 @@ setup() {
 }
 
 @test "entrypoint fails without eSigner secrets when not dry-run" {
-  unset ES_USERNAME
+  unset ES_OV_USERNAME
   touch "$SOURCE_DIR/app.exe"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"ES_USERNAME"* ]]
+  [[ "$output" == *"ES_OV_USERNAME"* ]]
 }
 
 # --- Full tree copy tests ---
@@ -212,7 +212,7 @@ setup() {
 }
 
 @test "dry-run does not require eSigner secrets" {
-  unset ES_USERNAME ES_PASSWORD CREDENTIAL_ID ES_TOTP_SECRET
+  unset ES_OV_USERNAME ES_OV_PASSWORD ES_OV_CREDENTIAL_ID ES_OV_TOTP_SECRET
   echo "x" > "$SOURCE_DIR/a.exe"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" --dry-run

--- a/.github/workflows/test_artifacts-cicd.yaml
+++ b/.github/workflows/test_artifacts-cicd.yaml
@@ -62,6 +62,9 @@ jobs:
       sign-mac: true
       mac-signing-identity: "Developer ID Application: Test (TESTID)"
       mac-installer-identity: "Developer ID Installer: Test (TESTID)"
+      sign-windows: true
+      win-artifact-glob: "*.exe"
+      win-runs-on: windows-2025
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}

--- a/.github/workflows/test_artifacts-cicd.yaml
+++ b/.github/workflows/test_artifacts-cicd.yaml
@@ -73,6 +73,10 @@ jobs:
       es-password: ${{ secrets.ES_PASSWORD }}
       credential_id: ${{ secrets.CREDENTIAL_ID }}
       es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+      es_ov_username: ${{ secrets.ES_OV_USERNAME }}
+      es_ov_password: ${{ secrets.ES_OV_PASSWORD }}
+      es_ov_credential_id: ${{ secrets.ES_OV_CREDENTIAL_ID }}
+      es_ov_totp_secret: ${{ secrets.ES_OV_TOTP_SECRET }}
       apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
       apple-installer-cert: ${{ secrets.APPLE_INSTALLER_CERT }}
       apple-cert-password: ${{ secrets.APPLE_CERT_PASSWORD }}

--- a/.github/workflows/test_artifacts-cicd.yaml
+++ b/.github/workflows/test_artifacts-cicd.yaml
@@ -55,7 +55,7 @@ jobs:
             "distro":"win10",
             "arch":"x64",
             "runs-on":"ubuntu-latest",
-            "build-script":"mkdir -p packaged && for f in ci-win-upload-artifact.exe ci-win-upload-artifact.msi ci-win-upload-artifact.msix; do head -c 2048 /dev/zero > packaged/$f; done"
+            "build-script":"mkdir -p packaged && head -c 2048 /dev/zero > packaged/ci-win-upload-artifact.exe && head -c 2048 /dev/zero > packaged/ci-win-upload-artifact.msi && head -c 2048 /dev/zero > packaged/ci-win-upload-artifact.msix"
           }
         ]}
       dry-run: true

--- a/.github/workflows/test_artifacts-cicd.yaml
+++ b/.github/workflows/test_artifacts-cicd.yaml
@@ -50,6 +50,12 @@ jobs:
             "arch":"arm64",
             "runs-on":"macos-14",
             "build-script":"mkdir -p packaged && echo 'test-pkg-payload' > /tmp/test-binary && pkgbuild --root /tmp --identifier com.aerospike.test --version 1.0.0-test --install-location /usr/local/bin packaged/test-1.0.0-test-darwin-arm64.pkg"
+          },
+          {
+            "distro":"win10",
+            "arch":"x64",
+            "runs-on":"ubuntu-latest",
+            "build-script":"mkdir -p packaged && for f in ci-win-upload-artifact.exe ci-win-upload-artifact.msi ci-win-upload-artifact.msix; do head -c 2048 /dev/zero > packaged/$f; done"
           }
         ]}
       dry-run: true

--- a/.github/workflows/test_artifacts-cicd.yaml
+++ b/.github/workflows/test_artifacts-cicd.yaml
@@ -63,7 +63,7 @@ jobs:
       mac-signing-identity: "Developer ID Application: Test (TESTID)"
       mac-installer-identity: "Developer ID Installer: Test (TESTID)"
       sign-windows: true
-      win-artifact-glob: "*.exe"
+      win-artifact-glob: "*.exe,*.msi,*.msix"
       win-runs-on: windows-2025
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}

--- a/.github/workflows/test_sign-win-artifacts-smoke.yaml
+++ b/.github/workflows/test_sign-win-artifacts-smoke.yaml
@@ -1,0 +1,80 @@
+name: "Smoke Test: Sign Windows Artifacts (Manual)"
+
+# End-to-end smoke test for Windows Authenticode with real SSL.com eSigner secrets.
+# Requires repository secrets (same as NuGet signing in reusable_sign-artifacts):
+#   ES_USERNAME, ES_PASSWORD, CREDENTIAL_ID, ES_TOTP_SECRET
+#
+# Optional repository variable:
+#   WIN_SIGNING_PROGRAM_NAME — passed to sign-win-artifacts signing-identity (MSI display name)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  create-test-binaries:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Create minimal unsigned Windows binaries
+        env:
+          TEST_VERSION: 0.0.0-smoke
+        run: |
+          set -euo pipefail
+          mkdir -p test-artifacts
+          head -c 2048 /dev/zero > "test-artifacts/smoke-win-${TEST_VERSION}.exe"
+          head -c 2048 /dev/zero > "test-artifacts/smoke-win-${TEST_VERSION}.msi"
+
+      - name: Upload unsigned artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-artifacts
+          path: test-artifacts
+
+  sign-win:
+    needs: create-test-binaries
+    uses: ./.github/workflows/reusable_sign-win-artifacts.yaml
+    with:
+      gh-unsigned-artifacts: build-artifacts
+      gh-workflows-ref: ${{ github.sha }}
+      signing-identity: ${{ vars.WIN_SIGNING_PROGRAM_NAME }}
+      artifact-glob: "*.exe"
+      dry-run: false
+      runs-on: windows-2025
+    secrets:
+      es-username: ${{ secrets.ES_USERNAME }}
+      es-password: ${{ secrets.ES_PASSWORD }}
+      credential_id: ${{ secrets.CREDENTIAL_ID }}
+      es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+
+  verify:
+    needs: sign-win
+    runs-on: windows-2025
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Download signed artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-artifacts
+          path: signed
+
+      - name: Verify Authenticode signature on .exe
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $exe = Get-ChildItem -Path signed -Recurse -Filter 'smoke-win-*.exe' | Select-Object -First 1
+          if (-not $exe) { throw "Signed .exe not found under signed/" }
+          $sig = Get-AuthenticodeSignature -FilePath $exe.FullName
+          Write-Host "Signature status: $($sig.Status) - $($exe.FullName)"
+          if ($sig.Status -eq 'NotSigned') { throw "File is not signed" }

--- a/.github/workflows/test_sign-win-artifacts-smoke.yaml
+++ b/.github/workflows/test_sign-win-artifacts-smoke.yaml
@@ -45,7 +45,7 @@ jobs:
       gh-unsigned-artifacts: build-artifacts
       gh-workflows-ref: ${{ github.sha }}
       signing-identity: ${{ vars.WIN_SIGNING_PROGRAM_NAME }}
-      artifact-glob: "*.exe"
+      artifact-glob: "*.exe,*.msi"
       dry-run: false
       runs-on: windows-2025
     secrets:

--- a/.github/workflows/test_sign-win-artifacts-smoke.yaml
+++ b/.github/workflows/test_sign-win-artifacts-smoke.yaml
@@ -2,7 +2,7 @@ name: "Smoke Test: Sign Windows Artifacts (Manual)"
 
 # End-to-end smoke test for Windows Authenticode with real SSL.com eSigner secrets.
 # Requires repository secrets (same as NuGet signing in reusable_sign-artifacts):
-#   ES_USERNAME, ES_PASSWORD, CREDENTIAL_ID, ES_TOTP_SECRET
+#   ES_OV_USERNAME, ES_OV_PASSWORD, ES_CREDENTIAL_OV_ID, ES_TOTP_OV_SECRET
 #
 # Optional repository variable:
 #   WIN_SIGNING_PROGRAM_NAME — passed to sign-win-artifacts signing-identity (MSI display name)
@@ -49,10 +49,10 @@ jobs:
       dry-run: false
       runs-on: windows-2025
     secrets:
-      es-username: ${{ secrets.ES_USERNAME }}
-      es-password: ${{ secrets.ES_PASSWORD }}
-      credential_id: ${{ secrets.CREDENTIAL_ID }}
-      es-totp_secret: ${{ secrets.ES_TOTP_SECRET }}
+      es_ov_username: ${{ secrets.ES_OV_USERNAME }}
+      es_ov_password: ${{ secrets.ES_OV_PASSWORD }}
+      es_credential_ov_id: ${{ secrets.ES_CREDENTIAL_OV_ID }}
+      es_totp_ov_secret: ${{ secrets.ES_OV_TOTP_SECRET }}
 
   verify:
     needs: sign-win

--- a/.github/workflows/test_sign-win-artifacts-smoke.yaml
+++ b/.github/workflows/test_sign-win-artifacts-smoke.yaml
@@ -1,8 +1,8 @@
 name: "Smoke Test: Sign Windows Artifacts (Manual)"
 
 # End-to-end smoke test for Windows Authenticode with real SSL.com eSigner secrets.
-# Requires repository secrets (same as NuGet signing in reusable_sign-artifacts):
-#   ES_OV_USERNAME, ES_OV_PASSWORD, ES_CREDENTIAL_OV_ID, ES_TOTP_OV_SECRET
+# Requires repository secrets for Windows OV signing:
+#   ES_OV_USERNAME, ES_OV_PASSWORD, ES_OV_CREDENTIAL_ID, ES_OV_TOTP_SECRET
 #
 # Optional repository variable:
 #   WIN_SIGNING_PROGRAM_NAME — passed to sign-win-artifacts signing-identity (MSI display name)
@@ -51,8 +51,8 @@ jobs:
     secrets:
       es_ov_username: ${{ secrets.ES_OV_USERNAME }}
       es_ov_password: ${{ secrets.ES_OV_PASSWORD }}
-      es_credential_ov_id: ${{ secrets.ES_CREDENTIAL_OV_ID }}
-      es_totp_ov_secret: ${{ secrets.ES_OV_TOTP_SECRET }}
+      es_ov_credential_id: ${{ secrets.ES_OV_CREDENTIAL_ID }}
+      es_ov_totp_secret: ${{ secrets.ES_OV_TOTP_SECRET }}
 
   verify:
     needs: sign-win

--- a/.github/workflows/test_sign-win-artifacts-workflow.yaml
+++ b/.github/workflows/test_sign-win-artifacts-workflow.yaml
@@ -1,0 +1,96 @@
+name: Test Sign Windows Artifacts Workflow
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/reusable_sign-win-artifacts.yaml
+      - .github/workflows/sign-win-artifacts/**
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  upload-test-fixtures:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Create test fixtures
+        run: |
+          mkdir -p test-fixtures
+          echo "fake-exe-data" > test-fixtures/myapp.exe
+          echo "fake-msi-data" > test-fixtures/myapp.msi
+          echo "fake-msix-data" > test-fixtures/myapp.msix
+          echo "fake-deb-data" > test-fixtures/myapp_amd64.deb
+
+      - name: Upload test fixtures
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-artifacts
+          path: test-fixtures
+
+  # Exercises reusable_sign-win-artifacts on windows-2025 (default runs-on) with dry-run
+  test-sign-win-dry-run:
+    if: github.actor != 'dependabot[bot]'
+    needs: upload-test-fixtures
+    uses: ./.github/workflows/reusable_sign-win-artifacts.yaml
+    with:
+      gh-unsigned-artifacts: build-artifacts
+      gh-workflows-ref: ${{ github.sha }}
+      signing-identity: Test Product
+      dry-run: true
+
+  verify-artifacts-preserved:
+    if: github.actor != 'dependabot[bot]'
+    needs: test-sign-win-dry-run
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-artifacts
+          path: output
+
+      - name: Verify all files preserved
+        run: |
+          set -euo pipefail
+          ls -laR output/
+          for f in myapp.exe myapp.msi myapp.msix myapp_amd64.deb; do
+            if [ ! -f "output/$f" ]; then
+              echo "FAIL: Missing file: $f"
+              exit 1
+            fi
+            echo "OK: $f"
+          done
+
+  run-bats-tests:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Bats
+        run: |
+          sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Run Bats tests
+        run: |
+          bats .github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats

--- a/.github/workflows/test_sign-win-artifacts-workflow.yaml
+++ b/.github/workflows/test_sign-win-artifacts-workflow.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - .github/workflows/reusable_artifacts-cicd.yaml
       - .github/workflows/reusable_sign-win-artifacts.yaml
       - .github/workflows/sign-win-artifacts/**
 

--- a/fakesecrets.env
+++ b/fakesecrets.env
@@ -79,3 +79,9 @@ CREDENTIAL_ID=fe537ace-e132-52a9-c2e7-egcd2ac3f1e6
 ES_PASSWORD=P0z9@lxo41
 ES_TOTP_SECRET=ii5gVvZ9G+WkxB3FauAnoL/z14AXSMistcE0jZMWWNSjQDlql2kt2D6Z+l8=
 ES_USERNAME=john.doe@example.com
+
+# Windows Authenticode (OV) — same sample values as NuGet eSigner above
+ES_OV_CREDENTIAL_ID=fe537ace-e132-52a9-c2e7-egcd2ac3f1e6
+ES_OV_PASSWORD=P0z9@lxo41
+ES_OV_TOTP_SECRET=ii5gVvZ9G+WkxB3FauAnoL/z14AXSMistcE0jZMWWNSjQDlql2kt2D6Z+l8=
+ES_OV_USERNAME=john.doe@example.com


### PR DESCRIPTION
- Added windows signing workflow based on Mac signing structure
- Added '--extensions' option that takes multiple extensions for the same type of artifacts
- Added 'win' registry type similar to generic
- Added tests and workflows similar to Mac signing along with test workflows
- Added option to use glob with multiple extensions as well as all
- Included isolation of windows artifacts from NuGet signing.
- New eSigner credentials and ssl.com related account data for signing windows related artifacts.