### PR TITLE
fix(jf-upload): [INFRA-502] Wrap jf_upload with run and update related

### DIFF
--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -118,14 +118,8 @@ fi
 
 ARTIFACT_BUILD_NUMBER="$BUILD_NUMBER-artifacts"
 
-# Source utilities
+# Source utilities (run must exist before upload_utils.sh — it wraps jf_upload for dry-run)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/package_utils.sh"
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/type_registry.sh"
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/upload_utils.sh"
 
 # Wrapper function that either executes or echoes commands
 run() {
@@ -133,6 +127,24 @@ run() {
         # Define color variables
         local green='\033[0;32m'
         local reset='\033[0m'
+
+        # run jf_upload … prints jf_upload to stderr; tests and parse_jf_upload_command expect
+        # the real CLI line (same as jf_upload invokes in non-dry-run).
+        if [[ ${1-} == jf_upload ]]; then
+            shift
+            local file="$1" repo="$2"
+            shift 2
+            {
+                printf '%s' "$green   "
+                printf '%q ' jf rt upload "$file" "$repo" --flat=false \
+                    "--build-name=$BUILD_NAME" \
+                    "--build-number=$ARTIFACT_BUILD_NUMBER" \
+                    "--project=$PROJECT"
+                (($# > 0)) && printf '%q ' "$@"
+                printf '%s\n' "$reset"
+            } >&2
+            return 0
+        fi
 
         echo -e "${green}   $*${reset}" >&2
     else
@@ -143,6 +155,13 @@ run() {
 run_optional() {
     run "$@" || echo "Warning: $*" >&2
 }
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/package_utils.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/type_registry.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/upload_utils.sh"
 
 structure_standalone_poms() {
     while IFS= read -r -d '' pom; do
@@ -335,7 +354,7 @@ upload_jar_packages() {
                         --target-props "$props"
                     ;;
                 *)
-                    jf_upload "$artifact_file" "$PROJECT-maven-dev-local" \
+                    run jf_upload "$artifact_file" "$PROJECT-maven-dev-local" \
                         --target-props "$props"
                     ;;
                 esac

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -118,38 +118,24 @@ fi
 
 ARTIFACT_BUILD_NUMBER="$BUILD_NUMBER-artifacts"
 
-# Source utilities (run must exist before upload_utils.sh — it wraps jf_upload for dry-run)
+# Source utilities (run must exist before upload_utils.sh)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Wrapper function that either executes or echoes commands
+# Wrapper: execute, or in dry-run log what would run (`Would run: …`). jf_upload is a
+# shell function, so dry-run must invoke it (jf_upload prints the same prefix + `jf rt upload …`);
+# printing "$*" would only show `jf_upload …`.
 run() {
-    if [[ $DRY_RUN == "true" ]]; then
-        # Define color variables
-        local green='\033[0;32m'
-        local reset='\033[0m'
-
-        # run jf_upload … prints jf_upload to stderr; tests and parse_jf_upload_command expect
-        # the real CLI line (same as jf_upload invokes in non-dry-run).
-        if [[ ${1-} == jf_upload ]]; then
-            shift
-            local file="$1" repo="$2"
-            shift 2
-            {
-                printf '%s' "$green   "
-                printf '%q ' jf rt upload "$file" "$repo" --flat=false \
-                    "--build-name=$BUILD_NAME" \
-                    "--build-number=$ARTIFACT_BUILD_NUMBER" \
-                    "--project=$PROJECT"
-                (($# > 0)) && printf '%q ' "$@"
-                printf '%s\n' "$reset"
-            } >&2
-            return 0
-        fi
-
-        echo -e "${green}   $*${reset}" >&2
-    else
+    if [[ $DRY_RUN != "true" ]]; then
         "$@"
+        return
     fi
+    # jf_upload is a shell function, so dry-run must invoke it (jf_upload prints the same prefix + `jf rt upload …`);
+    # printing "$*" would only show `jf_upload …`.
+    if [[ ${1-} == jf_upload ]]; then
+        "$@"
+        return
+    fi
+    printf 'Would run: %s\n' "$*" >&2
 }
 
 run_optional() {

--- a/.github/workflows/deploy-artifacts/tests/bats/test_bug_regressions.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_bug_regressions.bats
@@ -24,7 +24,7 @@ teardown() {
 
     # Extract only actual upload commands (strip ANSI codes)
     local upload_cmds
-    upload_cmds=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g' | grep -E "^\s*jf rt upload" || true)
+    upload_cmds=$(echo "$output" | sed 's/\x1b\[[0-9;]*m//g' | grep -E "jf rt upload" || true)
 
     # Find all .asc files in the fixture directory.
     # Exclude .md5.asc/.sha1.asc: Maven Central convention is that checksums

--- a/.github/workflows/deploy-artifacts/tests/bats/test_java_upload.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_java_upload.bats
@@ -318,3 +318,11 @@ teardown_file() {
   done
 }
 
+@test "parse_jf_upload_command tolerates ANSI and leading spaces before jf rt upload" {
+  local cmd parse_output
+  cmd=$'\033[0;32m   jf rt upload ./pkg.deb myrepo --flat=false --build-name=b --build-number=1-artifacts --project=p'
+  parse_output=$(parse_jf_upload_command "$cmd")
+  echo "$parse_output" | grep -q '^file_path=./pkg.deb$'
+  echo "$parse_output" | grep -q '^repo=myrepo$'
+}
+

--- a/.github/workflows/deploy-artifacts/tests/helpers/command_parsers.bash
+++ b/.github/workflows/deploy-artifacts/tests/helpers/command_parsers.bash
@@ -264,6 +264,7 @@ extract_nuget_commands() {
 # Returns: array of commands (one per line)
 extract_build_commands() {
         local output="$1"
-        # Strip ANSI color codes and extract commands with leading spaces
-        echo "$output" | sed 's/\x1b\[[0-9;]*m//g' | grep -E "^\s+jf rt build-" | sed 's/^\s*//'
+        # Strip ANSI; match build lines (dry-run prefixes with "Would run: ")
+        echo "$output" | sed 's/\x1b\[[0-9;]*m//g' | grep -E "jf rt build-" |
+                sed -e 's/^Would run: //' -e 's/^[[:space:]]*//'
 }

--- a/.github/workflows/deploy-artifacts/tests/helpers/command_parsers.bash
+++ b/.github/workflows/deploy-artifacts/tests/helpers/command_parsers.bash
@@ -6,6 +6,16 @@
 # Returns: associative array with keys: file_path, repo, build_name, build_number, project, target_props, deb_path, flat
 parse_jf_upload_command() {
         local cmd="$1"
+        # Normalize: strip ANSI, trim whitespace, isolate "jf rt upload ..." if prefixed (dry-run / log lines)
+        cmd=$(printf '%s' "$cmd" | LC_ALL=C sed 's/\x1b\[[0-9;]*m//g')
+        cmd="${cmd#"${cmd%%[![:space:]]*}"}"
+        cmd="${cmd%"${cmd##*[![:space:]]}"}"
+        if [[ $cmd != jf[[:space:]]* ]]; then
+                if [[ $cmd =~ (jf[[:space:]]+rt[[:space:]]+upload[[:space:]].*) ]]; then
+                        cmd="${BASH_REMATCH[1]}"
+                fi
+        fi
+
         local -A result=()
 
         # Extract file path (first argument after "jf rt upload")
@@ -214,8 +224,20 @@ parse_nuget_setapikey_command() {
 # Returns: array of commands (one per line)
 extract_upload_commands() {
         local output="$1"
-        # Strip ANSI color codes and extract commands with leading spaces
-        echo "$output" | sed 's/\x1b\[[0-9;]*m//g' | grep -E "^\s+(jf rt upload|jf nuget push)" | sed 's/^\s*//'
+        local line stripped
+        while IFS= read -r line || [[ -n $line ]]; do
+                [[ -z $line ]] && continue
+                stripped=$(printf '%s' "$line" | LC_ALL=C sed 's/\x1b\[[0-9;]*m//g')
+                if [[ $stripped =~ jf[[:space:]]+rt[[:space:]]+upload ]]; then
+                        if [[ $stripped =~ (jf[[:space:]]+rt[[:space:]]+upload[[:space:]].*) ]]; then
+                                echo "${BASH_REMATCH[1]}"
+                        fi
+                elif [[ $stripped =~ jf[[:space:]]+nuget[[:space:]]+push ]]; then
+                        if [[ $stripped =~ (jf[[:space:]]+nuget[[:space:]]+push[[:space:]].*) ]]; then
+                                echo "${BASH_REMATCH[1]}"
+                        fi
+                fi
+        done < <(printf '%s\n' "$output")
 }
 
 # Extract all nuget upload commands from output
@@ -223,8 +245,18 @@ extract_upload_commands() {
 # Returns: array of commands (one per line)
 extract_nuget_commands() {
         local output="$1"
-        # Strip ANSI color codes and extract jf rt upload commands targeting nuget repositories
-        echo "$output" | sed 's/\x1b\[[0-9;]*m//g' | grep -E "^\s+jf rt upload.*\.(nupkg|snupkg).*-nuget-dev-local" | sed 's/^\s*//'
+        local line stripped
+        while IFS= read -r line || [[ -n $line ]]; do
+                [[ -z $line ]] && continue
+                stripped=$(printf '%s' "$line" | LC_ALL=C sed 's/\x1b\[[0-9;]*m//g')
+                if [[ $stripped =~ jf[[:space:]]+rt[[:space:]]+upload ]] &&
+                        [[ $stripped =~ \.(nupkg|snupkg) ]] &&
+                        [[ $stripped =~ -nuget-dev-local ]]; then
+                        if [[ $stripped =~ (jf[[:space:]]+rt[[:space:]]+upload[[:space:]].*) ]]; then
+                                echo "${BASH_REMATCH[1]}"
+                        fi
+                fi
+        done < <(printf '%s\n' "$output")
 }
 
 # Extract all jf rt build-* commands from output

--- a/.github/workflows/deploy-artifacts/upload_utils.sh
+++ b/.github/workflows/deploy-artifacts/upload_utils.sh
@@ -3,7 +3,8 @@
 #
 # Required globals (set by entrypoint.sh before sourcing):
 #   BUILD_NAME, ARTIFACT_BUILD_NUMBER, PROJECT, DRY_RUN
-#   run() function must be defined
+#   run() must be defined before this file is sourced (entrypoint defines it first).
+#   Call jf_upload only as: run jf_upload <file> <repo> [extra-flags...] so dry-run skips real uploads.
 #   TYPE_EXTENSIONS, TYPE_COMPANIONS, TYPE_REPO, TYPE_STRUCT_DIR arrays from type_registry.sh
 
 # --- Manifest helpers ---
@@ -51,13 +52,14 @@ manifest_for_type() {
 # --- Upload helpers ---
 
 # Wraps `jf rt upload` with the standard flags that every upload needs.
-# Usage: jf_upload <file> <repo> [extra-flags...]
+# Usage: run jf_upload <file> <repo> [extra-flags...]
 # Automatically adds: --flat=false --build-name --build-number --project
+# Must be invoked through run() so --dry-run does not call the real CLI.
 jf_upload() {
     local file="$1"
     local repo="$2"
     shift 2
-    run jf rt upload "$file" "$repo" --flat=false \
+    jf rt upload "$file" "$repo" --flat=false \
         --build-name="$BUILD_NAME" \
         --build-number="$ARTIFACT_BUILD_NUMBER" \
         --project="$PROJECT" \
@@ -76,7 +78,7 @@ upload_companions() {
     for suffix in $companions; do
         if [[ -f "$file$suffix" ]]; then
             echo "  Uploading companion: $file$suffix" >&2
-            jf_upload "$file$suffix" "$repo"
+            run jf_upload "$file$suffix" "$repo"
         fi
     done
 }
@@ -174,7 +176,7 @@ upload_type() {
             extra_flags+=("${ef[@]}")
         fi
 
-        jf_upload "$file" "$repo" "${extra_flags[@]}"
+        run jf_upload "$file" "$repo" "${extra_flags[@]}"
         upload_companions "$file" "$repo" "$type"
     }
 

--- a/.github/workflows/deploy-artifacts/upload_utils.sh
+++ b/.github/workflows/deploy-artifacts/upload_utils.sh
@@ -4,7 +4,8 @@
 # Required globals (set by entrypoint.sh before sourcing):
 #   BUILD_NAME, ARTIFACT_BUILD_NUMBER, PROJECT, DRY_RUN
 #   run() must be defined before this file is sourced (entrypoint defines it first).
-#   Call jf_upload only as: run jf_upload <file> <repo> [extra-flags...] so dry-run skips real uploads.
+#   Call jf_upload only as: run jf_upload <file> <repo> [extra-flags...] so dry-run invokes
+#   jf_upload (which logs the real `jf rt upload …` line) instead of calling jf.
 #   TYPE_EXTENSIONS, TYPE_COMPANIONS, TYPE_REPO, TYPE_STRUCT_DIR arrays from type_registry.sh
 
 # --- Manifest helpers ---
@@ -54,11 +55,24 @@ manifest_for_type() {
 # Wraps `jf rt upload` with the standard flags that every upload needs.
 # Usage: run jf_upload <file> <repo> [extra-flags...]
 # Automatically adds: --flat=false --build-name --build-number --project
-# Must be invoked through run() so --dry-run does not call the real CLI.
+# Must be invoked through run() so dry-run dispatches here instead of echoing `jf_upload …`.
 jf_upload() {
     local file="$1"
     local repo="$2"
     shift 2
+    if [[ ${DRY_RUN-} == "true" ]]; then
+        # Use %s (not %q): %q escapes semicolons in --target-props and breaks bats parsers.
+        {
+            printf 'Would run: '
+            printf '%s ' jf rt upload "$file" "$repo" --flat=false \
+                "--build-name=$BUILD_NAME" \
+                "--build-number=$ARTIFACT_BUILD_NUMBER" \
+                "--project=$PROJECT"
+            (($# > 0)) && printf '%s ' "$@"
+            printf '\n'
+        } >&2
+        return 0
+    fi
     jf rt upload "$file" "$repo" --flat=false \
         --build-name="$BUILD_NAME" \
         --build-number="$ARTIFACT_BUILD_NUMBER" \


### PR DESCRIPTION
- moved run() before sourcing upload_utils.sh
- added a dry-run branch in run() for jf_upload so echoed lines remain jf rt upload ...
- make jf_upload perform the real jf rt upload (no inner run)
- updated call sites to run jf_upload
- hardening parse_jf_upload_command and extract_upload_commands / extract_nuget_commands