### PR TITLE
feat(setup-aerospike-server): [CLIENT-4668] support community edition servers

### DIFF
--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -79,7 +79,7 @@ A features file with `asdb-cluster-nodes-limit 0` is required for Enterprise clu
 
 ### Community edition
 
-Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config and ignore `features-file` / `features-content`.
+Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config, remove that directive from custom configs, and ignore `features-file` / `features-content`.
 
 With `server-edition: auto`, the action infers `enterprise` from repositories named `aerospike-server-enterprise` and `community` from repositories named `aerospike-server`. If you use a mirror or custom repository name, set `server-edition` explicitly.
 

--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -93,32 +93,32 @@ With `server-edition: auto`, the action infers `enterprise` from repositories na
 
 ## Inputs
 
-| Input                          | Required | Default                                                 | Description                                                                                 |
-| ------------------------------ | -------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `oidc-provider`                | Yes      |                                                         | JFrog OIDC provider name                                                                    |
-| `oidc-audience`                | Yes      |                                                         | JFrog OIDC audience                                                                         |
-| `server-tag`                   | No       | `latest`                                                | Aerospike Server Docker image tag                                                           |
-| `num-nodes`                    | No       | `1`                                                     | Number of cluster nodes                                                                     |
-| `container-name-prefix`        | No       | `aerospike`                                             | Container name prefix (nodes: `prefix-1`, `prefix-2`, ...)                                  |
-| `features-file`                | No       |                                                         | Path to `features.conf` on the runner                                                       |
-| `features-content`             | No       |                                                         | Raw `features.conf` content (e.g., from a secret). Ignored if `features-file` is set        |
-| `config-file`                  | No       |                                                         | Path to `aerospike.conf` on the runner                                                      |
-| `config-content`               | No       |                                                         | Raw `aerospike.conf` content. Ignored if `config-file` is set                               |
-| `env-vars`                     | No       |                                                         | Semicolon-delimited `KEY=VALUE` pairs passed as `-e` flags. Use `\;` for literal semicolons |
-| `network-name`                 | No       | `aerospike-net`                                         | Docker network name                                                                         |
-| `base-port`                    | No       | `3000`                                                  | Base host port (node N maps to `base-port + N - 1`)                                         |
-| `service-port`                 | No       | `3000`                                                  | Aerospike service port inside the container (must match `aerospike.conf`)                   |
-| `startup-timeout`              | No       | `30`                                                    | Seconds to wait for node readiness and cluster formation                                    |
-| `enable-tls`                   | No       | `false`                                                 | Enable TLS on Aerospike Server containers                                                   |
-| `tls-base-port`                | No       | `4333`                                                  | Base host TLS port (node N maps to `tls-base-port + N - 1`)                                 |
-| `enable-security`              | No       | `false`                                                 | Enable Aerospike security (authentication with default admin/admin credentials)             |
-| `enable-strong-consistency`    | No       | `false`                                                 | Enable strong consistency on the `test` namespace. Requires a features file                 |
-| `sc-stability-timeout-seconds` | No       | `30`                                                    | Seconds to wait for SC cluster stability after roster setup                                 |
-| `tools-tag`                    | No       | `12.1.1_2`                                              | Aerospike tools Docker image tag                                                            |
-| `container-repo-url`           | No       | `aerospike.jfrog.io`                                    | Docker registry hostname                                                                    |
-| `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise`   | Image repository path                                                                       |
-| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`; set explicitly for custom repo names  |
-| `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                            | JFrog platform URL                                                                          |
+| Input                          | Required | Default                                               | Description                                                                                 |
+| ------------------------------ | -------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `oidc-provider`                | Yes      |                                                       | JFrog OIDC provider name                                                                    |
+| `oidc-audience`                | Yes      |                                                       | JFrog OIDC audience                                                                         |
+| `server-tag`                   | No       | `latest`                                              | Aerospike Server Docker image tag                                                           |
+| `num-nodes`                    | No       | `1`                                                   | Number of cluster nodes                                                                     |
+| `container-name-prefix`        | No       | `aerospike`                                           | Container name prefix (nodes: `prefix-1`, `prefix-2`, ...)                                  |
+| `features-file`                | No       |                                                       | Path to `features.conf` on the runner                                                       |
+| `features-content`             | No       |                                                       | Raw `features.conf` content (e.g., from a secret). Ignored if `features-file` is set        |
+| `config-file`                  | No       |                                                       | Path to `aerospike.conf` on the runner                                                      |
+| `config-content`               | No       |                                                       | Raw `aerospike.conf` content. Ignored if `config-file` is set                               |
+| `env-vars`                     | No       |                                                       | Semicolon-delimited `KEY=VALUE` pairs passed as `-e` flags. Use `\;` for literal semicolons |
+| `network-name`                 | No       | `aerospike-net`                                       | Docker network name                                                                         |
+| `base-port`                    | No       | `3000`                                                | Base host port (node N maps to `base-port + N - 1`)                                         |
+| `service-port`                 | No       | `3000`                                                | Aerospike service port inside the container (must match `aerospike.conf`)                   |
+| `startup-timeout`              | No       | `30`                                                  | Seconds to wait for node readiness and cluster formation                                    |
+| `enable-tls`                   | No       | `false`                                               | Enable TLS on Aerospike Server containers                                                   |
+| `tls-base-port`                | No       | `4333`                                                | Base host TLS port (node N maps to `tls-base-port + N - 1`)                                 |
+| `enable-security`              | No       | `false`                                               | Enable Aerospike security (authentication with default admin/admin credentials)             |
+| `enable-strong-consistency`    | No       | `false`                                               | Enable strong consistency on the `test` namespace. Requires a features file                 |
+| `sc-stability-timeout-seconds` | No       | `30`                                                  | Seconds to wait for SC cluster stability after roster setup                                 |
+| `tools-tag`                    | No       | `12.1.1_2`                                            | Aerospike tools Docker image tag                                                            |
+| `container-repo-url`           | No       | `aerospike.jfrog.io`                                  | Docker registry hostname                                                                    |
+| `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise` | Image repository path                                                                       |
+| `server-edition`               | No       | `auto`                                                | Server edition: `auto`, `enterprise`, or `community`; set explicitly for custom repo names  |
+| `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                          | JFrog platform URL                                                                          |
 
 ## Outputs
 

--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -1,11 +1,11 @@
-# Setup Aerospike Enterprise Server
+# Setup Aerospike Server
 
-GitHub Action that starts one or more Aerospike Enterprise Server containers with optional clustering, TLS, security, strong consistency, and custom configuration.
+GitHub Action that starts one or more Aerospike Server containers with optional clustering, TLS, security, strong consistency, and custom configuration.
 
 ## Prerequisites
 
 - JFrog OIDC credentials (`oidc-provider` and `oidc-audience`) for pulling the Aerospike Server Docker image
-- A valid `features.conf` for enterprise features (e.g., multi-node clustering requires `asdb-cluster-nodes-limit 0`)
+- A valid `features.conf` for Enterprise-only features (e.g., Enterprise multi-node clustering requires `asdb-cluster-nodes-limit 0`)
 
 ## Quick Start
 
@@ -20,7 +20,7 @@ GitHub Action that starts one or more Aerospike Enterprise Server containers wit
 
 ### Multi-node cluster
 
-A features file with `asdb-cluster-nodes-limit 0` is required for clustering.
+A features file with `asdb-cluster-nodes-limit 0` is required for Enterprise clustering.
 
 ```yaml
 - uses: ./.github/actions/setup-aerospike-server
@@ -77,6 +77,18 @@ A features file with `asdb-cluster-nodes-limit 0` is required for clustering.
     oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
 ```
 
+### Community edition
+
+Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config and ignore `features-file` / `features-content`.
+
+```yaml
+- uses: ./.github/actions/setup-aerospike-server
+  with:
+    server-container-repo: database-docker-virtual/aerospike-server
+    oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+    oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+```
+
 ## Inputs
 
 | Input                          | Required | Default                                                 | Description                                                                                 |
@@ -102,7 +114,8 @@ A features file with `asdb-cluster-nodes-limit 0` is required for clustering.
 | `sc-stability-timeout-seconds` | No       | `30`                                                    | Seconds to wait for SC cluster stability after roster setup                                 |
 | `tools-tag`                    | No       | `12.1.1_2`                                              | Aerospike tools Docker image tag                                                            |
 | `container-repo-url`           | No       | `aerospike.jfrog.io`                                    | Docker registry hostname                                                                    |
-| `server-container-repo`        | No       | `database-docker-dev-local/aerospike-server-enterprise` | Image repository path                                                                       |
+| `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise`   | Image repository path                                                                       |
+| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`                                        |
 | `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                            | JFrog platform URL                                                                          |
 
 ## Outputs
@@ -124,6 +137,8 @@ For clusters (`num-nodes > 1`), the action:
 - Waits for all nodes to be ready, the cluster to form, and migrations to complete
 
 If you provide a custom config via `config-file` or `config-content`, it must include a `heartbeat` section with `mode mesh`. The action will inject `mesh-seed-address-port` entries automatically.
+
+For `server-edition: enterprise`, the action requires `features-file` or `features-content` for multi-node clusters. For `server-edition: community`, it does not render or mount a features file because `feature-key-file` is Enterprise-only.
 
 ## TLS
 

--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -81,6 +81,8 @@ A features file with `asdb-cluster-nodes-limit 0` is required for Enterprise clu
 
 Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config and ignore `features-file` / `features-content`.
 
+With `server-edition: auto`, the action infers `enterprise` from repositories named `aerospike-server-enterprise` and `community` from repositories named `aerospike-server`. If you use a mirror or custom repository name, set `server-edition` explicitly.
+
 ```yaml
 - uses: ./.github/actions/setup-aerospike-server
   with:
@@ -115,7 +117,7 @@ Set `server-container-repo` to the Community image repository. The action will o
 | `tools-tag`                    | No       | `12.1.1_2`                                              | Aerospike tools Docker image tag                                                            |
 | `container-repo-url`           | No       | `aerospike.jfrog.io`                                    | Docker registry hostname                                                                    |
 | `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise`   | Image repository path                                                                       |
-| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`                                        |
+| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`; set explicitly for custom repo names  |
 | `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                            | JFrog platform URL                                                                          |
 
 ## Outputs

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -145,7 +145,7 @@ runs:
 
         effective_security="${{ inputs.enable-security }}"
         server_edition=$(resolve_server_edition "${{ inputs.server-edition }}" "${{ inputs.server-container-repo }}") \
-          || error "server-edition must be one of: auto, enterprise, community"
+          || error "server-edition must be one of: auto, enterprise, community; use enterprise or community when auto cannot infer from server-container-repo"
 
         if [[ "${{ inputs.num-nodes }}" -gt 1 && "$server_edition" == "enterprise" ]]; then
           [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
@@ -271,18 +271,22 @@ runs:
           export NAMESPACE=$("$render_tpl" "$tpl_dir/namespace-memory.conf")
         fi
 
-        # Write features-content to temp file if no file path was given
-        if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
-          features_path="$(mktemp)"
-          printf '%s' "${FEATURES_CONTENT}" > "$features_path"
-          echo "Wrote features-content to $features_path"
-        fi
-
-        if ! should_use_features_file "$server_edition" "$features_path"; then
-          if [[ -n "$features_path" ]]; then
+        if [[ "$server_edition" == "community" ]]; then
+          if [[ -n "$features_path" || -n "${FEATURES_CONTENT}" ]]; then
             echo "::notice::Ignoring features-file/features-content for Aerospike Server Community"
           fi
           features_path=""
+        else
+          # Write features-content to temp file only when the edition can use it.
+          if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
+            features_path="$(mktemp)"
+            printf '%s' "${FEATURES_CONTENT}" > "$features_path"
+            echo "Wrote features-content to $features_path"
+          fi
+
+          if ! should_use_features_file "$server_edition" "$features_path"; then
+            features_path=""
+          fi
         fi
 
         # Write config-content to temp file if no file path was given

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -1,6 +1,6 @@
-name: Setup Aerospike Server Enterprise
+name: Setup Aerospike Server
 description: >
-  Starts one or more Aerospike Server Enterprise containers, optionally forming
+  Starts one or more Aerospike Server containers, optionally forming
   a cluster, with support for custom config, feature files, and environment
   variable passthrough.
 
@@ -45,6 +45,10 @@ inputs:
     description: Image repository path within the registry
     required: false
     default: database-docker-virtual/aerospike-server-enterprise
+  server-edition:
+    description: Server edition. Use auto to infer from server-container-repo.
+    required: false
+    default: auto
   jfrog-platform-url:
     description: JFrog platform URL
     required: false
@@ -120,6 +124,9 @@ runs:
       id: validate
       shell: bash
       run: |
+        # shellcheck source=/dev/null
+        source "${{ github.action_path }}/config-helpers.sh"
+
         error() { echo "Error: $1" >&2; exit 1; }
 
         [[ "${{ inputs.num-nodes }}" =~ ^[1-9][0-9]*$ ]] \
@@ -131,24 +138,29 @@ runs:
         [[ "${{ inputs.service-port }}" =~ ^[1-9][0-9]*$ ]] \
           || error "service-port must be a positive integer (got: '${{ inputs.service-port }}')"
 
-        if [[ "${{ inputs.num-nodes }}" -gt 1 ]]; then
-          [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
-            || error "features-file or features-content is required for multi-node clusters (asdb-cluster-nodes-limit 0 must be set)"
-        fi
-
         if [[ "${{ inputs.enable-tls }}" == "true" ]]; then
           [[ "${{ inputs.tls-base-port }}" =~ ^[1-9][0-9]*$ ]] \
             || error "tls-base-port must be a positive integer (got: '${{ inputs.tls-base-port }}')"
         fi
 
         effective_security="${{ inputs.enable-security }}"
+        server_edition=$(resolve_server_edition "${{ inputs.server-edition }}" "${{ inputs.server-container-repo }}") \
+          || error "server-edition must be one of: auto, enterprise, community"
+
+        if [[ "${{ inputs.num-nodes }}" -gt 1 && "$server_edition" == "enterprise" ]]; then
+          [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
+            || error "features-file or features-content is required for multi-node enterprise clusters (asdb-cluster-nodes-limit 0 must be set)"
+        fi
 
         if [[ "${{ inputs.enable-strong-consistency }}" == "true" ]]; then
+          [[ "$server_edition" == "enterprise" ]] \
+            || error "enable-strong-consistency requires Aerospike Server Enterprise"
           [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
             || error "features-file or features-content is required for strong consistency"
         fi
 
         echo "effective-security=$effective_security" >> "$GITHUB_OUTPUT"
+        echo "server-edition=$server_edition" >> "$GITHUB_OUTPUT"
 
     - name: Set up JFrog CLI
       id: jf
@@ -232,17 +244,17 @@ runs:
         features_path="${{ inputs.features-file }}"
         config_path="${{ inputs.config-file }}"
         effective_security="${{ steps.validate.outputs.effective-security }}"
+        server_edition="${{ steps.validate.outputs.server-edition }}"
         enable_sc="${{ inputs.enable-strong-consistency }}"
         num_nodes=${{ inputs.num-nodes }}
         tpl_dir="${{ github.action_path }}/templates"
 
         render_tpl="${{ github.action_path }}/render-template.sh"
+        # shellcheck source=/dev/null
+        source "${{ github.action_path }}/config-helpers.sh"
 
-        # Build feature-key-file directive (omitted from config when no features file is provided)
-        export FEATURE_KEY_FILE=""
-        if [[ -n "${{ inputs.features-file }}" || -n "${FEATURES_CONTENT}" ]]; then
-          FEATURE_KEY_FILE="feature-key-file /etc/aerospike/features.conf"
-        fi
+        export FEATURE_KEY_FILE
+        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}")
 
         # Build security stanza from template
         export SECURITY=""
@@ -264,6 +276,13 @@ runs:
           features_path="$(mktemp)"
           printf '%s' "${FEATURES_CONTENT}" > "$features_path"
           echo "Wrote features-content to $features_path"
+        fi
+
+        if ! should_use_features_file "$server_edition" "$features_path"; then
+          if [[ -n "$features_path" ]]; then
+            echo "::notice::Ignoring features-file/features-content for Aerospike Server Community"
+          fi
+          features_path=""
         fi
 
         # Write config-content to temp file if no file path was given
@@ -338,6 +357,7 @@ runs:
         tls_cert_dir="${{ steps.generate-tls-certs.outputs.tls-cert-dir }}"
         effective_security="${{ steps.validate.outputs.effective-security }}"
         enable_sc="${{ inputs.enable-strong-consistency }}"
+        server_edition="${{ steps.validate.outputs.server-edition }}"
 
         container_names=""
         service_ports=""
@@ -396,12 +416,11 @@ runs:
           if [[ -z "$config_path" ]]; then
             tpl_dir="${{ github.action_path }}/templates"
             render_tpl="${{ github.action_path }}/render-template.sh"
+            # shellcheck source=/dev/null
+            source "${{ github.action_path }}/config-helpers.sh"
 
-            # Build feature-key-file directive
-            export FEATURE_KEY_FILE=""
-            if [[ -n "$features_path" ]]; then
-              FEATURE_KEY_FILE="feature-key-file /etc/aerospike/features.conf"
-            fi
+            export FEATURE_KEY_FILE
+            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "")
 
             # Build security stanza from template
             export SECURITY=""

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -298,6 +298,13 @@ runs:
 
         # If user provided a custom config, handle security/SC injection
         if [[ -n "$config_path" ]]; then
+          if [[ "$server_edition" == "community" ]] && config_declares_feature_key_file "$config_path"; then
+            sanitized_config_path="$(mktemp)"
+            strip_feature_key_file_directive "$config_path" "$sanitized_config_path"
+            config_path="$sanitized_config_path"
+            echo "::notice::Removed enterprise-only feature-key-file directive from Aerospike Server Community config"
+          fi
+
           if [[ "$effective_security" == "true" ]]; then
             # Append security stanza if not already present
             if ! grep -q 'security {' "$config_path" 2>/dev/null; then

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -3,16 +3,20 @@
 resolve_server_edition() {
     local requested=$1
     local server_repo=$2
+    local repo_name=${server_repo##*/}
 
     case "$requested" in
     enterprise | community)
         printf '%s\n' "$requested"
         ;;
     auto)
-        if [[ $server_repo == *enterprise* ]]; then
+        if [[ $repo_name == "aerospike-server-enterprise" ]]; then
             printf '%s\n' "enterprise"
-        else
+        elif [[ $repo_name == "aerospike-server" ]]; then
             printf '%s\n' "community"
+        else
+            printf 'Error: server-edition auto cannot infer edition from server-container-repo %q; set server-edition explicitly\n' "$server_repo" >&2
+            return 1
         fi
         ;;
     *)

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -37,7 +37,7 @@ build_feature_key_file_directive() {
     local features_path=$2
     local features_content=$3
 
-    if [[ $server_edition == "enterprise" && ( -n $features_path || -n $features_content ) ]]; then
+    if [[ $server_edition == "enterprise" && (-n $features_path || -n $features_content) ]]; then
         printf '%s\n' "feature-key-file /etc/aerospike/features.conf"
     fi
 }

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+resolve_server_edition() {
+    local requested=$1
+    local server_repo=$2
+
+    case "$requested" in
+    enterprise | community)
+        printf '%s\n' "$requested"
+        ;;
+    auto)
+        if [[ $server_repo == *enterprise* ]]; then
+            printf '%s\n' "enterprise"
+        else
+            printf '%s\n' "community"
+        fi
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+should_use_features_file() {
+    local server_edition=$1
+    local features_path=$2
+
+    [[ $server_edition == "enterprise" && -n $features_path ]]
+}
+
+build_feature_key_file_directive() {
+    local server_edition=$1
+    local features_path=$2
+    local features_content=$3
+
+    if [[ $server_edition == "enterprise" && ( -n $features_path || -n $features_content ) ]]; then
+        printf '%s\n' "feature-key-file /etc/aerospike/features.conf"
+    fi
+}

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -52,5 +52,5 @@ strip_feature_key_file_directive() {
     local source_config=$1
     local target_config=$2
 
-    sed '/^[[:space:]]*feature-key-file[[:space:]]/d' "$source_config" > "$target_config"
+    sed '/^[[:space:]]*feature-key-file[[:space:]]/d' "$source_config" >"$target_config"
 }

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -41,3 +41,16 @@ build_feature_key_file_directive() {
         printf '%s\n' "feature-key-file /etc/aerospike/features.conf"
     fi
 }
+
+config_declares_feature_key_file() {
+    local config_path=$1
+
+    grep -Eq '^[[:space:]]*feature-key-file[[:space:]]+' "$config_path"
+}
+
+strip_feature_key_file_directive() {
+    local source_config=$1
+    local target_config=$2
+
+    sed '/^[[:space:]]*feature-key-file[[:space:]]/d' "$source_config" > "$target_config"
+}

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -107,6 +107,35 @@ render_multi_node_config() {
     [ "$status" -ne 0 ]
 }
 
+@test "custom config feature-key-file directive can be detected" {
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    cat > "$config_path" <<'EOF'
+service {
+    cluster-name docker
+    feature-key-file /etc/aerospike/features.conf
+}
+EOF
+
+    config_declares_feature_key_file "$config_path"
+}
+
+@test "custom community config can strip feature-key-file directive" {
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    sanitized_path="$TEST_TMPDIR/aerospike-community.conf"
+    cat > "$config_path" <<'EOF'
+service {
+    cluster-name docker
+    feature-key-file /etc/aerospike/features.conf
+}
+EOF
+
+    strip_feature_key_file_directive "$config_path" "$sanitized_path"
+
+    run grep -q "feature-key-file" "$sanitized_path"
+    [ "$status" -ne 0 ]
+    grep -q "cluster-name docker" "$sanitized_path"
+}
+
 @test "community does not mount features file" {
     run should_use_features_file community "$TEST_TMPDIR/features.conf"
 

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# Tests for Aerospike Server edition-specific config generation.
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+ACTION_DIR="$GIT_ROOT/.github/actions/setup-aerospike-server"
+
+# shellcheck source=/dev/null
+source "$ACTION_DIR/config-helpers.sh"
+
+setup() {
+    TEST_TMPDIR="$(mktemp -d)"
+    export TEST_TMPDIR
+}
+
+teardown() {
+    if [[ -n ${TEST_TMPDIR-} && -d $TEST_TMPDIR ]]; then
+        rm -rf "$TEST_TMPDIR"
+    fi
+}
+
+render_default_config() {
+    local target=$1
+
+    export SECURITY=""
+    export REPLICATION_FACTOR=1
+    export NAMESPACE
+    NAMESPACE=$("$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/namespace-memory.conf")
+
+    "$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/default.conf" "$target"
+}
+
+render_multi_node_config() {
+    local target=$1
+
+    export SECURITY=""
+    export REPLICATION_FACTOR=2
+    export MESH_SEEDS="        mesh-seed-address-port aerospike-1 3002"
+    export NAMESPACE
+    NAMESPACE=$("$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/namespace-memory.conf")
+
+    "$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/multi-node.conf" "$target"
+}
+
+@test "auto edition detects enterprise image repositories" {
+    run resolve_server_edition auto database-docker-virtual/aerospike-server-enterprise
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "enterprise" ]
+}
+
+@test "auto edition detects community image repositories" {
+    run resolve_server_edition auto database-docker-virtual/aerospike-server
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "community" ]
+}
+
+@test "explicit edition overrides auto detection" {
+    run resolve_server_edition community database-docker-virtual/aerospike-server-enterprise
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "community" ]
+}
+
+@test "invalid edition is rejected" {
+    run resolve_server_edition professional database-docker-virtual/aerospike-server
+
+    [ "$status" -ne 0 ]
+}
+
+@test "enterprise with features content renders feature-key-file" {
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive enterprise "" "feature-key-version 2")
+    export FEATURE_KEY_FILE
+
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    render_default_config "$config_path"
+
+    grep -q "feature-key-file /etc/aerospike/features.conf" "$config_path"
+}
+
+@test "community with features content omits feature-key-file" {
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "" "feature-key-version 2")
+    export FEATURE_KEY_FILE
+
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    render_default_config "$config_path"
+
+    run grep -q "feature-key-file" "$config_path"
+    [ "$status" -ne 0 ]
+}
+
+@test "community multi-node config omits feature-key-file" {
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "$TEST_TMPDIR/features.conf" "")
+    export FEATURE_KEY_FILE
+
+    config_path="$TEST_TMPDIR/aerospike-multi-node.conf"
+    render_multi_node_config "$config_path"
+
+    run grep -q "feature-key-file" "$config_path"
+    [ "$status" -ne 0 ]
+}
+
+@test "community does not mount features file" {
+    run should_use_features_file community "$TEST_TMPDIR/features.conf"
+
+    [ "$status" -ne 0 ]
+}
+
+@test "enterprise mounts features file" {
+    should_use_features_file enterprise "$TEST_TMPDIR/features.conf"
+}

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -55,6 +55,13 @@ render_multi_node_config() {
     [ "$output" = "community" ]
 }
 
+@test "auto edition rejects ambiguous image repositories" {
+    run --separate-stderr resolve_server_edition auto database-docker-virtual/aerospike-server-custom
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"server-edition auto cannot infer edition"* ]]
+}
+
 @test "explicit edition overrides auto detection" {
     run resolve_server_edition community database-docker-virtual/aerospike-server-enterprise
 

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -195,4 +195,4 @@ else
 fi
 echo "All nodes are stable."
 
-echo "Aerospike Enterprise Server is ready."
+echo "Aerospike Server is ready."

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -12,6 +12,29 @@ permissions:
   id-token: write
 
 jobs:
+  test-config-helpers:
+    name: Config helper unit tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install bats
+        run: |
+          git clone https://github.com/bats-core/bats-core.git
+          cd bats-core
+          sudo ./install.sh /usr/local
+          cd ..
+          rm -rf bats-core
+
+      - name: Run bats tests
+        run: bats .github/actions/setup-aerospike-server/tests/
+
   test-single-node:
     name: Single node (defaults)
     runs-on: ubuntu-22.04

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -26,8 +26,11 @@ jobs:
 
       - name: Install bats
         run: |
-          git clone https://github.com/bats-core/bats-core.git
+          git init bats-core
           cd bats-core
+          git remote add origin https://github.com/bats-core/bats-core.git
+          git fetch --depth 1 origin cf931b7b7c79998ded0f364126dbc9d46739a76f # v1.12.0
+          git checkout --detach FETCH_HEAD
           sudo ./install.sh /usr/local
           cd ..
           rm -rf bats-core
@@ -168,6 +171,64 @@ jobs:
           echo "Exit code: $rc"
           echo "asinfo status: $result"
           [[ $rc -eq 0 && "$result" == *"ok"* ]] || { echo "Expected status=ok"; exit 1; }
+
+  test-community-multi-node:
+    name: Community multi-node cluster (2 nodes)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Aerospike Server Community (2 nodes)
+        id: setup-aerospike-server
+        uses: ./.github/actions/setup-aerospike-server
+        with:
+          server-container-repo: database-docker-virtual/aerospike-server
+          num-nodes: "2"
+          features-content: |
+            feature-key-version 2
+          startup-timeout: "60"
+          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+
+      - name: Verify outputs
+        run: |
+          echo "container-names: ${{ steps.setup-aerospike-server.outputs.container-names }}"
+          echo "service-ports: ${{ steps.setup-aerospike-server.outputs.service-ports }}"
+
+          [[ "${{ steps.setup-aerospike-server.outputs.container-names }}" == "aerospike-1,aerospike-2" ]] \
+            || { echo "Unexpected container-names"; exit 1; }
+          [[ "${{ steps.setup-aerospike-server.outputs.service-ports }}" == "3000,3001" ]] \
+            || { echo "Unexpected service-ports"; exit 1; }
+
+      - name: Verify features file was not mounted
+        run: |
+          mounts=$(docker inspect aerospike-1 --format '{{range .Mounts}}{{println .Destination}}{{end}}')
+          echo "$mounts"
+          if grep -q "/etc/aerospike/features.conf" <<< "$mounts"; then
+            echo "Community container should not mount features.conf"
+            exit 1
+          fi
+
+      - name: Verify cluster formation via asinfo
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          for container in aerospike-1 aerospike-2; do
+            echo "Checking cluster_size on $container..."
+            rc=0
+            stats=$(docker run --rm --network "$network" "$tools_image" \
+              asinfo -h "$container" -p 3000 -v "statistics" 2>&1) || rc=$?
+            cluster_size=$(echo "$stats" | tr ';' '\n' | grep -oP 'cluster_size=\K\d+' || echo "N/A")
+            echo "$container cluster_size: $cluster_size (exit code: $rc)"
+            [[ $rc -eq 0 && "$cluster_size" == "2" ]] \
+              || { echo "Expected cluster_size=2 on $container, got $cluster_size"; exit 1; }
+          done
 
   test-env-vars:
     name: Custom env-vars passthrough


### PR DESCRIPTION
## Summary
- Adds Community edition support to the `setup-aerospike-server` action via a new `server-edition` input (`auto` | `enterprise` | `community`).
- Default `auto` infers edition from `server-container-repo` (`aerospike-server-enterprise` -> enterprise, `aerospike-server` -> community); existing enterprise callers are unaffected.
- For community, the action skips `feature-key-file` rendering, ignores `features-file`/`features-content`, strips a `feature-key-file` directive from user-supplied configs, and rejects `enable-strong-consistency`.

## Changes
- `action.yaml`: new `server-edition` input; edition resolved in `validate` step and propagated as a step output; multi-node features-file requirement now gated on `enterprise`; SC requires `enterprise`.
- `config-helpers.sh` (new): pure functions `resolve_server_edition`, `should_use_features_file`, `build_feature_key_file_directive`, `config_declares_feature_key_file`, `strip_feature_key_file_directive`.
- `tests/test_config_helpers.bats` (new): unit coverage for edition resolution (auto / explicit / invalid / ambiguous), feature-key directive build, declare detection, and strip.
- `test_setup-aerospike-server.yaml`: new `test-config-helpers` job runs bats; new `test-community-multi-node` integration job forms a 2-node community cluster and asserts no features mount.
- `wait-for-aerospike-server.sh`: ready message no longer says "Enterprise".
- `README.md`: documents `server-edition`, Community usage, and corrects `server-container-repo` default to `database-docker-virtual/aerospike-server-enterprise`.

## Test plan
- [ ] CI: `test-config-helpers` (bats) passes.
- [ ] CI: existing enterprise jobs (`test-single-node`, `test-multi-node`, `test-tls`, `test-security`, `test-strong-consistency`, `test-env-vars`) still pass with default inputs (backwards compatibility).
- [ ] CI: new `test-community-multi-node` job forms a 2-node community cluster, container has no `/etc/aerospike/features.conf` mount, `cluster_size=2` reported by asinfo.
- [ ] Manual: invoke with `server-edition: enterprise` + community repo (expect run; user opted in).
- [ ] Manual: invoke with `server-container-repo: my-mirror/aerospike-server-rc` and no explicit `server-edition` (expect actionable error telling caller to set `server-edition`).
- [ ] Manual: invoke with `enable-strong-consistency: true` against community (expect validation error).