### PR TITLE
feat(setup-aerospike-server): [CLIENT-4793] support self hosted Windows and macOS runners

### DIFF
--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -79,7 +79,7 @@ A features file with `asdb-cluster-nodes-limit 0` is required for Enterprise clu
 
 ### Community edition
 
-Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config and ignore `features-file` / `features-content`.
+Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config, remove that directive from custom configs, and ignore `features-file` / `features-content`.
 
 With `server-edition: auto`, the action infers `enterprise` from repositories named `aerospike-server-enterprise` and `community` from repositories named `aerospike-server`. If you use a mirror or custom repository name, set `server-edition` explicitly.
 

--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -93,32 +93,32 @@ With `server-edition: auto`, the action infers `enterprise` from repositories na
 
 ## Inputs
 
-| Input                          | Required | Default                                                 | Description                                                                                 |
-| ------------------------------ | -------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `oidc-provider`                | Yes      |                                                         | JFrog OIDC provider name                                                                    |
-| `oidc-audience`                | Yes      |                                                         | JFrog OIDC audience                                                                         |
-| `server-tag`                   | No       | `latest`                                                | Aerospike Server Docker image tag                                                           |
-| `num-nodes`                    | No       | `1`                                                     | Number of cluster nodes                                                                     |
-| `container-name-prefix`        | No       | `aerospike`                                             | Container name prefix (nodes: `prefix-1`, `prefix-2`, ...)                                  |
-| `features-file`                | No       |                                                         | Path to `features.conf` on the runner                                                       |
-| `features-content`             | No       |                                                         | Raw `features.conf` content (e.g., from a secret). Ignored if `features-file` is set        |
-| `config-file`                  | No       |                                                         | Path to `aerospike.conf` on the runner                                                      |
-| `config-content`               | No       |                                                         | Raw `aerospike.conf` content. Ignored if `config-file` is set                               |
-| `env-vars`                     | No       |                                                         | Semicolon-delimited `KEY=VALUE` pairs passed as `-e` flags. Use `\;` for literal semicolons |
-| `network-name`                 | No       | `aerospike-net`                                         | Docker network name                                                                         |
-| `base-port`                    | No       | `3000`                                                  | Base host port (node N maps to `base-port + N - 1`)                                         |
-| `service-port`                 | No       | `3000`                                                  | Aerospike service port inside the container (must match `aerospike.conf`)                   |
-| `startup-timeout`              | No       | `30`                                                    | Seconds to wait for node readiness and cluster formation                                    |
-| `enable-tls`                   | No       | `false`                                                 | Enable TLS on Aerospike Server containers                                                   |
-| `tls-base-port`                | No       | `4333`                                                  | Base host TLS port (node N maps to `tls-base-port + N - 1`)                                 |
-| `enable-security`              | No       | `false`                                                 | Enable Aerospike security (authentication with default admin/admin credentials)             |
-| `enable-strong-consistency`    | No       | `false`                                                 | Enable strong consistency on the `test` namespace. Requires a features file                 |
-| `sc-stability-timeout-seconds` | No       | `30`                                                    | Seconds to wait for SC cluster stability after roster setup                                 |
-| `tools-tag`                    | No       | `12.1.1_2`                                              | Aerospike tools Docker image tag                                                            |
-| `container-repo-url`           | No       | `aerospike.jfrog.io`                                    | Docker registry hostname                                                                    |
-| `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise`   | Image repository path                                                                       |
-| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`; set explicitly for custom repo names  |
-| `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                            | JFrog platform URL                                                                          |
+| Input                          | Required | Default                                               | Description                                                                                 |
+| ------------------------------ | -------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `oidc-provider`                | Yes      |                                                       | JFrog OIDC provider name                                                                    |
+| `oidc-audience`                | Yes      |                                                       | JFrog OIDC audience                                                                         |
+| `server-tag`                   | No       | `latest`                                              | Aerospike Server Docker image tag                                                           |
+| `num-nodes`                    | No       | `1`                                                   | Number of cluster nodes                                                                     |
+| `container-name-prefix`        | No       | `aerospike`                                           | Container name prefix (nodes: `prefix-1`, `prefix-2`, ...)                                  |
+| `features-file`                | No       |                                                       | Path to `features.conf` on the runner                                                       |
+| `features-content`             | No       |                                                       | Raw `features.conf` content (e.g., from a secret). Ignored if `features-file` is set        |
+| `config-file`                  | No       |                                                       | Path to `aerospike.conf` on the runner                                                      |
+| `config-content`               | No       |                                                       | Raw `aerospike.conf` content. Ignored if `config-file` is set                               |
+| `env-vars`                     | No       |                                                       | Semicolon-delimited `KEY=VALUE` pairs passed as `-e` flags. Use `\;` for literal semicolons |
+| `network-name`                 | No       | `aerospike-net`                                       | Docker network name                                                                         |
+| `base-port`                    | No       | `3000`                                                | Base host port (node N maps to `base-port + N - 1`)                                         |
+| `service-port`                 | No       | `3000`                                                | Aerospike service port inside the container (must match `aerospike.conf`)                   |
+| `startup-timeout`              | No       | `30`                                                  | Seconds to wait for node readiness and cluster formation                                    |
+| `enable-tls`                   | No       | `false`                                               | Enable TLS on Aerospike Server containers                                                   |
+| `tls-base-port`                | No       | `4333`                                                | Base host TLS port (node N maps to `tls-base-port + N - 1`)                                 |
+| `enable-security`              | No       | `false`                                               | Enable Aerospike security (authentication with default admin/admin credentials)             |
+| `enable-strong-consistency`    | No       | `false`                                               | Enable strong consistency on the `test` namespace. Requires a features file                 |
+| `sc-stability-timeout-seconds` | No       | `30`                                                  | Seconds to wait for SC cluster stability after roster setup                                 |
+| `tools-tag`                    | No       | `12.1.1_2`                                            | Aerospike tools Docker image tag                                                            |
+| `container-repo-url`           | No       | `aerospike.jfrog.io`                                  | Docker registry hostname                                                                    |
+| `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise` | Image repository path                                                                       |
+| `server-edition`               | No       | `auto`                                                | Server edition: `auto`, `enterprise`, or `community`; set explicitly for custom repo names  |
+| `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                          | JFrog platform URL                                                                          |
 
 ## Outputs
 

--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -1,11 +1,11 @@
-# Setup Aerospike Enterprise Server
+# Setup Aerospike Server
 
-GitHub Action that starts one or more Aerospike Enterprise Server containers with optional clustering, TLS, security, strong consistency, and custom configuration.
+GitHub Action that starts one or more Aerospike Server containers with optional clustering, TLS, security, strong consistency, and custom configuration.
 
 ## Prerequisites
 
 - JFrog OIDC credentials (`oidc-provider` and `oidc-audience`) for pulling the Aerospike Server Docker image
-- A valid `features.conf` for enterprise features (e.g., multi-node clustering requires `asdb-cluster-nodes-limit 0`)
+- A valid `features.conf` for Enterprise-only features (e.g., Enterprise multi-node clustering requires `asdb-cluster-nodes-limit 0`)
 
 ## Quick Start
 
@@ -20,7 +20,7 @@ GitHub Action that starts one or more Aerospike Enterprise Server containers wit
 
 ### Multi-node cluster
 
-A features file with `asdb-cluster-nodes-limit 0` is required for clustering.
+A features file with `asdb-cluster-nodes-limit 0` is required for Enterprise clustering.
 
 ```yaml
 - uses: ./.github/actions/setup-aerospike-server
@@ -77,6 +77,18 @@ A features file with `asdb-cluster-nodes-limit 0` is required for clustering.
     oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
 ```
 
+### Community edition
+
+Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config and ignore `features-file` / `features-content`.
+
+```yaml
+- uses: ./.github/actions/setup-aerospike-server
+  with:
+    server-container-repo: database-docker-virtual/aerospike-server
+    oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+    oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+```
+
 ## Inputs
 
 | Input                          | Required | Default                                                 | Description                                                                                 |
@@ -102,7 +114,8 @@ A features file with `asdb-cluster-nodes-limit 0` is required for clustering.
 | `sc-stability-timeout-seconds` | No       | `30`                                                    | Seconds to wait for SC cluster stability after roster setup                                 |
 | `tools-tag`                    | No       | `12.1.1_2`                                              | Aerospike tools Docker image tag                                                            |
 | `container-repo-url`           | No       | `aerospike.jfrog.io`                                    | Docker registry hostname                                                                    |
-| `server-container-repo`        | No       | `database-docker-dev-local/aerospike-server-enterprise` | Image repository path                                                                       |
+| `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise`   | Image repository path                                                                       |
+| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`                                        |
 | `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                            | JFrog platform URL                                                                          |
 
 ## Outputs
@@ -124,6 +137,8 @@ For clusters (`num-nodes > 1`), the action:
 - Waits for all nodes to be ready, the cluster to form, and migrations to complete
 
 If you provide a custom config via `config-file` or `config-content`, it must include a `heartbeat` section with `mode mesh`. The action will inject `mesh-seed-address-port` entries automatically.
+
+For `server-edition: enterprise`, the action requires `features-file` or `features-content` for multi-node clusters. For `server-edition: community`, it does not render or mount a features file because `feature-key-file` is Enterprise-only.
 
 ## TLS
 

--- a/.github/actions/setup-aerospike-server/README.md
+++ b/.github/actions/setup-aerospike-server/README.md
@@ -81,6 +81,8 @@ A features file with `asdb-cluster-nodes-limit 0` is required for Enterprise clu
 
 Set `server-container-repo` to the Community image repository. The action will omit Enterprise-only `feature-key-file` config and ignore `features-file` / `features-content`.
 
+With `server-edition: auto`, the action infers `enterprise` from repositories named `aerospike-server-enterprise` and `community` from repositories named `aerospike-server`. If you use a mirror or custom repository name, set `server-edition` explicitly.
+
 ```yaml
 - uses: ./.github/actions/setup-aerospike-server
   with:
@@ -115,7 +117,7 @@ Set `server-container-repo` to the Community image repository. The action will o
 | `tools-tag`                    | No       | `12.1.1_2`                                              | Aerospike tools Docker image tag                                                            |
 | `container-repo-url`           | No       | `aerospike.jfrog.io`                                    | Docker registry hostname                                                                    |
 | `server-container-repo`        | No       | `database-docker-virtual/aerospike-server-enterprise`   | Image repository path                                                                       |
-| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`                                        |
+| `server-edition`               | No       | `auto`                                                  | Server edition: `auto`, `enterprise`, or `community`; set explicitly for custom repo names  |
 | `jfrog-platform-url`           | No       | `https://aerospike.jfrog.io`                            | JFrog platform URL                                                                          |
 
 ## Outputs

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -99,6 +99,10 @@ inputs:
     description: Aerospike tools Docker image tag
     required: false
     default: 12.1.1_2
+  enable-bash-trace-mode:
+    description: Show commands being executed in shell scripts for debugging
+    required: false
+    default: "false"
 
 outputs:
   container-names:
@@ -122,8 +126,15 @@ runs:
   steps:
     - name: Validate inputs
       id: validate
-      shell: bash -ex {0}
+      shell: bash
+      env:
+        ENABLE_BASH_TRACE_MODE: ${{ inputs.enable-bash-trace-mode }}
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          echo "ENABLE_BASH_TRACE_MODE=$ENABLE_BASH_TRACE_MODE" >> "$GITHUB_ENV"
+          set -x
+        fi
+
         # shellcheck source=/dev/null
         source "${{ github.action_path }}/config-helpers.sh"
 
@@ -181,6 +192,10 @@ runs:
     - name: Create volumes to send TLS files and server config file to the server
       id: server-volume
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          set -x
+        fi
+
         CONFIG_FILES_VOLUME_NAME="server_volume"
         echo "conf_volume_name=$CONFIG_FILES_VOLUME_NAME" >> "$GITHUB_OUTPUT"
         docker volume create "$CONFIG_FILES_VOLUME_NAME"
@@ -203,7 +218,7 @@ runs:
           -v "$CONFIG_FILES_VOLUME_NAME:$VOLUME_DEST_DIR" \
           -v "$TLS_VOLUME_NAME:$TLS_VOLUME_DEST_DIR" \
           alpine tail -f /dev/null
-      shell: bash -ex {0}
+      shell: bash
       env:
         # Prevents volume directories from being expanded since they start with /
         MSYS_NO_PATHCONV: 1
@@ -211,11 +226,15 @@ runs:
     - name: Generate TLS certificates
       id: generate-tls-certs
       if: inputs.enable-tls == 'true'
-      shell: bash -ex {0}
+      shell: bash
       env:
         # Prevents subject name from being treated like a path while running openssl commands
         MSYS_NO_PATHCONV: 1
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          set -x
+        fi
+
         cert_dir="$(mktemp -d)"
         cd "$cert_dir"
 
@@ -279,11 +298,15 @@ runs:
 
     - name: Prepare config files
       id: prepare-config
-      shell: bash -ex {0}
+      shell: bash
       env:
         FEATURES_CONTENT: ${{ inputs.features-content }}
         CONFIG_CONTENT: ${{ inputs.config-content }}
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          set -x
+        fi
+
         features_path="${{ inputs.features-file }}"
         config_path="${{ inputs.config-file }}"
         effective_security="${{ steps.validate.outputs.effective-security }}"
@@ -389,8 +412,12 @@ runs:
 
     - name: Create Docker network
       id: create-network
-      shell: bash -ex {0}
+      shell: bash
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          set -x
+        fi
+
         network="${{ inputs.network-name }}"
         if ! docker network inspect "$network" >/dev/null 2>&1; then
           docker network create "$network"
@@ -402,10 +429,14 @@ runs:
 
     - name: Start Aerospike Server containers
       id: start-containers
-      shell: bash -ex {0}
+      shell: bash
       env:
         ENV_VARS: ${{ inputs.env-vars }}
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          set -x
+        fi
+
         num_nodes=${{ inputs.num-nodes }}
         base_port=${{ inputs.base-port }}
         prefix="${{ inputs.container-name-prefix }}"
@@ -608,7 +639,13 @@ runs:
       shell: bash
       run: |
         chmod +x "${{ github.action_path }}/wait-for-aerospike-server.sh"
-        "${{ github.action_path }}/wait-for-aerospike-server.sh" \
+
+        bash_command=( "bash" )
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          bash_command+=("-x")
+        fi
+
+        "${bash_command[@]}" "${{ github.action_path }}/wait-for-aerospike-server.sh" \
           --container-names "${{ steps.start-containers.outputs.container-names }}" \
           --num-nodes "${{ inputs.num-nodes }}" \
           --timeout "${{ inputs.startup-timeout }}" \
@@ -621,6 +658,10 @@ runs:
     - name: Print Aerospike server version
       shell: bash
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          set -x
+        fi
+
         image="${{ inputs.container-repo-url }}/${{ inputs.server-container-repo }}:${{ inputs.server-tag }}"
         first_container="${{ inputs.container-name-prefix }}-1"
 
@@ -651,6 +692,10 @@ runs:
       if: inputs.enable-strong-consistency == 'true'
       shell: bash
       run: |
+        if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
+          set -x
+        fi
+
         tools_image="${{ inputs.container-repo-url }}/database-docker-virtual/aerospike-tools:${{ inputs.tools-tag }}"
         network="${{ inputs.network-name }}"
         first_container="${{ inputs.container-name-prefix }}-1"

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -360,7 +360,10 @@ runs:
         echo "features-path=$features_path" >> "$GITHUB_OUTPUT"
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
-        files_to_upload=("$config_path")
+        files_to_upload=()
+        if [[ -z "$config_path" ]]; then
+          files_to_upload+=("$config_path")
+        fi
 
         if [[ "$server_edition" == "enterprise" ]]; then
           files_to_upload+=("$features_path")
@@ -546,8 +549,10 @@ runs:
             run_args+=("--foreground")
           fi
 
-          aerospike_conf_filename=$(basename "$config_path")
-          run_args+=("--config-file" "${{ steps.server-volume.outputs.volume_dest_dir }}/$aerospike_conf_filename")
+          if [[ -n "$config_path" ]];
+            aerospike_conf_filename=$(basename "$config_path")
+            run_args+=("--config-file" "${{ steps.server-volume.outputs.volume_dest_dir }}/$aerospike_conf_filename")
+          fi
 
           # No longer need this
           docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -346,7 +346,7 @@ runs:
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
         files_to_upload=("$features_path" "$config_path")
-        for file in "${files_to_upload[@]}"; then
+        for file in "${files_to_upload[@]}"; do
           docker cp "$file" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         done
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -345,7 +345,10 @@ runs:
         echo "features-path=$features_path" >> "$GITHUB_OUTPUT"
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
-        docker cp "$config_path" "$features_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+        files_to_upload=("$features_path" "$config_path")
+        for file in "${files_to_upload[@]}"; then
+          docker cp "$file" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+        done
 
     - name: Create Docker network
       id: create-network

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -515,7 +515,7 @@ runs:
 
           # Bypass entrypoint to prevent config overwrite
           if [[ "$bypass_entrypoint" == "true" ]]; then
-            run_args+=("--entrypoint" "asd" "--config-file" "$volume_dest_folder/aerospike.conf")
+            run_args+=("--entrypoint" "asd")
           fi
 
           run_args+=("$image")
@@ -524,6 +524,8 @@ runs:
           if [[ "$bypass_entrypoint" == "true" ]]; then
             run_args+=("--foreground")
           fi
+
+          run_args+=("--config-file" "$volume_dest_folder/aerospike.conf")
 
           # No longer need this
           docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -248,7 +248,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
-        docker cp $cert_dir "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
+        docker cp "$cert_dir/" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 
     - name: Prepare config files
       id: prepare-config

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -265,7 +265,7 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
-        docker cp "$cert_dir/" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
+        docker cp "$cert_dir/." "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 
     - name: Prepare config files

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -644,7 +644,6 @@ runs:
 
         "${bash_command[@]}" "${{ github.action_path }}/wait-for-aerospike-server.sh" \
           --container-names "${{ steps.start-containers.outputs.container-names }}" \
-          --num-nodes "${{ inputs.num-nodes }}" \
           --timeout "${{ inputs.startup-timeout }}" \
           --service-port "${{ inputs.service-port }}" \
           --security "${{ steps.validate.outputs.effective-security }}" \

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -268,7 +268,7 @@ runs:
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
-        export MSYS2_ARG_CONV_EXCL="${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
+        export MSYS2_ARG_CONV_EXCL="${{ steps.server-volume.outputs.container_name_to_load_volume }}"
         docker cp "$cert_dir/." "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -265,7 +265,7 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
-        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:$TLS_VOLUME_DEST_DIR"
+        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:$${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 
     - name: Prepare config files
       id: prepare-config

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -607,10 +607,6 @@ runs:
             run_args+=("--config-file" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/$aerospike_conf_filename")
           fi
 
-          # No longer need this
-          docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}
-          docker container rm -f ${{ steps.server-volume.outputs.container_name_to_load_volume }}
-
           echo "Starting container: $name (host port: $host_port)"
 
           # Prevent UNIX to windows path conversions here to prevent the aerospike.conf path from being wrongly converted
@@ -630,6 +626,10 @@ runs:
             tls_service_ports+="$tls_host_port"
           fi
         done
+
+        # No longer need this
+        docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}
+        docker container rm -f ${{ steps.server-volume.outputs.container_name_to_load_volume }}
 
         echo "container-names=$container_names" >> "$GITHUB_OUTPUT"
         echo "service-ports=$service_ports" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -266,6 +266,7 @@ runs:
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
         docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
+        docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 
     - name: Prepare config files
       id: prepare-config

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -187,7 +187,8 @@ runs:
 
         CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume"
         echo "container_name_to_load_volume=$CONTAINER_NAME_TO_LOAD_VOLUME" >> "$GITHUB_OUTPUT"
-        VOLUME_DEST_DIR=/etc/aerospike
+        # Avoid overriding the default config files in /etc/aerospike
+        VOLUME_DEST_DIR=/etc/aerospike-custom
         echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash -ex {0}
@@ -256,7 +257,7 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
-        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
+        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:/etc/aerospike/tls/"
 
     - name: Prepare config files
       id: prepare-config
@@ -360,18 +361,9 @@ runs:
         echo "features-path=$features_path" >> "$GITHUB_OUTPUT"
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
-        files_to_upload=()
         if [[ -n "$config_path" ]]; then
-          files_to_upload+=("$config_path")
+          docker cp "$config_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         fi
-
-        if [[ "$server_edition" == "enterprise" && -n "$features_path" ]]; then
-          files_to_upload+=("$features_path")
-        fi
-
-        for file in "${files_to_upload[@]}"; do
-          docker cp "$file" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
-        done
 
     - name: Create Docker network
       id: create-network

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -494,6 +494,8 @@ runs:
             # Inject mesh seeds into the user-provided config
             cluster_config="$(mktemp)"
             awk -v seeds="$mesh_seeds" '/mode mesh/{print; printf "%s", seeds; next}1' "$config_path" > "$cluster_config"
+
+            docker cp "$cluster_config" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
             config_path="$cluster_config"
           fi
         fi

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -122,7 +122,7 @@ runs:
   steps:
     - name: Validate inputs
       id: validate
-      shell: bash
+      shell: bash -ex {0}
       run: |
         # shellcheck source=/dev/null
         source "${{ github.action_path }}/config-helpers.sh"

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -549,7 +549,7 @@ runs:
             run_args+=("--foreground")
           fi
 
-          if [[ -n "$config_path" ]];
+          if [[ -n "$config_path" ]]; then
             aerospike_conf_filename=$(basename "$config_path")
             run_args+=("--config-file" "${{ steps.server-volume.outputs.volume_dest_dir }}/$aerospike_conf_filename")
           fi

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -308,7 +308,7 @@ runs:
 
     - name: Create Docker network
       id: create-network
-      shell: bash
+      shell: bash -x
       run: |
         network="${{ inputs.network-name }}"
         if ! docker network inspect "$network" >/dev/null 2>&1; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -248,7 +248,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
-        docker cp "$cert_dir/*" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
+        docker cp $cert_dir "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 
     - name: Prepare config files
       id: prepare-config

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -525,7 +525,7 @@ runs:
             run_args+=("--foreground")
           fi
 
-          run_args+=("--config-file" "$volume_dest_folder/aerospike.conf")
+          run_args+=("--config-file" "${{ steps.server-volume.outputs.volume_dest_dir }}/aerospike.conf")
 
           # No longer need this
           docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -145,7 +145,7 @@ runs:
 
         effective_security="${{ inputs.enable-security }}"
         server_edition=$(resolve_server_edition "${{ inputs.server-edition }}" "${{ inputs.server-container-repo }}") \
-          || error "server-edition must be one of: auto, enterprise, community"
+          || error "server-edition must be one of: auto, enterprise, community; use enterprise or community when auto cannot infer from server-container-repo"
 
         if [[ "${{ inputs.num-nodes }}" -gt 1 && "$server_edition" == "enterprise" ]]; then
           [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
@@ -271,18 +271,22 @@ runs:
           export NAMESPACE=$("$render_tpl" "$tpl_dir/namespace-memory.conf")
         fi
 
-        # Write features-content to temp file if no file path was given
-        if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
-          features_path="$(mktemp)"
-          printf '%s' "${FEATURES_CONTENT}" > "$features_path"
-          echo "Wrote features-content to $features_path"
-        fi
-
-        if ! should_use_features_file "$server_edition" "$features_path"; then
-          if [[ -n "$features_path" ]]; then
+        if [[ "$server_edition" == "community" ]]; then
+          if [[ -n "$features_path" || -n "${FEATURES_CONTENT}" ]]; then
             echo "::notice::Ignoring features-file/features-content for Aerospike Server Community"
           fi
           features_path=""
+        else
+          # Write features-content to temp file only when the edition can use it.
+          if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
+            features_path="$(mktemp)"
+            printf '%s' "${FEATURES_CONTENT}" > "$features_path"
+            echo "Wrote features-content to $features_path"
+          fi
+
+          if ! should_use_features_file "$server_edition" "$features_path"; then
+            features_path=""
+          fi
         fi
 
         # Write config-content to temp file if no file path was given

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -511,8 +511,9 @@ runs:
             # shellcheck source=/dev/null
             source "${{ github.action_path }}/config-helpers.sh"
 
+            features_conf_filename=$(basename "$features_path")
             export FEATURE_KEY_FILE
-            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/features.conf")
+            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/$features_conf_filename")
 
             # Build security stanza from template
             export SECURITY=""

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -345,7 +345,7 @@ runs:
         else
           # Write features-content to temp file only when the edition can use it.
           if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
-            features_path="$RUNNER_TEMP/features.conf"
+            features_path="$(mktemp)"
             printf '%s' "${FEATURES_CONTENT}" > "$features_path"
             echo "Wrote features-content to $features_path"
           fi

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -295,7 +295,7 @@ runs:
         else
           # Write features-content to temp file only when the edition can use it.
           if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
-            features_path="$(mktemp)"
+            features_path="./features.conf"
             printf '%s' "${FEATURES_CONTENT}" > "$features_path"
             echo "Wrote features-content to $features_path"
           fi

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -264,6 +264,7 @@ runs:
       env:
         FEATURES_CONTENT: ${{ inputs.features-content }}
         CONFIG_CONTENT: ${{ inputs.config-content }}
+        SERVER_EDITION: ${{ inputs.server-edition }}
       run: |
         features_path="${{ inputs.features-file }}"
         config_path="${{ inputs.config-file }}"
@@ -360,7 +361,12 @@ runs:
         echo "features-path=$features_path" >> "$GITHUB_OUTPUT"
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
-        files_to_upload=("$features_path" "$config_path")
+        files_to_upload=("$config_path")
+
+        if [[ "$SERVER_EDITION" == "enterprise" ]]; then
+          files_to_upload+=("$features_path")
+        fi
+
         for file in "${files_to_upload[@]}"; do
           docker cp "$file" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         done

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -1,6 +1,6 @@
-name: Setup Aerospike Server Enterprise
+name: Setup Aerospike Server
 description: >
-  Starts one or more Aerospike Server Enterprise containers, optionally forming
+  Starts one or more Aerospike Server containers, optionally forming
   a cluster, with support for custom config, feature files, and environment
   variable passthrough.
 
@@ -45,6 +45,10 @@ inputs:
     description: Image repository path within the registry
     required: false
     default: database-docker-virtual/aerospike-server-enterprise
+  server-edition:
+    description: Server edition. Use auto to infer from server-container-repo.
+    required: false
+    default: auto
   jfrog-platform-url:
     description: JFrog platform URL
     required: false
@@ -120,6 +124,9 @@ runs:
       id: validate
       shell: bash
       run: |
+        # shellcheck source=/dev/null
+        source "${{ github.action_path }}/config-helpers.sh"
+
         error() { echo "Error: $1" >&2; exit 1; }
 
         [[ "${{ inputs.num-nodes }}" =~ ^[1-9][0-9]*$ ]] \
@@ -131,24 +138,29 @@ runs:
         [[ "${{ inputs.service-port }}" =~ ^[1-9][0-9]*$ ]] \
           || error "service-port must be a positive integer (got: '${{ inputs.service-port }}')"
 
-        if [[ "${{ inputs.num-nodes }}" -gt 1 ]]; then
-          [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
-            || error "features-file or features-content is required for multi-node clusters (asdb-cluster-nodes-limit 0 must be set)"
-        fi
-
         if [[ "${{ inputs.enable-tls }}" == "true" ]]; then
           [[ "${{ inputs.tls-base-port }}" =~ ^[1-9][0-9]*$ ]] \
             || error "tls-base-port must be a positive integer (got: '${{ inputs.tls-base-port }}')"
         fi
 
         effective_security="${{ inputs.enable-security }}"
+        server_edition=$(resolve_server_edition "${{ inputs.server-edition }}" "${{ inputs.server-container-repo }}") \
+          || error "server-edition must be one of: auto, enterprise, community"
+
+        if [[ "${{ inputs.num-nodes }}" -gt 1 && "$server_edition" == "enterprise" ]]; then
+          [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
+            || error "features-file or features-content is required for multi-node enterprise clusters (asdb-cluster-nodes-limit 0 must be set)"
+        fi
 
         if [[ "${{ inputs.enable-strong-consistency }}" == "true" ]]; then
+          [[ "$server_edition" == "enterprise" ]] \
+            || error "enable-strong-consistency requires Aerospike Server Enterprise"
           [[ -n "${{ inputs.features-file }}" || -n "${{ inputs.features-content }}" ]] \
             || error "features-file or features-content is required for strong consistency"
         fi
 
         echo "effective-security=$effective_security" >> "$GITHUB_OUTPUT"
+        echo "server-edition=$server_edition" >> "$GITHUB_OUTPUT"
 
     - name: Set up JFrog CLI
       id: jf
@@ -232,17 +244,17 @@ runs:
         features_path="${{ inputs.features-file }}"
         config_path="${{ inputs.config-file }}"
         effective_security="${{ steps.validate.outputs.effective-security }}"
+        server_edition="${{ steps.validate.outputs.server-edition }}"
         enable_sc="${{ inputs.enable-strong-consistency }}"
         num_nodes=${{ inputs.num-nodes }}
         tpl_dir="${{ github.action_path }}/templates"
 
         render_tpl="${{ github.action_path }}/render-template.sh"
+        # shellcheck source=/dev/null
+        source "${{ github.action_path }}/config-helpers.sh"
 
-        # Build feature-key-file directive (omitted from config when no features file is provided)
-        export FEATURE_KEY_FILE=""
-        if [[ -n "${{ inputs.features-file }}" || -n "${FEATURES_CONTENT}" ]]; then
-          FEATURE_KEY_FILE="feature-key-file /etc/aerospike/features.conf"
-        fi
+        export FEATURE_KEY_FILE
+        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}")
 
         # Build security stanza from template
         export SECURITY=""
@@ -264,6 +276,13 @@ runs:
           features_path="$(mktemp)"
           printf '%s' "${FEATURES_CONTENT}" > "$features_path"
           echo "Wrote features-content to $features_path"
+        fi
+
+        if ! should_use_features_file "$server_edition" "$features_path"; then
+          if [[ -n "$features_path" ]]; then
+            echo "::notice::Ignoring features-file/features-content for Aerospike Server Community"
+          fi
+          features_path=""
         fi
 
         # Write config-content to temp file if no file path was given
@@ -338,6 +357,7 @@ runs:
         tls_cert_dir="${{ steps.generate-tls-certs.outputs.tls-cert-dir }}"
         effective_security="${{ steps.validate.outputs.effective-security }}"
         enable_sc="${{ inputs.enable-strong-consistency }}"
+        server_edition="${{ steps.validate.outputs.server-edition }}"
 
         container_names=""
         service_ports=""
@@ -396,12 +416,11 @@ runs:
           if [[ -z "$config_path" ]]; then
             tpl_dir="${{ github.action_path }}/templates"
             render_tpl="${{ github.action_path }}/render-template.sh"
+            # shellcheck source=/dev/null
+            source "${{ github.action_path }}/config-helpers.sh"
 
-            # Build feature-key-file directive
-            export FEATURE_KEY_FILE=""
-            if [[ -n "$features_path" ]]; then
-              FEATURE_KEY_FILE="feature-key-file /etc/aerospike/features.conf"
-            fi
+            export FEATURE_KEY_FILE
+            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "")
 
             # Build security stanza from template
             export SECURITY=""

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -268,8 +268,10 @@ runs:
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
-        export MSYS2_ARG_CONV_EXCL="${{ steps.server-volume.outputs.container_name_to_load_volume }}"
-        docker cp "$cert_dir/." "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
+        # exporting MSYS2_ARG_CONV_EXCL set to the container name doesn't work
+        unset MSYS_NO_PATHCONV
+        copy_path="$(cygpath -w "$cert_dir")\\."
+        docker cp "$copy_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 
     - name: Prepare config files

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -265,7 +265,7 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
-        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:$${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
+        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 
     - name: Prepare config files
       id: prepare-config

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -319,11 +319,6 @@ runs:
         # shellcheck source=/dev/null
         source "${{ github.action_path }}/config-helpers.sh"
 
-        features_conf_filename=$(basename "$features_path")
-
-        export FEATURE_KEY_FILE
-        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/$features_conf_filename")
-
         # Build security stanza from template
         export SECURITY=""
         if [[ "$effective_security" == "true" ]]; then
@@ -354,6 +349,11 @@ runs:
 
           if ! should_use_features_file "$server_edition" "$features_path"; then
             features_path=""
+          else
+            features_conf_filename=$(basename "$features_path")
+
+            export FEATURE_KEY_FILE
+            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/$features_conf_filename")
           fi
         fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -527,6 +527,7 @@ runs:
           # User-supplied env vars
           run_args+=("${env_flags[@]}")
           run_args+=("-v" "${{ steps.server-volume.outputs.volume_name }}:${{ steps.server-volume.outputs.volume_dest_dir }}")
+          run_args+=("--ulimit" "nofile=15000")
 
           # Bypass entrypoint to prevent config overwrite
           if [[ "$bypass_entrypoint" == "true" ]]; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -269,7 +269,7 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         # Exporting MSYS2_ARG_CONV_EXCL set to the container name doesn't prevent the volume dest dir from being expanded
-        if [[ ${{ runner.os == 'Windows' }} ]]; then
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
           copy_path="$(cygpath -w "$cert_dir")\\."
         else
           copy_path="$cert_dir/."

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -248,8 +248,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
-        export MSYS_NO_PATHCONV=1
-        docker cp "$cert_dir/" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
+        docker cp "$(cygpath -w $cert_dir)" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 
     - name: Prepare config files
       id: prepare-config
@@ -349,7 +348,7 @@ runs:
         files_to_upload=("$features_path" "$config_path")
         export MSYS_NO_PATHCONV=1
         for file in "${files_to_upload[@]}"; do
-          docker cp "$file" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+          docker cp "$(cygpath -w $file)" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         done
 
     - name: Create Docker network

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -268,7 +268,7 @@ runs:
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
-        unset MSYS_NO_PATHCONV
+        export MSYS2_ARG_CONV_EXCL="${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker cp "$cert_dir/." "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -345,7 +345,7 @@ runs:
         else
           # Write features-content to temp file only when the edition can use it.
           if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
-            features_path="./features.conf"
+            features_path="$RUNNER_TEMP/features.conf"
             printf '%s' "${FEATURES_CONTENT}" > "$features_path"
             echo "Wrote features-content to $features_path"
           fi

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -288,7 +288,7 @@ runs:
         source "${{ github.action_path }}/config-helpers.sh"
 
         export FEATURE_KEY_FILE
-        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}")
+        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}" "${{ steps.server-volume.outputs.volume_dest_dir }}/features.conf")
 
         # Build security stanza from template
         export SECURITY=""
@@ -372,6 +372,10 @@ runs:
 
         if [[ -n "$config_path" ]]; then
           docker cp "$config_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+        fi
+
+        if [[ "$server_edition" == "enterprise" && -n "$features_path" ]]; then
+          docker cp "$features_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         fi
 
     - name: Create Docker network
@@ -469,7 +473,7 @@ runs:
             source "${{ github.action_path }}/config-helpers.sh"
 
             export FEATURE_KEY_FILE
-            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "")
+            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "" "${{ steps.server-volume.outputs.volume_dest_dir }}/features.conf")
 
             # Build security stanza from template
             export SECURITY=""

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -190,14 +190,16 @@ runs:
         VOLUME_DEST_DIR=/etc/aerospike
         echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
-      shell: bash -x {0}
+      shell: bash -ex {0}
       env:
         MSYS_NO_PATHCONV: 1
 
     - name: Generate TLS certificates
       id: generate-tls-certs
       if: inputs.enable-tls == 'true'
-      shell: bash -x {0}
+      shell: bash -ex {0}
+      env:
+        MSYS_NO_PATHCONV: 1
       run: |
         cert_dir="$(mktemp -d)"
         cd "$cert_dir"
@@ -254,7 +256,7 @@ runs:
 
     - name: Prepare config files
       id: prepare-config
-      shell: bash -x {0}
+      shell: bash -ex {0}
       env:
         FEATURES_CONTENT: ${{ inputs.features-content }}
         CONFIG_CONTENT: ${{ inputs.config-content }}
@@ -361,7 +363,7 @@ runs:
 
     - name: Create Docker network
       id: create-network
-      shell: bash -x {0}
+      shell: bash -ex {0}
       run: |
         network="${{ inputs.network-name }}"
         if ! docker network inspect "$network" >/dev/null 2>&1; then
@@ -374,7 +376,7 @@ runs:
 
     - name: Start Aerospike Server containers
       id: start-containers
-      shell: bash -x {0}
+      shell: bash -ex {0}
       env:
         ENV_VARS: ${{ inputs.env-vars }}
       run: |

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -287,7 +287,7 @@ runs:
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
-        # Exporting MSYS2_ARG_CONV_EXCL set to the container name doesn't prevent the volume dest dir from being expanded
+        # MSYS2_ARG_CONV_EXCL is another way to do this, but I had trouble using it
         if [[ "${{ runner.os }}" == "Windows" ]]; then
           copy_path="$(cygpath -w "$cert_dir")\\."
         else

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -771,7 +771,7 @@ runs:
         echo "Strong consistency roster setup complete."
 
     - name: Cleanup
-      if: ${{ always() }}
+      if: ${{ always() && steps.server-volume.outcome == 'success' }}
       shell: bash
       run: |
         # No longer need these

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -189,7 +189,7 @@ runs:
         echo container_name_to_load_volume="$CONTAINER_NAME_TO_LOAD_VOLUME" >> $GITHUB_OUTPUT
         VOLUME_DEST_DIR=/etc/aerospike
         echo volume_dest_dir=$VOLUME_DEST_DIR >> $GITHUB_OUTPUT
-        docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d alpine -v "$VOLUME_NAME:$VOLUME_DEST_DIR" tail -f /dev/null
+        docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash
 
     - name: Generate TLS certificates

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -190,7 +190,15 @@ runs:
         # Avoid overriding the default config files in /etc/aerospike
         VOLUME_DEST_DIR=/etc/aerospike-custom
         echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
-        docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
+
+        TLS_VOLUME_NAME="tls_server_volume"
+        echo "tls_volume_name=$TLS_VOLUME_NAME" >> "$GITHUB_OUTPUT"
+        docker volume create "$TLS_VOLUME_NAME"
+
+        TLS_VOLUME_DEST_DIR=/etc/aerospike/tls
+        echo "tls_volume_dest_dir=$TLS_VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
+
+        docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" -v "$TLS_VOLUME_NAME:$TLS_VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash -ex {0}
       env:
         # Prevents VOLUME_DEST_DIR from being expanded since it starts with /
@@ -257,7 +265,7 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
-        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:/etc/aerospike/tls/"
+        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:$TLS_VOLUME_DEST_DIR"
 
     - name: Prepare config files
       id: prepare-config
@@ -527,7 +535,15 @@ runs:
 
           # User-supplied env vars
           run_args+=("${env_flags[@]}")
-          run_args+=("-v" "${{ steps.server-volume.outputs.volume_name }}:${{ steps.server-volume.outputs.volume_dest_dir }}")
+
+          if [[ -n "$config_path" ]]; then
+            run_args+=("-v" "${{ steps.server-volume.outputs.volume_name }}:${{ steps.server-volume.outputs.volume_dest_dir }}")
+          fi
+
+          if [[ -n "$tls_cert_dir" ]]; then
+            run_args+=("-v" "${{ steps.server-volume.outputs.tls_volume_name }}:$tls_cert_dir")
+          fi
+
           run_args+=("--ulimit" "nofile=15000")
 
           # Bypass entrypoint to prevent config overwrite

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -139,7 +139,7 @@ runs:
           || error "service-port must be a positive integer (got: '${{ inputs.service-port }}')"
 
         if [[ "${{ inputs.enable-tls }}" == "true" ]]; then
-          [[ "${{ inputs.tls-base-port }}" resolve_server_edition=~ ^[1-9][0-9]*$ ]] \
+          [[ "${{ inputs.tls-base-port }}" =~ ^[1-9][0-9]*$ ]] \
             || error "tls-base-port must be a positive integer (got: '${{ inputs.tls-base-port }}')"
         fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -252,6 +252,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
+        unset MSYS_NO_PATHCONV
         docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 
     - name: Prepare config files

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -139,7 +139,7 @@ runs:
           || error "service-port must be a positive integer (got: '${{ inputs.service-port }}')"
 
         if [[ "${{ inputs.enable-tls }}" == "true" ]]; then
-          [[ "${{ inputs.tls-base-port }}" =~ ^[1-9][0-9]*$ ]] \
+          [[ "${{ inputs.tls-base-port }}" resolve_server_edition=~ ^[1-9][0-9]*$ ]] \
             || error "tls-base-port must be a positive integer (got: '${{ inputs.tls-base-port }}')"
         fi
 
@@ -264,7 +264,6 @@ runs:
       env:
         FEATURES_CONTENT: ${{ inputs.features-content }}
         CONFIG_CONTENT: ${{ inputs.config-content }}
-        SERVER_EDITION: ${{ inputs.server-edition }}
       run: |
         features_path="${{ inputs.features-file }}"
         config_path="${{ inputs.config-file }}"
@@ -363,7 +362,7 @@ runs:
 
         files_to_upload=("$config_path")
 
-        if [[ "$SERVER_EDITION" == "enterprise" ]]; then
+        if [[ "$server_edition" == "enterprise" ]]; then
           files_to_upload+=("$features_path")
         fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -361,7 +361,7 @@ runs:
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
         files_to_upload=()
-        if [[ -z "$config_path" ]]; then
+        if [[ -n "$config_path" ]]; then
           files_to_upload+=("$config_path")
         fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -578,6 +578,7 @@ runs:
 
           # No longer need this
           docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}
+          docker container rm -f ${{ steps.server-volume.outputs.container_name_to_load_volume }}
 
           echo "Starting container: $name (host port: $host_port)"
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -248,6 +248,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
+        export MSYS_NO_PATHCONV=1
         docker cp "$cert_dir/" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 
     - name: Prepare config files

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -365,7 +365,7 @@ runs:
           files_to_upload+=("$config_path")
         fi
 
-        if [[ "$server_edition" == "enterprise" ]]; then
+        if [[ "$server_edition" == "enterprise" && -n "$features_path" ]]; then
           files_to_upload+=("$features_path")
         fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -303,7 +303,7 @@ runs:
         else
           # Write features-content to temp file only when the edition can use it.
           if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
-            features_path="$(mktemp)"
+            features_path="./features.conf"
             printf '%s' "${FEATURES_CONTENT}" > "$features_path"
             echo "Wrote features-content to $features_path"
           fi

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -563,6 +563,7 @@ runs:
           # TLS port mapping and cert mounting
           if [[ "$enable_tls" == "true" ]]; then
             run_args+=("-p" "${tls_host_port}:4333")
+            run_args+=("-v" "${{ steps.server-volume.outputs.tls_volume_name }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}")
           fi
 
           # Decide whether to bypass the entrypoint. The Aerospike Docker entrypoint
@@ -586,10 +587,6 @@ runs:
 
           if [[ -n "$config_path" ]]; then
             run_args+=("-v" "${{ steps.server-volume.outputs.conf_volume_name }}:${{ steps.server-volume.outputs.conf_volume_dest_dir }}")
-          fi
-
-          if [[ "$enable_tls" == "true" ]]; then
-            run_args+=("-v" "${{ steps.server-volume.outputs.tls_volume_name }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}")
           fi
 
           run_args+=("--ulimit" "nofile=15000")

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -348,6 +348,7 @@ runs:
           fi
 
           if ! should_use_features_file "$server_edition" "$features_path"; then
+            export FEATURE_KEY_FILE=""
             features_path=""
           else
             features_conf_filename=$(basename "$features_path")

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -178,6 +178,20 @@ runs:
         username: ${{ steps.jf.outputs.oidc-user }}
         password: ${{ steps.jf.outputs.oidc-token }}
 
+    - name: Create named volume to send TLS and config files to the server
+      id: server-volume
+      run: |
+        VOLUME_NAME="server_volume"
+        echo volume_name="$VOLUME_NAME" >> $GITHUB_OUTPUT
+        docker volume create "$VOLUME_NAME"
+
+        CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume"
+        echo container_name_to_load_volume="$CONTAINER_NAME_TO_LOAD_VOLUME" >> $GITHUB_OUTPUT
+        VOLUME_DEST_DIR=/etc/aerospike
+        echo volume_dest_dir=$VOLUME_DEST_DIR >> $GITHUB_OUTPUT
+        docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d alpine -v "$VOLUME_NAME:$VOLUME_DEST_DIR" tail -f /dev/null
+      shell: bash
+
     - name: Generate TLS certificates
       id: generate-tls-certs
       if: inputs.enable-tls == 'true'
@@ -233,6 +247,8 @@ runs:
         echo "Generated TLS certificates in $cert_dir"
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
+
+        docker cp -r "$cert_dir/*" "$CONTAINER_NAME_TO_LOAD_VOLUME:$VOLUME_DEST_DIR/tls/"
 
     - name: Prepare config files
       id: prepare-config
@@ -328,6 +344,8 @@ runs:
 
         echo "features-path=$features_path" >> "$GITHUB_OUTPUT"
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
+
+        docker cp "$config_path" "$features_path" "$CONTAINER_NAME_TO_LOAD_VOLUME:$VOLUME_DEST_DIR"
 
     - name: Create Docker network
       id: create-network
@@ -470,12 +488,6 @@ runs:
           # TLS port mapping and cert mounting
           if [[ "$enable_tls" == "true" ]]; then
             run_args+=("-p" "${tls_host_port}:4333")
-            run_args+=("-v" "${tls_cert_dir}:/etc/aerospike/tls:ro")
-          fi
-
-          # Mount features.conf if provided
-          if [[ -n "$features_path" ]]; then
-            run_args+=("-v" "$(realpath "$features_path"):/etc/aerospike/features.conf:ro")
           fi
 
           # Decide whether to bypass the entrypoint. The Aerospike Docker entrypoint
@@ -494,21 +506,13 @@ runs:
             bypass_entrypoint="true"
           fi
 
-          # Mount aerospike.conf (read-only when bypassing entrypoint)
-          if [[ -n "$config_path" ]]; then
-            if [[ "$bypass_entrypoint" == "true" ]]; then
-              run_args+=("-v" "$(realpath "$config_path"):/etc/aerospike/aerospike.conf:ro")
-            else
-              run_args+=("-v" "$(realpath "$config_path"):/etc/aerospike/aerospike.conf")
-            fi
-          fi
-
           # User-supplied env vars
           run_args+=("${env_flags[@]}")
+          run_args+=("-v" "${{ steps.server-volume.outputs.volume_name }}:${{ steps.server-volume.outputs.volume_dest_dir }}")
 
           # Bypass entrypoint to prevent config overwrite
           if [[ "$bypass_entrypoint" == "true" ]]; then
-            run_args+=("--entrypoint" "asd")
+            run_args+=("--entrypoint" "asd" "--config-file" "$volume_dest_folder/aerospike.conf")
           fi
 
           run_args+=("$image")
@@ -517,6 +521,9 @@ runs:
           if [[ "$bypass_entrypoint" == "true" ]]; then
             run_args+=("--foreground")
           fi
+
+          # No longer need this
+          docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}
 
           echo "Starting container: $name (host port: $host_port)"
           docker run "${run_args[@]}"

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -248,7 +248,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
-        docker cp "$cert_dir/*" "$CONTAINER_NAME_TO_LOAD_VOLUME:$VOLUME_DEST_DIR/tls/"
+        docker cp "$cert_dir/*" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 
     - name: Prepare config files
       id: prepare-config
@@ -345,7 +345,7 @@ runs:
         echo "features-path=$features_path" >> "$GITHUB_OUTPUT"
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
-        docker cp "$config_path" "$features_path" "$CONTAINER_NAME_TO_LOAD_VOLUME:$VOLUME_DEST_DIR"
+        docker cp "$config_path" "$features_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
 
     - name: Create Docker network
       id: create-network

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -190,7 +190,7 @@ runs:
         VOLUME_DEST_DIR=/etc/aerospike
         echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
-      shell: bash
+      shell: bash -x {0}
 
     - name: Generate TLS certificates
       id: generate-tls-certs
@@ -252,7 +252,7 @@ runs:
 
     - name: Prepare config files
       id: prepare-config
-      shell: bash
+      shell: bash -x {0}
       env:
         FEATURES_CONTENT: ${{ inputs.features-content }}
         CONFIG_CONTENT: ${{ inputs.config-content }}
@@ -352,7 +352,7 @@ runs:
 
     - name: Create Docker network
       id: create-network
-      shell: bash
+      shell: bash -x {0}
       run: |
         network="${{ inputs.network-name }}"
         if ! docker network inspect "$network" >/dev/null 2>&1; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -178,18 +178,19 @@ runs:
         username: ${{ steps.jf.outputs.oidc-user }}
         password: ${{ steps.jf.outputs.oidc-token }}
 
-    - name: Create named volume to send TLS and config files to the server
+    - name: Create volumes to send TLS files and server config file to the server
       id: server-volume
       run: |
-        VOLUME_NAME="server_volume"
-        echo "volume_name=$VOLUME_NAME" >> "$GITHUB_OUTPUT"
-        docker volume create "$VOLUME_NAME"
+        CONFIG_FILES_VOLUME_NAME="server_volume"
+        echo "conf_volume_name=$CONFIG_FILES_VOLUME_NAME" >> "$GITHUB_OUTPUT"
+        docker volume create "$CONFIG_FILES_VOLUME_NAME"
 
         CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume"
         echo "container_name_to_load_volume=$CONTAINER_NAME_TO_LOAD_VOLUME" >> "$GITHUB_OUTPUT"
+
         # Avoid overriding the default config files in /etc/aerospike
         VOLUME_DEST_DIR=/etc/aerospike-custom
-        echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
+        echo "conf_volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
 
         TLS_VOLUME_NAME="tls_server_volume"
         echo "tls_volume_name=$TLS_VOLUME_NAME" >> "$GITHUB_OUTPUT"
@@ -198,10 +199,13 @@ runs:
         TLS_VOLUME_DEST_DIR=/etc/aerospike/tls
         echo "tls_volume_dest_dir=$TLS_VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
 
-        docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" -v "$TLS_VOLUME_NAME:$TLS_VOLUME_DEST_DIR" alpine tail -f /dev/null
+        docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d \
+          -v "$CONFIG_FILES_VOLUME_NAME:$VOLUME_DEST_DIR" \
+          -v "$TLS_VOLUME_NAME:$TLS_VOLUME_DEST_DIR" \
+          alpine tail -f /dev/null
       shell: bash -ex {0}
       env:
-        # Prevents VOLUME_DEST_DIR from being expanded since it starts with /
+        # Prevents volume directories from being expanded since they start with /
         MSYS_NO_PATHCONV: 1
 
     - name: Generate TLS certificates
@@ -288,7 +292,7 @@ runs:
         source "${{ github.action_path }}/config-helpers.sh"
 
         export FEATURE_KEY_FILE
-        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}" "${{ steps.server-volume.outputs.volume_dest_dir }}/features.conf")
+        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/features.conf")
 
         # Build security stanza from template
         export SECURITY=""
@@ -371,11 +375,11 @@ runs:
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
         if [[ -n "$config_path" ]]; then
-          docker cp "$config_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+          docker cp "$config_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.conf_volume_dest_dir }}"
         fi
 
         if [[ "$server_edition" == "enterprise" && -n "$features_path" ]]; then
-          docker cp "$features_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+          docker cp "$features_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.conf_volume_dest_dir }}"
         fi
 
     - name: Create Docker network
@@ -407,7 +411,6 @@ runs:
         config_path="${{ steps.prepare-config.outputs.config-path }}"
         enable_tls="${{ inputs.enable-tls }}"
         tls_base_port=${{ inputs.tls-base-port }}
-        tls_cert_dir="${{ steps.generate-tls-certs.outputs.tls-cert-dir }}"
         effective_security="${{ steps.validate.outputs.effective-security }}"
         enable_sc="${{ inputs.enable-strong-consistency }}"
         server_edition="${{ steps.validate.outputs.server-edition }}"
@@ -473,7 +476,7 @@ runs:
             source "${{ github.action_path }}/config-helpers.sh"
 
             export FEATURE_KEY_FILE
-            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "" "${{ steps.server-volume.outputs.volume_dest_dir }}/features.conf")
+            FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "$features_path" "" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/features.conf")
 
             # Build security stanza from template
             export SECURITY=""
@@ -501,7 +504,7 @@ runs:
             awk -v seeds="$mesh_seeds" '/mode mesh/{print; printf "%s", seeds; next}1' "$config_path" > "$cluster_config"
             config_path="$cluster_config"
           fi
-          docker cp "$config_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+          docker cp "$config_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.conf_volume_dest_dir }}"
         fi
 
         for (( i=1; i<=num_nodes; i++ )); do
@@ -542,10 +545,10 @@ runs:
           run_args+=("${env_flags[@]}")
 
           if [[ -n "$config_path" ]]; then
-            run_args+=("-v" "${{ steps.server-volume.outputs.volume_name }}:${{ steps.server-volume.outputs.volume_dest_dir }}")
+            run_args+=("-v" "${{ steps.server-volume.outputs.conf_volume_name }}:${{ steps.server-volume.outputs.conf_volume_dest_dir }}")
           fi
 
-          if [[ -n "$tls_cert_dir" ]]; then
+          if [[ "${{ inputs.enable_tls }}" == "true" ]]; then
             run_args+=("-v" "${{ steps.server-volume.outputs.tls_volume_name }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}")
           fi
 
@@ -565,7 +568,7 @@ runs:
 
           if [[ -n "$config_path" ]]; then
             aerospike_conf_filename=$(basename "$config_path")
-            run_args+=("--config-file" "${{ steps.server-volume.outputs.volume_dest_dir }}/$aerospike_conf_filename")
+            run_args+=("--config-file" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/$aerospike_conf_filename")
           fi
 
           # No longer need this

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -182,13 +182,13 @@ runs:
       id: server-volume
       run: |
         VOLUME_NAME="server_volume"
-        echo volume_name="$VOLUME_NAME" >> $GITHUB_OUTPUT
+        echo "volume_name=$VOLUME_NAME" >> "$GITHUB_OUTPUT"
         docker volume create "$VOLUME_NAME"
 
         CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume"
-        echo container_name_to_load_volume="$CONTAINER_NAME_TO_LOAD_VOLUME" >> $GITHUB_OUTPUT
+        echo "container_name_to_load_volume=$CONTAINER_NAME_TO_LOAD_VOLUME" >> "$GITHUB_OUTPUT"
         VOLUME_DEST_DIR=/etc/aerospike
-        echo volume_dest_dir=$VOLUME_DEST_DIR >> $GITHUB_OUTPUT
+        echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -346,6 +346,7 @@ runs:
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
         files_to_upload=("$features_path" "$config_path")
+        export MSYS_NO_PATHCONV=1
         for file in "${files_to_upload[@]}"; do
           docker cp "$file" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         done

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -548,7 +548,7 @@ runs:
             run_args+=("-v" "${{ steps.server-volume.outputs.conf_volume_name }}:${{ steps.server-volume.outputs.conf_volume_dest_dir }}")
           fi
 
-          if [[ "${{ inputs.enable_tls }}" == "true" ]]; then
+          if [[ "$enable_tls" == "true" ]]; then
             run_args+=("-v" "${{ steps.server-volume.outputs.tls_volume_name }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}")
           fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -120,10 +120,6 @@ outputs:
 runs:
   using: composite
   steps:
-    # TODO: this is a side effect that needs to be documented
-    - run: echo "MSYS2_ARG_CONV_EXCL='/tmp*'" >> $GITHUB_ENV
-      shell: bash
-
     - name: Validate inputs
       id: validate
       shell: bash
@@ -191,11 +187,12 @@ runs:
 
         CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume"
         echo "container_name_to_load_volume=$CONTAINER_NAME_TO_LOAD_VOLUME" >> "$GITHUB_OUTPUT"
-
         VOLUME_DEST_DIR=/etc/aerospike
         echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash -x {0}
+      env:
+        MSYS_NO_PATHCONV: 1
 
     - name: Generate TLS certificates
       id: generate-tls-certs

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -265,7 +265,7 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
-        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
+        docker cp "$cert_dir/" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 
     - name: Prepare config files

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -298,6 +298,13 @@ runs:
 
         # If user provided a custom config, handle security/SC injection
         if [[ -n "$config_path" ]]; then
+          if [[ "$server_edition" == "community" ]] && config_declares_feature_key_file "$config_path"; then
+            sanitized_config_path="$(mktemp)"
+            strip_feature_key_file_directive "$config_path" "$sanitized_config_path"
+            config_path="$sanitized_config_path"
+            echo "::notice::Removed enterprise-only feature-key-file directive from Aerospike Server Community config"
+          fi
+
           if [[ "$effective_security" == "true" ]]; then
             # Append security stanza if not already present
             if ! grep -q 'security {' "$config_path" 2>/dev/null; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -541,7 +541,7 @@ runs:
           fi
 
           if [[ -n "$tls_cert_dir" ]]; then
-            run_args+=("-v" "${{ steps.server-volume.outputs.tls_volume_name }}:$tls_cert_dir")
+            run_args+=("-v" "${{ steps.server-volume.outputs.tls_volume_name }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}")
           fi
 
           run_args+=("--ulimit" "nofile=15000")

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -192,6 +192,7 @@ runs:
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash -ex {0}
       env:
+        # Prevents VOLUME_DEST_DIR from being expanded since it starts with /
         MSYS_NO_PATHCONV: 1
 
     - name: Generate TLS certificates
@@ -199,6 +200,7 @@ runs:
       if: inputs.enable-tls == 'true'
       shell: bash -ex {0}
       env:
+        # Prevents subject name from being treated like a path while running openssl commands
         MSYS_NO_PATHCONV: 1
       run: |
         cert_dir="$(mktemp -d)"
@@ -252,6 +254,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
+        # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         unset MSYS_NO_PATHCONV
         docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -494,10 +494,9 @@ runs:
             # Inject mesh seeds into the user-provided config
             cluster_config="$(mktemp)"
             awk -v seeds="$mesh_seeds" '/mode mesh/{print; printf "%s", seeds; next}1' "$config_path" > "$cluster_config"
-
-            docker cp "$cluster_config" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
             config_path="$cluster_config"
           fi
+          docker cp "$config_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         fi
 
         for (( i=1; i<=num_nodes; i++ )); do

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -268,8 +268,7 @@ runs:
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
-        # exporting MSYS2_ARG_CONV_EXCL set to the container name doesn't work
-        unset MSYS_NO_PATHCONV
+        # Exporting MSYS2_ARG_CONV_EXCL set to the container name doesn't prevent the volume dest dir from being expanded
         copy_path="$(cygpath -w "$cert_dir")\\."
         docker cp "$copy_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -308,7 +308,7 @@ runs:
 
     - name: Create Docker network
       id: create-network
-      shell: bash -x {0}
+      shell: bash
       run: |
         network="${{ inputs.network-name }}"
         if ! docker network inspect "$network" >/dev/null 2>&1; then
@@ -321,7 +321,7 @@ runs:
 
     - name: Start Aerospike Server containers
       id: start-containers
-      shell: bash
+      shell: bash -x {0}
       env:
         ENV_VARS: ${{ inputs.env-vars }}
       run: |

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -585,7 +585,7 @@ runs:
           # User-supplied env vars
           run_args+=("${env_flags[@]}")
 
-          if [[ -n "$config_path" ]]; then
+          if [[ -n "$config_path" || -n "$features_path" ]]; then
             run_args+=("-v" "${{ steps.server-volume.outputs.conf_volume_name }}:${{ steps.server-volume.outputs.conf_volume_dest_dir }}")
           fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -319,8 +319,10 @@ runs:
         # shellcheck source=/dev/null
         source "${{ github.action_path }}/config-helpers.sh"
 
+        features_conf_filename=$(basename "$features_path")
+
         export FEATURE_KEY_FILE
-        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/features.conf")
+        FEATURE_KEY_FILE=$(build_feature_key_file_directive "$server_edition" "${{ inputs.features-file }}" "${FEATURES_CONTENT}" "${{ steps.server-volume.outputs.conf_volume_dest_dir }}/$features_conf_filename")
 
         # Build security stanza from template
         export SECURITY=""

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -547,7 +547,8 @@ runs:
             run_args+=("--foreground")
           fi
 
-          run_args+=("--config-file" "${{ steps.server-volume.outputs.volume_dest_dir }}/aerospike.conf")
+          aerospike_conf_filename=$(basename "$config_path")
+          run_args+=("--config-file" "${{ steps.server-volume.outputs.volume_dest_dir }}/$aerospike_conf_filename")
 
           # No longer need this
           docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -631,10 +631,6 @@ runs:
           fi
         done
 
-        # No longer need this
-        docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}
-        docker container rm -f ${{ steps.server-volume.outputs.container_name_to_load_volume }}
-
         echo "container-names=$container_names" >> "$GITHUB_OUTPUT"
         echo "service-ports=$service_ports" >> "$GITHUB_OUTPUT"
         echo "tls-service-ports=$tls_service_ports" >> "$GITHUB_OUTPUT"
@@ -777,3 +773,11 @@ runs:
         fi
 
         echo "Strong consistency roster setup complete."
+
+    - name: Cleanup
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        # No longer need these
+        docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}
+        docker container rm -f ${{ steps.server-volume.outputs.container_name_to_load_volume }}

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -191,6 +191,8 @@ runs:
         echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash -x {0}
+      env:
+        MSYS_NO_PATHCONV: 1
 
     - name: Generate TLS certificates
       id: generate-tls-certs
@@ -248,7 +250,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
-        docker cp "$(cygpath -w $cert_dir)" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
+        docker cp "$cert_dir" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}/tls/"
 
     - name: Prepare config files
       id: prepare-config
@@ -353,9 +355,8 @@ runs:
         echo "config-path=$config_path" >> "$GITHUB_OUTPUT"
 
         files_to_upload=("$features_path" "$config_path")
-        export MSYS_NO_PATHCONV=1
         for file in "${files_to_upload[@]}"; do
-          docker cp "$(cygpath -w $file)" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
+          docker cp "$file" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.volume_dest_dir }}"
         done
 
     - name: Create Docker network

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -169,7 +169,7 @@ runs:
     - name: Generate TLS certificates
       id: generate-tls-certs
       if: inputs.enable-tls == 'true'
-      shell: bash
+      shell: bash -x {0}
       run: |
         cert_dir="$(mktemp -d)"
         cd "$cert_dir"

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -540,7 +540,9 @@ runs:
           docker stop ${{ steps.server-volume.outputs.container_name_to_load_volume }}
 
           echo "Starting container: $name (host port: $host_port)"
-          docker run "${run_args[@]}"
+
+          # Prevent UNIX to windows path conversions here to prevent the aerospike.conf path from being wrongly converted
+          MSYS_NO_PATHCONV=1 docker run "${run_args[@]}"
 
           # Build CSV outputs
           if [[ -n "$container_names" ]]; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -248,7 +248,7 @@ runs:
         ls -la "$cert_dir"
         echo "tls-cert-dir=$cert_dir" >> "$GITHUB_OUTPUT"
 
-        docker cp -r "$cert_dir/*" "$CONTAINER_NAME_TO_LOAD_VOLUME:$VOLUME_DEST_DIR/tls/"
+        docker cp "$cert_dir/*" "$CONTAINER_NAME_TO_LOAD_VOLUME:$VOLUME_DEST_DIR/tls/"
 
     - name: Prepare config files
       id: prepare-config

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -130,8 +130,8 @@ runs:
       env:
         ENABLE_BASH_TRACE_MODE: ${{ inputs.enable-bash-trace-mode }}
       run: |
+        echo "ENABLE_BASH_TRACE_MODE=$ENABLE_BASH_TRACE_MODE" >> "$GITHUB_ENV"
         if [[ "$ENABLE_BASH_TRACE_MODE" == "true" ]]; then
-          echo "ENABLE_BASH_TRACE_MODE=$ENABLE_BASH_TRACE_MODE" >> "$GITHUB_ENV"
           set -x
         fi
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -308,7 +308,7 @@ runs:
 
     - name: Create Docker network
       id: create-network
-      shell: bash -x
+      shell: bash -x {0}
       run: |
         network="${{ inputs.network-name }}"
         if ! docker network inspect "$network" >/dev/null 2>&1; then

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -297,7 +297,7 @@ runs:
         else
           # Write features-content to temp file only when the edition can use it.
           if [[ -z "$features_path" && -n "${FEATURES_CONTENT}" ]]; then
-            features_path="$(mktemp)"
+            features_path="./features.conf"
             printf '%s' "${FEATURES_CONTENT}" > "$features_path"
             echo "Wrote features-content to $features_path"
           fi

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -269,7 +269,11 @@ runs:
 
         # Make sure that docker gets the actual Windows path of the user's temp folder in order to copy properly
         # Exporting MSYS2_ARG_CONV_EXCL set to the container name doesn't prevent the volume dest dir from being expanded
-        copy_path="$(cygpath -w "$cert_dir")\\."
+        if [[ ${{ runner.os == 'Windows' }} ]]; then
+          copy_path="$(cygpath -w "$cert_dir")\\."
+        else
+          copy_path="$cert_dir/."
+        fi
         docker cp "$copy_path" "${{ steps.server-volume.outputs.container_name_to_load_volume }}:${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
         docker exec "${{ steps.server-volume.outputs.container_name_to_load_volume }}" ls "${{ steps.server-volume.outputs.tls_volume_dest_dir }}"
 

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -120,6 +120,10 @@ outputs:
 runs:
   using: composite
   steps:
+    # TODO: this is a side effect that needs to be documented
+    - run: echo "MSYS2_ARG_CONV_EXCL='/tmp*'" >> $GITHUB_ENV
+      shell: bash
+
     - name: Validate inputs
       id: validate
       shell: bash
@@ -187,12 +191,11 @@ runs:
 
         CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume"
         echo "container_name_to_load_volume=$CONTAINER_NAME_TO_LOAD_VOLUME" >> "$GITHUB_OUTPUT"
+
         VOLUME_DEST_DIR=/etc/aerospike
         echo "volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d -v "$VOLUME_NAME:$VOLUME_DEST_DIR" alpine tail -f /dev/null
       shell: bash -x {0}
-      env:
-        MSYS_NO_PATHCONV: 1
 
     - name: Generate TLS certificates
       id: generate-tls-certs

--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -196,18 +196,18 @@ runs:
           set -x
         fi
 
-        CONFIG_FILES_VOLUME_NAME="server_volume"
+        CONFIG_FILES_VOLUME_NAME="server_volume_${{ github.run_id }}_${{ github.run_attempt }}"
         echo "conf_volume_name=$CONFIG_FILES_VOLUME_NAME" >> "$GITHUB_OUTPUT"
         docker volume create "$CONFIG_FILES_VOLUME_NAME"
 
-        CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume"
+        CONTAINER_NAME_TO_LOAD_VOLUME="container_to_load_volume_${{ github.run_id }}_${{ github.run_attempt }}"
         echo "container_name_to_load_volume=$CONTAINER_NAME_TO_LOAD_VOLUME" >> "$GITHUB_OUTPUT"
 
         # Avoid overriding the default config files in /etc/aerospike
         VOLUME_DEST_DIR=/etc/aerospike-custom
         echo "conf_volume_dest_dir=$VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
 
-        TLS_VOLUME_NAME="tls_server_volume"
+        TLS_VOLUME_NAME="tls_server_volume_${{ github.run_id }}_${{ github.run_attempt }}"
         echo "tls_volume_name=$TLS_VOLUME_NAME" >> "$GITHUB_OUTPUT"
         docker volume create "$TLS_VOLUME_NAME"
 

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -3,16 +3,20 @@
 resolve_server_edition() {
     local requested=$1
     local server_repo=$2
+    local repo_name=${server_repo##*/}
 
     case "$requested" in
     enterprise | community)
         printf '%s\n' "$requested"
         ;;
     auto)
-        if [[ $server_repo == *enterprise* ]]; then
+        if [[ $repo_name == "aerospike-server-enterprise" ]]; then
             printf '%s\n' "enterprise"
-        else
+        elif [[ $repo_name == "aerospike-server" ]]; then
             printf '%s\n' "community"
+        else
+            printf 'Error: server-edition auto cannot infer edition from server-container-repo %q; set server-edition explicitly\n' "$server_repo" >&2
+            return 1
         fi
         ;;
     *)

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -37,7 +37,7 @@ build_feature_key_file_directive() {
     local features_path=$2
     local features_content=$3
 
-    if [[ $server_edition == "enterprise" && ( -n $features_path || -n $features_content ) ]]; then
+    if [[ $server_edition == "enterprise" && (-n $features_path || -n $features_content) ]]; then
         printf '%s\n' "feature-key-file /etc/aerospike/features.conf"
     fi
 }

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+resolve_server_edition() {
+    local requested=$1
+    local server_repo=$2
+
+    case "$requested" in
+    enterprise | community)
+        printf '%s\n' "$requested"
+        ;;
+    auto)
+        if [[ $server_repo == *enterprise* ]]; then
+            printf '%s\n' "enterprise"
+        else
+            printf '%s\n' "community"
+        fi
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+
+should_use_features_file() {
+    local server_edition=$1
+    local features_path=$2
+
+    [[ $server_edition == "enterprise" && -n $features_path ]]
+}
+
+build_feature_key_file_directive() {
+    local server_edition=$1
+    local features_path=$2
+    local features_content=$3
+
+    if [[ $server_edition == "enterprise" && ( -n $features_path || -n $features_content ) ]]; then
+        printf '%s\n' "feature-key-file /etc/aerospike/features.conf"
+    fi
+}

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -52,5 +52,5 @@ strip_feature_key_file_directive() {
     local source_config=$1
     local target_config=$2
 
-    sed '/^[[:space:]]*feature-key-file[[:space:]]/d' "$source_config" > "$target_config"
+    sed '/^[[:space:]]*feature-key-file[[:space:]]/d' "$source_config" >"$target_config"
 }

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -36,9 +36,10 @@ build_feature_key_file_directive() {
     local server_edition=$1
     local features_path=$2
     local features_content=$3
+    local feature_path_in_container=$4
 
     if [[ $server_edition == "enterprise" && (-n $features_path || -n $features_content) ]]; then
-        printf '%s\n' "feature-key-file /etc/aerospike/features.conf"
+        printf '%s\n' "feature-key-file $feature_path_in_container"
     fi
 }
 

--- a/.github/actions/setup-aerospike-server/config-helpers.sh
+++ b/.github/actions/setup-aerospike-server/config-helpers.sh
@@ -41,3 +41,16 @@ build_feature_key_file_directive() {
         printf '%s\n' "feature-key-file /etc/aerospike/features.conf"
     fi
 }
+
+config_declares_feature_key_file() {
+    local config_path=$1
+
+    grep -Eq '^[[:space:]]*feature-key-file[[:space:]]+' "$config_path"
+}
+
+strip_feature_key_file_directive() {
+    local source_config=$1
+    local target_config=$2
+
+    sed '/^[[:space:]]*feature-key-file[[:space:]]/d' "$source_config" > "$target_config"
+}

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -107,6 +107,35 @@ render_multi_node_config() {
     [ "$status" -ne 0 ]
 }
 
+@test "custom config feature-key-file directive can be detected" {
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    cat > "$config_path" <<'EOF'
+service {
+    cluster-name docker
+    feature-key-file /etc/aerospike/features.conf
+}
+EOF
+
+    config_declares_feature_key_file "$config_path"
+}
+
+@test "custom community config can strip feature-key-file directive" {
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    sanitized_path="$TEST_TMPDIR/aerospike-community.conf"
+    cat > "$config_path" <<'EOF'
+service {
+    cluster-name docker
+    feature-key-file /etc/aerospike/features.conf
+}
+EOF
+
+    strip_feature_key_file_directive "$config_path" "$sanitized_path"
+
+    run grep -q "feature-key-file" "$sanitized_path"
+    [ "$status" -ne 0 ]
+    grep -q "cluster-name docker" "$sanitized_path"
+}
+
 @test "community does not mount features file" {
     run should_use_features_file community "$TEST_TMPDIR/features.conf"
 

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# Tests for Aerospike Server edition-specific config generation.
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+ACTION_DIR="$GIT_ROOT/.github/actions/setup-aerospike-server"
+
+# shellcheck source=/dev/null
+source "$ACTION_DIR/config-helpers.sh"
+
+setup() {
+    TEST_TMPDIR="$(mktemp -d)"
+    export TEST_TMPDIR
+}
+
+teardown() {
+    if [[ -n ${TEST_TMPDIR-} && -d $TEST_TMPDIR ]]; then
+        rm -rf "$TEST_TMPDIR"
+    fi
+}
+
+render_default_config() {
+    local target=$1
+
+    export SECURITY=""
+    export REPLICATION_FACTOR=1
+    export NAMESPACE
+    NAMESPACE=$("$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/namespace-memory.conf")
+
+    "$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/default.conf" "$target"
+}
+
+render_multi_node_config() {
+    local target=$1
+
+    export SECURITY=""
+    export REPLICATION_FACTOR=2
+    export MESH_SEEDS="        mesh-seed-address-port aerospike-1 3002"
+    export NAMESPACE
+    NAMESPACE=$("$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/namespace-memory.conf")
+
+    "$ACTION_DIR/render-template.sh" "$ACTION_DIR/templates/multi-node.conf" "$target"
+}
+
+@test "auto edition detects enterprise image repositories" {
+    run resolve_server_edition auto database-docker-virtual/aerospike-server-enterprise
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "enterprise" ]
+}
+
+@test "auto edition detects community image repositories" {
+    run resolve_server_edition auto database-docker-virtual/aerospike-server
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "community" ]
+}
+
+@test "explicit edition overrides auto detection" {
+    run resolve_server_edition community database-docker-virtual/aerospike-server-enterprise
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "community" ]
+}
+
+@test "invalid edition is rejected" {
+    run resolve_server_edition professional database-docker-virtual/aerospike-server
+
+    [ "$status" -ne 0 ]
+}
+
+@test "enterprise with features content renders feature-key-file" {
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive enterprise "" "feature-key-version 2")
+    export FEATURE_KEY_FILE
+
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    render_default_config "$config_path"
+
+    grep -q "feature-key-file /etc/aerospike/features.conf" "$config_path"
+}
+
+@test "community with features content omits feature-key-file" {
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "" "feature-key-version 2")
+    export FEATURE_KEY_FILE
+
+    config_path="$TEST_TMPDIR/aerospike.conf"
+    render_default_config "$config_path"
+
+    run grep -q "feature-key-file" "$config_path"
+    [ "$status" -ne 0 ]
+}
+
+@test "community multi-node config omits feature-key-file" {
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "$TEST_TMPDIR/features.conf" "")
+    export FEATURE_KEY_FILE
+
+    config_path="$TEST_TMPDIR/aerospike-multi-node.conf"
+    render_multi_node_config "$config_path"
+
+    run grep -q "feature-key-file" "$config_path"
+    [ "$status" -ne 0 ]
+}
+
+@test "community does not mount features file" {
+    run should_use_features_file community "$TEST_TMPDIR/features.conf"
+
+    [ "$status" -ne 0 ]
+}
+
+@test "enterprise mounts features file" {
+    should_use_features_file enterprise "$TEST_TMPDIR/features.conf"
+}

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -76,13 +76,14 @@ render_multi_node_config() {
 }
 
 @test "enterprise with features content renders feature-key-file" {
-    FEATURE_KEY_FILE=$(build_feature_key_file_directive enterprise "" "feature-key-version 2" "/etc/aerospike/features.conf")
+    features_conf_path=$(mktemp)
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive enterprise "" "feature-key-version 2" "$features_conf_path")
     export FEATURE_KEY_FILE
 
     config_path="$TEST_TMPDIR/aerospike.conf"
     render_default_config "$config_path"
 
-    grep -q "feature-key-file /etc/aerospike/features.conf" "$config_path"
+    grep -q "feature-key-file $features_conf_path" "$config_path"
 }
 
 @test "community with features content omits feature-key-file" {

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -55,6 +55,13 @@ render_multi_node_config() {
     [ "$output" = "community" ]
 }
 
+@test "auto edition rejects ambiguous image repositories" {
+    run --separate-stderr resolve_server_edition auto database-docker-virtual/aerospike-server-custom
+
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"server-edition auto cannot infer edition"* ]]
+}
+
 @test "explicit edition overrides auto detection" {
     run resolve_server_edition community database-docker-virtual/aerospike-server-enterprise
 

--- a/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
+++ b/.github/actions/setup-aerospike-server/tests/test_config_helpers.bats
@@ -76,7 +76,7 @@ render_multi_node_config() {
 }
 
 @test "enterprise with features content renders feature-key-file" {
-    FEATURE_KEY_FILE=$(build_feature_key_file_directive enterprise "" "feature-key-version 2")
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive enterprise "" "feature-key-version 2" "/etc/aerospike/features.conf")
     export FEATURE_KEY_FILE
 
     config_path="$TEST_TMPDIR/aerospike.conf"
@@ -86,7 +86,7 @@ render_multi_node_config() {
 }
 
 @test "community with features content omits feature-key-file" {
-    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "" "feature-key-version 2")
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "" "feature-key-version 2" "/etc/aerospike/features.conf")
     export FEATURE_KEY_FILE
 
     config_path="$TEST_TMPDIR/aerospike.conf"
@@ -97,7 +97,7 @@ render_multi_node_config() {
 }
 
 @test "community multi-node config omits feature-key-file" {
-    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "$TEST_TMPDIR/features.conf" "")
+    FEATURE_KEY_FILE=$(build_feature_key_file_directive community "$TEST_TMPDIR/features.conf" "" "/etc/aerospike/features.conf")
     export FEATURE_KEY_FILE
 
     config_path="$TEST_TMPDIR/aerospike-multi-node.conf"

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -14,7 +14,6 @@ handle_error() {
 
 # Default values
 CONTAINER_NAMES=""
-NUM_NODES=1
 TIMEOUT=30
 SERVICE_PORT=3000
 SECURITY="false"
@@ -27,10 +26,6 @@ while [[ $# -gt 0 ]]; do
     case $1 in
     --container-names)
         CONTAINER_NAMES="$2"
-        shift 2
-        ;;
-    --num-nodes)
-        NUM_NODES="$2"
         shift 2
         ;;
     --timeout)

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -72,64 +72,7 @@ fi
 # Convert CSV to array
 IFS=',' read -ra containers <<<"$CONTAINER_NAMES"
 
-# Phase 1: Wait for each node's service port to accept connections
-echo "Phase 1: Waiting for individual node readiness..."
-for container in "${containers[@]}"; do
-    echo "  Waiting for $container..."
-    elapsed=0
-    ready="false"
-    # Prevent the /dev/tcp* command from being expanded
-    export MSYS_NO_PATHCONV=1
-    while ((elapsed < TIMEOUT)); do
-        if docker exec "$container" bash -c "</dev/tcp/localhost/${SERVICE_PORT}" 2>/dev/null; then
-            echo "  $container is ready (${elapsed}s)"
-            ready="true"
-            break
-        fi
-        sleep 2
-        elapsed=$((elapsed + 2))
-    done
-    unset MSYS_NO_PATHCONV
-
-    if [[ $ready != "true" ]]; then
-        echo "Error: $container did not become ready within ${TIMEOUT}s" >&2
-        echo "Container logs:" >&2
-        docker logs "$container" >&2
-        exit 1
-    fi
-done
-echo "All nodes are ready."
-
-# Phase 2: Wait for cluster formation (only for multi-node)
-if ((NUM_NODES > 1)); then
-    echo "Phase 2: Waiting for cluster formation (expected size: $NUM_NODES)..."
-    first_container="${containers[0]}"
-    elapsed=0
-    cluster_size=0
-    while ((elapsed < TIMEOUT)); do
-        cluster_size=$(docker logs "$first_container" 2>&1 | grep -oP 'CLUSTER-SIZE \K\d+' | tail -1 || echo "0")
-        if [[ $cluster_size == "$NUM_NODES" ]]; then
-            echo "Cluster formed: $cluster_size nodes (${elapsed}s)"
-            break
-        fi
-        sleep 2
-        elapsed=$((elapsed + 2))
-    done
-
-    if [[ $cluster_size != "$NUM_NODES" ]]; then
-        echo "Error: Cluster did not form within ${TIMEOUT}s (expected $NUM_NODES nodes)" >&2
-        echo "Per-node cluster-size for debugging:" >&2
-        for container in "${containers[@]}"; do
-            size=$(docker logs "$container" 2>&1 | grep -oP 'CLUSTER-SIZE \K\d+' | tail -1 || echo "N/A")
-            echo "  $container: cluster-size=$size" >&2
-            docker logs "$container" 2>&1
-        done
-        exit 1
-    fi
-fi
-
-# Phase 3: Wait for cluster stability
-echo "Phase 3: Waiting for cluster stability..."
+echo "Waiting for cluster stability..."
 
 ignore_migrations="$ENABLE_SC"
 

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -122,6 +122,7 @@ if ((NUM_NODES > 1)); then
         for container in "${containers[@]}"; do
             size=$(docker logs "$container" 2>&1 | grep -oP 'CLUSTER-SIZE \K\d+' | tail -1 || echo "N/A")
             echo "  $container: cluster-size=$size" >&2
+            docker logs "$container" 2>&1
         done
         exit 1
     fi

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -130,72 +130,50 @@ fi
 # Phase 3: Wait for cluster stability
 echo "Phase 3: Waiting for cluster stability..."
 
-if [[ $ENABLE_SC == "true" ]]; then
-    # SC mode: use tools container with asinfo to check cluster-stable
-    # SC partitions won't complete migrations until roster is set up,
-    # so we use ignore-migrations=true
-    auth_flags=""
-    if [[ $SECURITY == "true" ]]; then
-        auth_flags="-U admin -P admin"
-    fi
+ignore_migrations="$ENABLE_SC"
 
-    echo "  Tools image: $TOOLS_IMAGE"
-    echo "  Network: $NETWORK"
-    echo "  Auth flags: ${auth_flags:-(none)}"
-
-    # shellcheck disable=SC2086
-    for container in "${containers[@]}"; do
-        echo "  Waiting for $container to stabilize (SC mode)..."
-        elapsed=0
-        stable="false"
-        while ((elapsed < TIMEOUT)); do
-            echo "    [${elapsed}s] Running: docker run --rm --network $NETWORK $TOOLS_IMAGE asinfo -h $container -p $SERVICE_PORT $auth_flags -v cluster-stable:ignore-migrations=true"
-            rc=0
-            result=$(docker run --rm --network "$NETWORK" "$TOOLS_IMAGE" \
-                asinfo -h "$container" -p "$SERVICE_PORT" $auth_flags \
-                -v "cluster-stable:ignore-migrations=true" 2>&1) || rc=$?
-            echo "    [${elapsed}s] Exit code: $rc, Output: $result"
-            # A non-ERROR response containing a cluster key means stable
-            if [[ $rc -eq 0 && -n $result && $result != *"ERROR"* ]]; then
-                echo "  $container is stable (SC mode, ${elapsed}s): $result"
-                stable="true"
-                break
-            fi
-            sleep 2
-            elapsed=$((elapsed + 2))
-        done
-
-        if [[ $stable != "true" ]]; then
-            echo "Error: $container did not stabilize within ${TIMEOUT}s (SC mode)" >&2
-            echo "Last 20 lines of container logs:" >&2
-            docker logs "$container" >&2
-            exit 1
-        fi
-    done
-else
-    # Standard mode: check logs for migrations complete
-    for container in "${containers[@]}"; do
-        echo "  Waiting for $container to stabilize..."
-        elapsed=0
-        stable="false"
-        while ((elapsed < TIMEOUT)); do
-            if docker logs "$container" 2>&1 | grep -q 'migrations: complete'; then
-                echo "  $container is stable (${elapsed}s)"
-                stable="true"
-                break
-            fi
-            sleep 2
-            elapsed=$((elapsed + 2))
-        done
-
-        if [[ $stable != "true" ]]; then
-            echo "Error: $container did not stabilize within ${TIMEOUT}s" >&2
-            echo "Last 20 lines of container logs:" >&2
-            docker logs "$container" >&2
-            exit 1
-        fi
-    done
+# SC mode: use tools container with asinfo to check cluster-stable
+# SC partitions won't complete migrations until roster is set up,
+# so we use ignore-migrations=true
+auth_flags=""
+if [[ $SECURITY == "true" ]]; then
+    auth_flags="-U admin -P admin"
 fi
+
+echo "  Tools image: $TOOLS_IMAGE"
+echo "  Network: $NETWORK"
+echo "  Auth flags: ${auth_flags:-(none)}"
+
+# shellcheck disable=SC2086
+for container in "${containers[@]}"; do
+    echo "  Waiting for $container to stabilize..."
+    elapsed=0
+    stable="false"
+    while ((elapsed < TIMEOUT)); do
+        echo "    [${elapsed}s] Running: docker run --rm --network $NETWORK $TOOLS_IMAGE asinfo -h $container -p $SERVICE_PORT $auth_flags -v cluster-stable:ignore-migrations=$ignore_migrations"
+        rc=0
+        result=$(docker run --rm --network "$NETWORK" "$TOOLS_IMAGE" \
+            asinfo -h "$container" -p "$SERVICE_PORT" $auth_flags \
+            -v "cluster-stable:ignore-migrations=${ignore_migrations}" 2>&1) || rc=$?
+        echo "    [${elapsed}s] Exit code: $rc, Output: $result"
+        # A non-ERROR response containing a cluster key means stable
+        if [[ $rc -eq 0 && -n $result && $result != *"ERROR"* ]]; then
+            echo "  $container is stable (${elapsed}s): $result"
+            stable="true"
+            break
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    if [[ $stable != "true" ]]; then
+        echo "Error: $container did not stabilize within ${TIMEOUT}s" >&2
+        echo "Last 20 lines of container logs:" >&2
+        docker logs "$container" >&2
+        exit 1
+    fi
+done
+
 echo "All nodes are stable."
 
 echo "Aerospike Server is ready."

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euox pipefail
 
 export PS4='+($LINENO): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 trap 'handle_error ${LINENO}' ERR

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -168,7 +168,7 @@ if [[ $ENABLE_SC == "true" ]]; then
         if [[ $stable != "true" ]]; then
             echo "Error: $container did not stabilize within ${TIMEOUT}s (SC mode)" >&2
             echo "Last 20 lines of container logs:" >&2
-            docker logs --tail 20 "$container" >&2
+            docker logs "$container" >&2
             exit 1
         fi
     done
@@ -191,7 +191,7 @@ else
         if [[ $stable != "true" ]]; then
             echo "Error: $container did not stabilize within ${TIMEOUT}s" >&2
             echo "Last 20 lines of container logs:" >&2
-            docker logs --tail 20 "$container" >&2
+            docker logs "$container" >&2
             exit 1
         fi
     done

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euox pipefail
+set -euo pipefail
 
 export PS4='+($LINENO): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 trap 'handle_error ${LINENO}' ERR

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -78,6 +78,7 @@ for container in "${containers[@]}"; do
     echo "  Waiting for $container..."
     elapsed=0
     ready="false"
+    # Prevent the /dev/tcp* command from being expanded
     export MSYS_NO_PATHCONV=1
     while ((elapsed < TIMEOUT)); do
         if docker exec "$container" bash -c "</dev/tcp/localhost/${SERVICE_PORT}" 2>/dev/null; then

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -195,4 +195,4 @@ else
 fi
 echo "All nodes are stable."
 
-echo "Aerospike Enterprise Server is ready."
+echo "Aerospike Server is ready."

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -91,7 +91,7 @@ for container in "${containers[@]}"; do
     if [[ $ready != "true" ]]; then
         echo "Error: $container did not become ready within ${TIMEOUT}s" >&2
         echo "Last 20 lines of container logs:" >&2
-        docker logs --tail 20 "$container" >&2
+        docker logs "$container" >&2
         exit 1
     fi
 done

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -93,7 +93,7 @@ for container in "${containers[@]}"; do
 
     if [[ $ready != "true" ]]; then
         echo "Error: $container did not become ready within ${TIMEOUT}s" >&2
-        echo "Last 20 lines of container logs:" >&2
+        echo "Container logs:" >&2
         docker logs "$container" >&2
         exit 1
     fi
@@ -171,7 +171,7 @@ for container in "${containers[@]}"; do
 
     if [[ $stable != "true" ]]; then
         echo "Error: $container did not stabilize within ${TIMEOUT}s" >&2
-        echo "Last 20 lines of container logs:" >&2
+        echo "Container logs:" >&2
         docker logs "$container" >&2
         exit 1
     fi

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -144,13 +144,15 @@ echo "  Tools image: $TOOLS_IMAGE"
 echo "  Network: $NETWORK"
 echo "  Auth flags: ${auth_flags:-(none)}"
 
+docker pull "$TOOLS_IMAGE"
+
 # shellcheck disable=SC2086
 for container in "${containers[@]}"; do
     echo "  Waiting for $container to stabilize..."
     elapsed=0
     stable="false"
     while ((elapsed < TIMEOUT)); do
-        echo "    [${elapsed}s] Running: docker run --rm --network $NETWORK $TOOLS_IMAGE asinfo -h $container -p $SERVICE_PORT $auth_flags -v cluster-stable:ignore-migrations=$ignore_migrations"
+        echo "Elapsed:" "$elapsed"
         rc=0
         result=$(docker run --rm --network "$NETWORK" "$TOOLS_IMAGE" \
             asinfo -h "$container" -p "$SERVICE_PORT" $auth_flags \

--- a/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
+++ b/.github/actions/setup-aerospike-server/wait-for-aerospike-server.sh
@@ -78,6 +78,7 @@ for container in "${containers[@]}"; do
     echo "  Waiting for $container..."
     elapsed=0
     ready="false"
+    export MSYS_NO_PATHCONV=1
     while ((elapsed < TIMEOUT)); do
         if docker exec "$container" bash -c "</dev/tcp/localhost/${SERVICE_PORT}" 2>/dev/null; then
             echo "  $container is ready (${elapsed}s)"
@@ -87,6 +88,7 @@ for container in "${containers[@]}"; do
         sleep 2
         elapsed=$((elapsed + 2))
     done
+    unset MSYS_NO_PATHCONV
 
     if [[ $ready != "true" ]]; then
         echo "Error: $container did not become ready within ${TIMEOUT}s" >&2

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -17,7 +17,7 @@ permissions:
   id-token: write
 
 env:
-  ENABLE_BASH_TRACE_MODE: ${{ inputs.enable-bash-trace-mode }}
+  ENABLE_BASH_TRACE_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.enable-bash-trace-mode || 'false' }}
 
 jobs:
   test-config-helpers:

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -12,6 +12,29 @@ permissions:
   id-token: write
 
 jobs:
+  test-config-helpers:
+    name: Config helper unit tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install bats
+        run: |
+          git clone https://github.com/bats-core/bats-core.git
+          cd bats-core
+          sudo ./install.sh /usr/local
+          cd ..
+          rm -rf bats-core
+
+      - name: Run bats tests
+        run: bats .github/actions/setup-aerospike-server/tests/
+
   test-single-node:
     name: Single node (defaults)
     runs-on: ubuntu-22.04

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -26,8 +26,11 @@ jobs:
 
       - name: Install bats
         run: |
-          git clone https://github.com/bats-core/bats-core.git
+          git init bats-core
           cd bats-core
+          git remote add origin https://github.com/bats-core/bats-core.git
+          git fetch --depth 1 origin cf931b7b7c79998ded0f364126dbc9d46739a76f # v1.12.0
+          git checkout --detach FETCH_HEAD
           sudo ./install.sh /usr/local
           cd ..
           rm -rf bats-core
@@ -168,6 +171,64 @@ jobs:
           echo "Exit code: $rc"
           echo "asinfo status: $result"
           [[ $rc -eq 0 && "$result" == *"ok"* ]] || { echo "Expected status=ok"; exit 1; }
+
+  test-community-multi-node:
+    name: Community multi-node cluster (2 nodes)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Aerospike Server Community (2 nodes)
+        id: setup-aerospike-server
+        uses: ./.github/actions/setup-aerospike-server
+        with:
+          server-container-repo: database-docker-virtual/aerospike-server
+          num-nodes: "2"
+          features-content: |
+            feature-key-version 2
+          startup-timeout: "60"
+          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+
+      - name: Verify outputs
+        run: |
+          echo "container-names: ${{ steps.setup-aerospike-server.outputs.container-names }}"
+          echo "service-ports: ${{ steps.setup-aerospike-server.outputs.service-ports }}"
+
+          [[ "${{ steps.setup-aerospike-server.outputs.container-names }}" == "aerospike-1,aerospike-2" ]] \
+            || { echo "Unexpected container-names"; exit 1; }
+          [[ "${{ steps.setup-aerospike-server.outputs.service-ports }}" == "3000,3001" ]] \
+            || { echo "Unexpected service-ports"; exit 1; }
+
+      - name: Verify features file was not mounted
+        run: |
+          mounts=$(docker inspect aerospike-1 --format '{{range .Mounts}}{{println .Destination}}{{end}}')
+          echo "$mounts"
+          if grep -q "/etc/aerospike/features.conf" <<< "$mounts"; then
+            echo "Community container should not mount features.conf"
+            exit 1
+          fi
+
+      - name: Verify cluster formation via asinfo
+        run: |
+          tools_image="aerospike.jfrog.io/database-docker-virtual/aerospike-tools:12.1.1_2"
+          network="${{ steps.setup-aerospike-server.outputs.network-name }}"
+          for container in aerospike-1 aerospike-2; do
+            echo "Checking cluster_size on $container..."
+            rc=0
+            stats=$(docker run --rm --network "$network" "$tools_image" \
+              asinfo -h "$container" -p 3000 -v "statistics" 2>&1) || rc=$?
+            cluster_size=$(echo "$stats" | tr ';' '\n' | grep -oP 'cluster_size=\K\d+' || echo "N/A")
+            echo "$container cluster_size: $cluster_size (exit code: $rc)"
+            [[ $rc -eq 0 && "$cluster_size" == "2" ]] \
+              || { echo "Expected cluster_size=2 on $container, got $cluster_size"; exit 1; }
+          done
 
   test-env-vars:
     name: Custom env-vars passthrough

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -1,6 +1,11 @@
 name: Test Setup Aerospike Server Action
 on:
   workflow_dispatch:
+    inputs:
+      enable-bash-trace-mode:
+        type: boolean
+        required: false
+        default: false
   pull_request:
     branches: [main]
     paths:
@@ -10,6 +15,9 @@ on:
 permissions:
   contents: read
   id-token: write
+
+env:
+  ENABLE_BASH_TRACE_MODE: ${{ inputs.enable-bash-trace-mode }}
 
 jobs:
   test-config-helpers:
@@ -56,6 +64,7 @@ jobs:
         with:
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify outputs
         run: |
@@ -108,6 +117,7 @@ jobs:
           features-content: ${{ secrets.AES_FEATURES_CONF }}
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify outputs
         run: |
@@ -159,6 +169,7 @@ jobs:
           features-content: ${{ secrets.AES_FEATURES_CONF }}
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify server status via asinfo
         run: |
@@ -195,6 +206,7 @@ jobs:
           startup-timeout: "60"
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify outputs
         run: |
@@ -249,6 +261,7 @@ jobs:
           env-vars: NAMESPACE=test;SERVICE_THREADS=4
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify env vars in container
         run: |
@@ -277,6 +290,7 @@ jobs:
           enable-tls: "true"
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify TLS outputs
         run: |
@@ -334,6 +348,7 @@ jobs:
           features-content: ${{ secrets.AES_FEATURES_CONF }}
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify admin auth works
         run: |
@@ -381,6 +396,7 @@ jobs:
           startup-timeout: "60"
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify SC namespace
         run: |
@@ -417,6 +433,7 @@ jobs:
           startup-timeout: "60"
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify SC namespace with auth
         run: |
@@ -466,6 +483,7 @@ jobs:
           startup-timeout: "60"
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify TLS outputs
         run: |
@@ -552,6 +570,7 @@ jobs:
           startup-timeout: "60"
           oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
           oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          enable-bash-trace-mode: ${{ env.ENABLE_BASH_TRACE_MODE }}
 
       - name: Verify outputs
         run: |

--- a/.github/workflows/test_setup-aerospike-server.yaml
+++ b/.github/workflows/test_setup-aerospike-server.yaml
@@ -2,6 +2,7 @@ name: Test Setup Aerospike Server Action
 on:
   workflow_dispatch:
     inputs:
+      # checkov:skip=CKV_GHA_7:workflow_dispatch input used for debugging failing test cases in this repo
       enable-bash-trace-mode:
         type: boolean
         required: false


### PR DESCRIPTION
## Summary

- Replaces all bind mounts with Docker named volumes for TLS certs and server config, enabling this action on self-hosted Windows and macOS runners where bind mounts require extra VM configuration or fail entirely
- Adds `MSYS_NO_PATHCONV=1` guards wherever shell paths touch Docker on Windows to prevent Git Bash path mangling
- Unifies the SC and non-SC cluster stability check into a single `asinfo cluster-stable:ignore-migrations=<bool>` path

## Jira
[CLIENT-4793](https://aerospike.atlassian.net/browse/CLIENT-4793)

## Changes

- New `Create volumes` step creates two named volumes (`server_volume`, `tls_server_volume`) and a short-lived alpine container to load files into them via `docker cp`; bind mount `-v` flags removed from `docker run`
- Config passed to `asd` via `--config-file` pointing to the volume path instead of a hardcoded `/etc/aerospike/aerospike.conf` mount
- `build_feature_key_file_directive` takes a new `feature_path_in_container` arg so the in-container features path is no longer hardcoded
- Windows `docker cp` converts the temp path with `cygpath -w` before copying
- SC/non-SC stability branches merged; tools image `docker pull` runs unconditionally before the loop
- Debug: `bash -ex {0}` on all action steps, `set -euox pipefail` in wait script, full `docker logs` on timeout

## Test plan

- Bats unit tests: `bats .github/actions/setup-aerospike-server/tests/`
- CI passes on Linux runner (regression check)
- Manual smoke on self-hosted macOS and Windows runners

---
*Previously:*

---

Bind mounts don't work without extra configuration on macOS due to Docker running in a Linux VM. On Windows, the Docker daemon is running on a remote host, so bind mounts cannot work in this case

## Extra Changes

- Adds debug print statements to show where a step fails exactly
- Print all server logs if server container is not ready by a deadline for easier debugging.

[CLIENT-4793]: https://aerospike.atlassian.net/browse/CLIENT-4793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ