### PR TITLE
fix: [INFRA-493] Fix sign path handling

### DIFF
--- a/.github/workflows/example_artifacts-cicd.yaml
+++ b/.github/workflows/example_artifacts-cicd.yaml
@@ -125,7 +125,7 @@ jobs:
             "arch":"x64",
             "working-directory":"repo-source/.github/workflows/execute-build/test_apps/hi",
             "gh-artifact-directory":"packaged-artifacts",
-            "build-script":"mkdir -p packaged-artifacts && head -c 2048 /dev/zero > packaged-artifacts/example-win-ci.exe && head -c 2048 /dev/zero > packaged-artifacts/example-win-ci.msi && head -c 2048 /dev/zero > packaged-artifacts/example-win-ci.msix"
+            "build-script":"sudo apt-get update -qq && sudo apt-get install -y -qq gcc-mingw-w64-x86-64 && mkdir -p packaged-artifacts && printf '%s\\n' 'int main(void) { return 0; }' > /tmp/example-win-ci.c && x86_64-w64-mingw32-gcc -O2 /tmp/example-win-ci.c -o packaged-artifacts/example-win-ci.exe"
           }
         ]}
       build-script: |
@@ -154,7 +154,7 @@ jobs:
       mac-artifact-glob: "*.pkg"
       mac-notarize: true
       sign-windows: true
-      win-artifact-glob: "*.exe,*.msi,*.msix"
+      win-artifact-glob: "*.exe"
       win-runs-on: windows-2025
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}

--- a/.github/workflows/example_win-signing.yaml
+++ b/.github/workflows/example_win-signing.yaml
@@ -65,13 +65,13 @@ jobs:
             "arch":"x64",
             "working-directory":"repo-source/.github/workflows/execute-build/test_apps/hi",
             "gh-artifact-directory":"packaged-artifacts",
-            "build-script":"mkdir -p packaged-artifacts && head -c 2048 /dev/zero > packaged-artifacts/example-win-test.exe && head -c 2048 /dev/zero > packaged-artifacts/example-win-test.msi && head -c 2048 /dev/zero > packaged-artifacts/example-win-test.msix"
+            "build-script":"sudo apt-get update -qq && sudo apt-get install -y -qq gcc-mingw-w64-x86-64 && mkdir -p packaged-artifacts && printf '%s\\n' 'int main(void) { return 0; }' > /tmp/example-win-test.c && x86_64-w64-mingw32-gcc -O2 /tmp/example-win-test.c -o packaged-artifacts/example-win-test.exe"
           }
         ]}
 
       sign-mac: false
       sign-windows: true
-      win-artifact-glob: "*.exe,*.msi,*.msix"
+      win-artifact-glob: "*.exe"
       win-runs-on: windows-2025
 
       build-script: |

--- a/.github/workflows/reusable_sign-win-artifacts.yaml
+++ b/.github/workflows/reusable_sign-win-artifacts.yaml
@@ -143,6 +143,9 @@ jobs:
               echo "ERROR: CodeSignTool.bat not found in zip" >&2
               exit 1
             fi
+            if command -v cygpath >/dev/null 2>&1; then
+              cst=$(cygpath -u "$cst")
+            fi
           else
             sudo apt-get update -qq
             sudo apt-get install -y -qq default-jre-headless curl unzip

--- a/.github/workflows/reusable_sign-win-artifacts.yaml
+++ b/.github/workflows/reusable_sign-win-artifacts.yaml
@@ -144,6 +144,9 @@ jobs:
               exit 1
             fi
             if command -v cygpath >/dev/null 2>&1; then
+              # CodeSignTool.bat uses .\jdk-... when unset; cwd is the workspace, so Java is not found.
+              # SSL.com documents CODE_SIGN_TOOL_PATH as the extracted bundle root (contains jdk-*, jar/).
+              echo "CODE_SIGN_TOOL_PATH=$(cygpath -wa "$dest")" >> "$GITHUB_ENV"
               cst=$(cygpath -u "$cst")
             fi
           else

--- a/.github/workflows/sign-win-artifacts/README.md
+++ b/.github/workflows/sign-win-artifacts/README.md
@@ -37,6 +37,8 @@ The signing step sets environment variables **`ES_OV_USERNAME`**, **`ES_OV_PASSW
 
 When `dry-run: true`, these secrets may be omitted.
 
+**Windows:** SSL.com’s `CodeSignTool.bat` runs the bundled JRE via paths relative to the **extracted bundle root** only when `CODE_SIGN_TOOL_PATH` is set; otherwise it uses `.\jdk-*`, which resolves against the **process cwd** (often the GitHub workspace, where there is no `jdk-*`). This reusable workflow sets `CODE_SIGN_TOOL_PATH` after unzip. If you call [`entrypoint.sh`](./entrypoint.sh) yourself on Windows, export `CODE_SIGN_TOOL_PATH` to the absolute Windows path of that bundle root (parent of `CodeSignTool.bat`).
+
 ---
 
 ## Example Usage

--- a/.github/workflows/sign-win-artifacts/README.md
+++ b/.github/workflows/sign-win-artifacts/README.md
@@ -39,6 +39,8 @@ When `dry-run: true`, these secrets may be omitted.
 
 **Windows:** SSL.com’s `CodeSignTool.bat` runs the bundled JRE via paths relative to the **extracted bundle root** only when `CODE_SIGN_TOOL_PATH` is set; otherwise it uses `.\jdk-*`, which resolves against the **process cwd** (often the GitHub workspace, where there is no `jdk-*`). This reusable workflow sets `CODE_SIGN_TOOL_PATH` after unzip. If you call [`entrypoint.sh`](./entrypoint.sh) yourself on Windows, export `CODE_SIGN_TOOL_PATH` to the absolute Windows path of that bundle root (parent of `CodeSignTool.bat`).
 
+**`java.io.IOException: DOS header signature not found`:** CodeSignTool is parsing the file as a **PE executable** (`.exe`). The first two bytes must be **`MZ`** (`0x4D 0x5A`). Placeholder or zero-filled files, or non-PE content renamed to `.exe`, will fail. Build a real Windows binary (e.g. MSVC or MinGW) or use a valid test artifact.
+
 ---
 
 ## Example Usage

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -227,6 +227,37 @@ lower_ext() {
     echo "$ext" | tr '[:upper:]' '[:lower:]'
 }
 
+# CodeSignTool / Java Authenticode expects real Windows binaries. Placeholders (e.g. /dev/zero)
+# fail with: java.io.IOException: DOS header signature not found
+preflight_windows_signable() {
+    local path="$1"
+    local ext="$2"
+    case "$ext" in
+    exe)
+        if ! printf '\x4d\x5a' | cmp -s -n 2 - "$path" 2>/dev/null; then
+            echo "ERROR: Not a valid PE executable (missing MZ DOS header): $path" >&2
+            echo "Authenticode (.exe) requires a real Windows binary (e.g. MSVC or MinGW), not empty or arbitrary bytes." >&2
+            return 1
+        fi
+        ;;
+    msi)
+        if ! printf '\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1' | cmp -s -n 8 - "$path" 2>/dev/null; then
+            echo "ERROR: Not a valid MSI (missing compound file / structured storage header): $path" >&2
+            echo "Authenticode (.msi) requires a real Windows Installer database." >&2
+            return 1
+        fi
+        ;;
+    msix)
+        if ! printf '\x50\x4b\x03\x04' | cmp -s -n 4 - "$path" 2>/dev/null; then
+            echo "ERROR: Not a valid MSIX package (expected ZIP local file header at offset 0): $path" >&2
+            echo "Authenticode (.msix) requires a real MSIX (OPC / ZIP-based) file." >&2
+            return 1
+        fi
+        ;;
+    esac
+    return 0
+}
+
 sign_one_file() {
     local file="$1"
     local ext
@@ -249,6 +280,7 @@ sign_one_file() {
     fi
 
     cst=$(resolve_codesigntool)
+    preflight_windows_signable "$file" "$ext" || exit 1
 
     local outdir
     case "$(uname -s 2>/dev/null)" in

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -51,6 +51,9 @@ Environment variables (required when not dry-run):
 Environment variables (optional):
   ESIGNER_PROGRAM_NAME   Passed to CodeSignTool as -program_name for MSI (UAC display name)
   CODESIGNTOOL           Path to CodeSignTool (CodeSignTool.bat on Windows, CodeSignTool.sh on Linux/macOS)
+  CODE_SIGN_TOOL_PATH    (Windows .bat only) Absolute Windows path to the extracted CodeSignTool bundle root
+                         (directory that contains jdk-*, jar/, CodeSignTool.bat). Required when the process
+                         cwd is not that directory; reusable_sign-win-artifacts sets this after unzip.
 
 Examples:
   entrypoint.sh --source-dir unsigned-artifacts --target-dir signed-output
@@ -283,8 +286,17 @@ sign_one_file() {
 
     cmd+=("-output_dir_path=$win_outdir")
 
+    # CodeSignTool.bat runs .\jdk-11...\java when CODE_SIGN_TOOL_PATH is unset; cwd is usually the repo root.
+    case "$(uname -s 2>/dev/null)" in
+    MINGW* | MSYS* | CYGWIN*)
+        if [[ ${cst,,} == *.bat ]]; then
+            export CODE_SIGN_TOOL_PATH
+            CODE_SIGN_TOOL_PATH=$(codesigntool_path_for_args "$(dirname "$cst")")
+        fi
+        ;;
+    esac
+
     echo "  Running CodeSignTool sign for: $file"
-    echo "  ...debug '${cmd[*]}'"
     run "${cmd[@]}"
 
     local base outpath

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -113,21 +113,56 @@ if [[ $DRY_RUN != "true" ]]; then
     done
 fi
 
+# CodeSignTool.bat runs a Windows JVM: -input_file_path / -output_dir_path must be
+# absolute Windows paths. cygpath -w alone keeps relative paths relative; the JVM
+# then resolves them against the wrong working directory ("path not specified").
+codesigntool_path_for_args() {
+    local p="$1"
+    case "$(uname -s 2>/dev/null)" in
+    MINGW* | MSYS* | CYGWIN*)
+        if command -v cygpath >/dev/null 2>&1; then
+            cygpath -wa "$p" 2>/dev/null || cygpath -w "$p" 2>/dev/null || echo "$p"
+        else
+            echo "$p"
+        fi
+        ;;
+    *)
+        echo "$p"
+        ;;
+    esac
+}
+
+# Prefer MSYS-style path so bash can exec CodeSignTool.bat without mixed D:\.../... segments.
+normalize_codesigntool_exe() {
+    local c="$1"
+    case "$(uname -s 2>/dev/null)" in
+    MINGW* | MSYS* | CYGWIN*)
+        if command -v cygpath >/dev/null 2>&1 && [[ -f $c ]]; then
+            cygpath -u "$c" 2>/dev/null || echo "$c"
+        else
+            echo "$c"
+        fi
+        ;;
+    *)
+        echo "$c"
+        ;;
+    esac
+}
+
 resolve_codesigntool() {
+    local c=""
     if [[ -n ${CODESIGNTOOL-} ]]; then
-        echo "$CODESIGNTOOL"
-        return
+        c="$CODESIGNTOOL"
+    elif command -v CodeSignTool.bat >/dev/null 2>&1; then
+        c=$(command -v CodeSignTool.bat)
+    elif command -v CodeSignTool.sh >/dev/null 2>&1; then
+        c=$(command -v CodeSignTool.sh)
+    else
+        echo "ERROR: CodeSignTool not found. Set CODESIGNTOOL or install CodeSignTool.bat / CodeSignTool.sh on PATH." >&2
+        exit 1
     fi
-    if command -v CodeSignTool.bat >/dev/null 2>&1; then
-        command -v CodeSignTool.bat
-        return
-    fi
-    if command -v CodeSignTool.sh >/dev/null 2>&1; then
-        command -v CodeSignTool.sh
-        return
-    fi
-    echo "ERROR: CodeSignTool not found. Set CODESIGNTOOL or install CodeSignTool.bat / CodeSignTool.sh on PATH." >&2
-    exit 1
+
+    normalize_codesigntool_exe "$c"
 }
 
 # --- Glob matching (same semantics as sign-mac-artifacts, plus comma-separated alternates) ---
@@ -212,26 +247,44 @@ sign_one_file() {
 
     cst=$(resolve_codesigntool)
 
+    local outdir
+    case "$(uname -s 2>/dev/null)" in
+    MINGW* | MSYS* | CYGWIN*)
+        if [[ -n ${RUNNER_TEMP-} ]]; then
+            outdir="${RUNNER_TEMP}/signwin-out-$$-${RANDOM}"
+            mkdir -p "$outdir"
+        else
+            outdir=$(mktemp -d)
+        fi
+        ;;
+    *)
+        outdir=$(mktemp -d)
+        ;;
+    esac
+    # shellcheck disable=SC2064
+    trap "rm -rf '$outdir'" RETURN
+
+    local win_file win_outdir
+    win_file=$(codesigntool_path_for_args "$file")
+    win_outdir=$(codesigntool_path_for_args "$outdir")
+
     local -a cmd
     cmd=(
         "$cst" sign
         "-username=$ES_OV_USERNAME"
         "-password=$ES_OV_PASSWORD"
         "-credential_id=$ES_OV_CREDENTIAL_ID"
-        "-input_file_path=$file"
+        "-input_file_path=$win_file"
         "-totp_secret=$ES_OV_TOTP_SECRET"
     )
     if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
         cmd+=("-program_name=$ESIGNER_PROGRAM_NAME")
     fi
 
-    local outdir
-    outdir=$(mktemp -d)
-    # shellcheck disable=SC2064
-    trap "rm -rf '$outdir'" RETURN
-    cmd+=("-output_dir_path=$outdir")
+    cmd+=("-output_dir_path=$win_outdir")
 
     echo "  Running CodeSignTool sign for: $file"
+    echo "  ...debug '${cmd[*]}'"
     run "${cmd[@]}"
 
     local base outpath

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -273,18 +273,18 @@ sign_one_file() {
 
     local -a cmd
     cmd=(
-        "$cst" sign
-        "-username=$ES_OV_USERNAME"
-        "-password=$ES_OV_PASSWORD"
-        "-credential_id=$ES_OV_CREDENTIAL_ID"
-        "-input_file_path=$win_file"
-        "-totp_secret=$ES_OV_TOTP_SECRET"
+        "$cst" "sign"
+        "-username=${ES_OV_USERNAME}"
+        "-password=${ES_OV_PASSWORD}"
+        "-credential_id=${ES_OV_CREDENTIAL_ID}"
+        "-input_file_path=${win_file}"
+        "-totp_secret=${ES_OV_TOTP_SECRET}"
     )
     if [[ $ext == "msi" && -n ${ESIGNER_PROGRAM_NAME-} ]]; then
-        cmd+=("-program_name=$ESIGNER_PROGRAM_NAME")
+        cmd+=("-program_name=${ESIGNER_PROGRAM_NAME}")
     fi
 
-    cmd+=("-output_dir_path=$win_outdir")
+    cmd+=("-output_dir_path=${win_outdir}")
 
     # CodeSignTool.bat runs .\jdk-11...\java when CODE_SIGN_TOOL_PATH is unset; cwd is usually the repo root.
     case "$(uname -s 2>/dev/null)" in

--- a/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
+++ b/.github/workflows/sign-win-artifacts/tests/bats/test_sign_win.bats
@@ -4,6 +4,11 @@
 # Mocks CodeSignTool.sh for Linux CI. Covers argument validation, tree copy,
 # glob filtering, .exe/.msi/.msix signing, and dry-run behavior.
 
+# Minimal file headers so preflight_windows_signable() matches real Windows formats.
+_fake_pe_to() { printf '\x4d\x5a%s' "$1" >"$2"; }
+_fake_msi_to() { printf '\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1%s' "$1" >"$2"; }
+_fake_msix_to() { printf '\x50\x4b\x03\x04%s' "$1" >"$2"; }
+
 setup_file() {
   GIT_ROOT="$(git rev-parse --show-toplevel)"
   export GIT_ROOT
@@ -61,6 +66,15 @@ setup() {
   export CODESIGNTOOL="$MOCK_BIN/CodeSignTool.sh"
 }
 
+@test "entrypoint rejects .exe without PE MZ header" {
+  echo "not-a-pe" > "$SOURCE_DIR/bad.exe"
+
+  run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"MZ DOS header"* ]]
+}
+
 # --- Argument parsing tests ---
 
 @test "entrypoint fails without --source-dir" {
@@ -114,7 +128,7 @@ setup() {
 }
 
 @test "only glob-matched exe is signed in non-dry-run" {
-  echo "fake-exe" > "$SOURCE_DIR/app.exe"
+  _fake_pe_to "fake-exe" "$SOURCE_DIR/app.exe"
   echo "fake-deb" > "$SOURCE_DIR/app.deb"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" \
@@ -123,13 +137,13 @@ setup() {
   [ "$status" -eq 0 ]
   grep -q "CodeSignTool.*sign" "$TEST_TMPDIR/commands.log"
   ! grep -q "app.deb" "$TEST_TMPDIR/commands.log"
-  [[ "$(cat "$TARGET_DIR/app.exe")" == "fake-exe" ]]
+  [[ "$(cat "$TARGET_DIR/app.exe")" == "$(printf '\x4d\x5a%s' 'fake-exe')" ]]
 }
 
 @test "comma-separated artifact-glob signs multiple Windows types" {
-  echo "fake-exe" > "$SOURCE_DIR/app.exe"
-  echo "fake-msi" > "$SOURCE_DIR/setup.msi"
-  echo "fake-msix" > "$SOURCE_DIR/bundle.msix"
+  _fake_pe_to "fake-exe" "$SOURCE_DIR/app.exe"
+  _fake_msi_to "fake-msi" "$SOURCE_DIR/setup.msi"
+  _fake_msix_to "fake-msix" "$SOURCE_DIR/bundle.msix"
   echo "fake-deb" > "$SOURCE_DIR/app.deb"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR" \
@@ -143,7 +157,7 @@ setup() {
 }
 
 @test ".exe is signed with CodeSignTool" {
-  echo "payload" > "$SOURCE_DIR/tool.exe"
+  _fake_pe_to "payload" "$SOURCE_DIR/tool.exe"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
 
@@ -152,7 +166,7 @@ setup() {
 }
 
 @test ".msi is signed with CodeSignTool" {
-  echo "msi-payload" > "$SOURCE_DIR/setup.msi"
+  _fake_msi_to "msi-payload" "$SOURCE_DIR/setup.msi"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
 
@@ -161,7 +175,7 @@ setup() {
 }
 
 @test ".msi receives -program_name when ESIGNER_PROGRAM_NAME is set" {
-  echo "msi" > "$SOURCE_DIR/setup.msi"
+  _fake_msi_to "msi" "$SOURCE_DIR/setup.msi"
   export ESIGNER_PROGRAM_NAME="Contoso Setup"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
@@ -171,7 +185,7 @@ setup() {
 }
 
 @test ".exe does not receive -program_name when ESIGNER_PROGRAM_NAME is set" {
-  echo "bin" > "$SOURCE_DIR/app.exe"
+  _fake_pe_to "bin" "$SOURCE_DIR/app.exe"
   export ESIGNER_PROGRAM_NAME="Contoso Setup"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
@@ -181,13 +195,13 @@ setup() {
 }
 
 @test ".msix is signed with CodeSignTool" {
-  echo "msix-payload" > "$SOURCE_DIR/bundle.msix"
+  _fake_msix_to "msix-payload" "$SOURCE_DIR/bundle.msix"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
 
   [ "$status" -eq 0 ]
   grep -q "CodeSignTool.*sign.*-input_file_path=.*bundle.msix" "$TEST_TMPDIR/commands.log"
-  [[ "$(cat "$TARGET_DIR/bundle.msix")" == "msix-payload" ]]
+  [[ "$(cat "$TARGET_DIR/bundle.msix")" == "$(printf '\x50\x4b\x03\x04%s' 'msix-payload')" ]]
 }
 
 @test ".msix dry-run invokes redacted CodeSignTool line" {
@@ -232,7 +246,7 @@ setup() {
 }
 
 @test "uppercase extension .EXE is signed" {
-  echo "data" > "$SOURCE_DIR/TOOL.EXE"
+  _fake_pe_to "data" "$SOURCE_DIR/TOOL.EXE"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
 
@@ -242,7 +256,7 @@ setup() {
 
 @test ".asc files are ignored for signing" {
   echo "sig" > "$SOURCE_DIR/file.asc"
-  echo "exe" > "$SOURCE_DIR/file.exe"
+  _fake_pe_to "exe" "$SOURCE_DIR/file.exe"
 
   run "$ENTRYPOINT" --source-dir "$SOURCE_DIR" --target-dir "$TARGET_DIR"
 

--- a/.github/workflows/test_sign-win-artifacts-smoke.yaml
+++ b/.github/workflows/test_sign-win-artifacts-smoke.yaml
@@ -28,9 +28,12 @@ jobs:
           TEST_VERSION: 0.0.0-smoke
         run: |
           set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gcc-mingw-w64-x86-64
           mkdir -p test-artifacts
-          head -c 2048 /dev/zero > "test-artifacts/smoke-win-${TEST_VERSION}.exe"
-          head -c 2048 /dev/zero > "test-artifacts/smoke-win-${TEST_VERSION}.msi"
+          # Minimal valid PE via MinGW (unsigned). MSI omitted — real MSIs need WiX/msbuild.
+          printf '%s\n' 'int main(void) { return 0; }' > /tmp/smoke-win.c
+          x86_64-w64-mingw32-gcc -O2 /tmp/smoke-win.c -o "test-artifacts/smoke-win-${TEST_VERSION}.exe"
 
       - name: Upload unsigned artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -45,7 +48,7 @@ jobs:
       gh-unsigned-artifacts: build-artifacts
       gh-workflows-ref: ${{ github.sha }}
       signing-identity: ${{ vars.WIN_SIGNING_PROGRAM_NAME }}
-      artifact-glob: "*.exe,*.msi"
+      artifact-glob: "*.exe"
       dry-run: false
       runs-on: windows-2025
     secrets:


### PR DESCRIPTION
Fix path handling in case CodeSigning would be running in either windows or linux runner