### PR TITLE
chore(test): unpin test_execute-build-dotnet from v2.0.2

### DIFF
--- a/.github/workflows/test_execute-build-dotnet.yaml
+++ b/.github/workflows/test_execute-build-dotnet.yaml
@@ -1,6 +1,8 @@
 name: Test Execute Build Dotnet Workflow
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/test_execute-build-dotnet.yaml
+++ b/.github/workflows/test_execute-build-dotnet.yaml
@@ -31,4 +31,4 @@ jobs:
       oidc-provider-name: gh-dev-test
       oidc-audience: aerospike/testing
       dry-run: false
-      gh-workflows-ref: v2.0.2
+      gh-workflows-ref: ${{ github.sha }}


### PR DESCRIPTION
Two related defects in `test_execute-build-dotnet.yaml`:

1. `gh-workflows-ref` was pinned to `v2.0.2`, so reusable code changes in any later release ran against the wrong version. Surfaced when [#237](https://github.com/aerospike/shared-workflows/pull/237) added `parse-build-env.sh` (not present in v2.0.2). Switching to `${{ github.sha }}` matches every other test/example workflow.
2. The trigger was `push: branches: [main]` only, so breakage from the above only showed up after merge instead of on the PR. Adding `pull_request: branches: [main]` (matching the sibling `test_execute-build-workflow.yaml`).

## Test plan

- This PR's own pull_request trigger now exercises the dotnet path under the branch's SHA. If the run is green here, both defects are addressed.
