### PR TITLE
ci: temporary ES_OV_USERNAME length probe (do not merge)

### DIFF
--- a/.github/workflows/debug-es-ov-username-length.yaml
+++ b/.github/workflows/debug-es-ov-username-length.yaml
@@ -1,4 +1,4 @@
-name: Debug ES_OV username length
+name: Debug ES_OV secret fingerprints
 on:
   pull_request:
     branches: [main]
@@ -7,9 +7,17 @@ permissions:
   contents: read
 
 jobs:
-  length:
+  fingerprints:
     runs-on: ubuntu-22.04
     steps:
       - env:
           ES_OV_USERNAME: ${{ secrets.ES_OV_USERNAME }}
-        run: printf 'ES_OV_USERNAME len=%d\n' "${#ES_OV_USERNAME}"
+          ES_OV_PASSWORD: ${{ secrets.ES_OV_PASSWORD }}
+          ES_OV_CREDENTIAL_ID: ${{ secrets.ES_OV_CREDENTIAL_ID }}
+          ES_OV_TOTP_SECRET: ${{ secrets.ES_OV_TOTP_SECRET }}
+        run: |
+          h() { printf '%s' "$1" | sha256sum | awk '{print $1}'; }
+          printf 'ES_OV_USERNAME       sha256=%s\n' "$(h "$ES_OV_USERNAME")"
+          printf 'ES_OV_PASSWORD       sha256=%s\n' "$(h "$ES_OV_PASSWORD")"
+          printf 'ES_OV_CREDENTIAL_ID  sha256=%s\n' "$(h "$ES_OV_CREDENTIAL_ID")"
+          printf 'ES_OV_TOTP_SECRET    sha256=%s\n' "$(h "$ES_OV_TOTP_SECRET")"

--- a/.github/workflows/debug-es-ov-username-length.yaml
+++ b/.github/workflows/debug-es-ov-username-length.yaml
@@ -1,0 +1,15 @@
+name: Debug ES_OV username length
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  length:
+    runs-on: ubuntu-22.04
+    steps:
+      - env:
+          ES_OV_USERNAME: ${{ secrets.ES_OV_USERNAME }}
+        run: printf 'ES_OV_USERNAME len=%d\n' "${#ES_OV_USERNAME}"


### PR DESCRIPTION
Print length of aerospike org's ES_OV_USERNAME for comparison with citrusleaf org (citrusleaf showed 11 chars, suspicious). Will close once we have the number.