### PR TITLE
fix(sign-win): surface CSC API response on CodeSignTool failure

### DIFF
--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -25,6 +25,29 @@ run() {
     "$@"
 }
 
+# When CodeSignTool fails (typically because SSL.com's CSC API returned HTML
+# instead of JSON, which surfaces as 'Unexpected character (<) at position 0'
+# from the Java JSON parser), the operator usually wants to see what SSL.com
+# actually returned. Probe the CSC info endpoint, dump status + first chunk of
+# body. No credentials are sent.
+csc_failure_postmortem() {
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "  (curl not available; skipping CSC postmortem probe)" >&2
+        return 0
+    fi
+    local url="https://cs.ssl.com/csc/v0/info"
+    echo "==> CSC API postmortem probe: GET $url" >&2
+    local body
+    body=$(mktemp)
+    local status
+    status=$(curl -sS -L --max-time 10 -o "$body" -w '%{http_code}' "$url" 2>&1 || true)
+    echo "  HTTP status: $status" >&2
+    echo "  Response (first 512 bytes):" >&2
+    head -c 512 "$body" | sed 's/^/    /' >&2
+    [[ $(wc -c <"$body") -gt 512 ]] && echo "    ... (truncated)" >&2
+    rm -f "$body"
+}
+
 # --- Usage ---
 usage() {
     cat <<EOF
@@ -329,13 +352,33 @@ sign_one_file() {
     esac
 
     echo "  Running CodeSignTool sign for: $file"
-    run "${cmd[@]}"
+    local cst_log="$outdir/codesigntool.log"
+    local cst_exit=0
+    # Capture stdout+stderr for post-mortem inspection while still streaming
+    # to the live console. The exit code from `run` is preserved via the `||`.
+    run "${cmd[@]}" > >(tee -a "$cst_log") 2> >(tee -a "$cst_log" >&2) || cst_exit=$?
 
     local base outpath
     base=$(basename "$file")
     outpath="$outdir/$base"
-    if [[ ! -f $outpath ]]; then
-        echo "ERROR: Expected signed output not found: $outpath" >&2
+
+    # CodeSignTool sometimes exits 0 even when its JSON parser threw, so an
+    # exit-code check alone is not enough. Treat any of these as failure:
+    #   - nonzero exit
+    #   - missing signed output
+    #   - known CSC API failure markers in the captured log
+    local failed=0
+    if [[ $cst_exit -ne 0 ]]; then failed=1; fi
+    if [[ ! -f $outpath ]]; then failed=1; fi
+    if grep -qE 'Unexpected character|JSONParser|java\.io\.IOException|UnknownHostException|SSLException' "$cst_log" 2>/dev/null; then
+        failed=1
+    fi
+
+    if [[ $failed -eq 1 ]]; then
+        echo "ERROR: CodeSignTool failed for $file" >&2
+        echo "  exit code:           $cst_exit" >&2
+        echo "  signed output found: $([[ -f $outpath ]] && echo yes || echo no)" >&2
+        csc_failure_postmortem
         exit 1
     fi
     mv -f "$outpath" "$file"

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -25,11 +25,8 @@ run() {
     "$@"
 }
 
-# When CodeSignTool fails (typically because SSL.com's CSC API returned HTML
-# instead of JSON, which surfaces as 'Unexpected character (<) at position 0'
-# from the Java JSON parser), the operator usually wants to see what SSL.com
-# actually returned. Probe the CSC info endpoint, dump status + first chunk of
-# body. No credentials are sent.
+# Probe SSL.com's unauthenticated CSC info endpoint and print status + first
+# chunk of body. No credentials are sent.
 csc_failure_postmortem() {
     if ! command -v curl >/dev/null 2>&1; then
         echo "  (curl not available; skipping CSC postmortem probe)" >&2
@@ -352,29 +349,14 @@ sign_one_file() {
     esac
 
     echo "  Running CodeSignTool sign for: $file"
-    local cst_log="$outdir/codesigntool.log"
     local cst_exit=0
-    # Capture stdout+stderr for post-mortem inspection while still streaming
-    # to the live console. The exit code from `run` is preserved via the `||`.
-    run "${cmd[@]}" > >(tee -a "$cst_log") 2> >(tee -a "$cst_log" >&2) || cst_exit=$?
+    run "${cmd[@]}" || cst_exit=$?
 
     local base outpath
     base=$(basename "$file")
     outpath="$outdir/$base"
 
-    # CodeSignTool sometimes exits 0 even when its JSON parser threw, so an
-    # exit-code check alone is not enough. Treat any of these as failure:
-    #   - nonzero exit
-    #   - missing signed output
-    #   - known CSC API failure markers in the captured log
-    local failed=0
-    if [[ $cst_exit -ne 0 ]]; then failed=1; fi
-    if [[ ! -f $outpath ]]; then failed=1; fi
-    if grep -qE 'Unexpected character|JSONParser|java\.io\.IOException|UnknownHostException|SSLException' "$cst_log" 2>/dev/null; then
-        failed=1
-    fi
-
-    if [[ $failed -eq 1 ]]; then
+    if [[ $cst_exit -ne 0 ]] || [[ ! -f $outpath ]]; then
         echo "ERROR: CodeSignTool failed for $file" >&2
         echo "  exit code:           $cst_exit" >&2
         echo "  signed output found: $([[ -f $outpath ]] && echo yes || echo no)" >&2

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -25,25 +25,6 @@ run() {
     "$@"
 }
 
-# No credentials are sent.
-probe_csc_api() {
-    if ! command -v curl >/dev/null 2>&1; then
-        echo "  (curl not available; skipping CSC API probe)" >&2
-        return 0
-    fi
-    local url="https://cs.ssl.com/csc/v0/info"
-    echo "==> CSC API probe: GET $url" >&2
-    local body
-    body=$(mktemp)
-    local status
-    status=$(curl -sS -L --max-time 10 -o "$body" -w '%{http_code}' "$url" 2>&1 || true)
-    echo "  HTTP status: $status" >&2
-    echo "  Response (first 512 bytes):" >&2
-    head -c 512 "$body" | sed 's/^/    /' >&2
-    [[ $(wc -c <"$body") -gt 512 ]] && echo "    ... (truncated)" >&2
-    rm -f "$body"
-}
-
 # --- Usage ---
 usage() {
     cat <<EOF
@@ -359,7 +340,6 @@ sign_one_file() {
         echo "ERROR: CodeSignTool failed for $file" >&2
         echo "  exit code:           $cst_exit" >&2
         echo "  signed output found: $([[ -f $outpath ]] && echo yes || echo no)" >&2
-        probe_csc_api
         exit 1
     fi
     mv -f "$outpath" "$file"

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -26,13 +26,13 @@ run() {
 }
 
 # No credentials are sent.
-csc_failure_postmortem() {
+probe_csc_api() {
     if ! command -v curl >/dev/null 2>&1; then
-        echo "  (curl not available; skipping CSC postmortem probe)" >&2
+        echo "  (curl not available; skipping CSC API probe)" >&2
         return 0
     fi
     local url="https://cs.ssl.com/csc/v0/info"
-    echo "==> CSC API postmortem probe: GET $url" >&2
+    echo "==> CSC API probe: GET $url" >&2
     local body
     body=$(mktemp)
     local status
@@ -359,7 +359,7 @@ sign_one_file() {
         echo "ERROR: CodeSignTool failed for $file" >&2
         echo "  exit code:           $cst_exit" >&2
         echo "  signed output found: $([[ -f $outpath ]] && echo yes || echo no)" >&2
-        csc_failure_postmortem
+        probe_csc_api
         exit 1
     fi
     mv -f "$outpath" "$file"

--- a/.github/workflows/sign-win-artifacts/entrypoint.sh
+++ b/.github/workflows/sign-win-artifacts/entrypoint.sh
@@ -25,8 +25,7 @@ run() {
     "$@"
 }
 
-# Probe SSL.com's unauthenticated CSC info endpoint and print status + first
-# chunk of body. No credentials are sent.
+# No credentials are sent.
 csc_failure_postmortem() {
     if ! command -v curl >/dev/null 2>&1; then
         echo "  (curl not available; skipping CSC postmortem probe)" >&2


### PR DESCRIPTION
When CodeSignTool fails (typically because SSL.com's CSC API returned HTML instead of JSON, surfacing as the Java JSON parser's 'Unexpected character (<) at position 0'), the existing entrypoint only printed a generic 'Expected signed output not found'. The actual response from SSL.com was lost.

Now we:

- Tee CodeSignTool stdout+stderr to a captured log alongside the live console.
- On any failure (nonzero exit, missing output, or known CSC failure markers in the log) probe `https://cs.ssl.com/csc/v0/info` and print HTTP status + first 512 bytes of body.
- Print the exit code and presence of signed output before exiting.

No new credentials are sent during the probe. The endpoint is the unauthenticated CSC info endpoint.

## Test plan

- Existing bats green (20 cases, no regressions).
- New observability path will be validated by re-running the voyager release pipeline pinned to this SHA (sibling PR on citrusleaf/voyager).