### PR TITLE
docs(workflows): refresh CI/CD docs and READMEs for current features

### DIFF
--- a/.github/actions/detect-artifacts/README.md
+++ b/.github/actions/detect-artifacts/README.md
@@ -1,13 +1,13 @@
 # Detect artifact types
 
-Runs [`detect_types.sh`](../../workflows/deploy-artifacts/detect_types.sh): content-based detection for ambiguous archives (npm tarballs, PyPI sdists, Go module zips) and writes `structured_build_artifacts/` plus a manifest, matching the deploy entrypoint’s detection phase. JFrog/build metadata is not required because detection only inspects file contents and copies into the structured tree.
+Runs [`detect_types.sh`](../../workflows/deploy-artifacts/detect_types.sh): content-based detection for ambiguous archives (npm tarballs, PyPI sdists, Go module zips, Helm charts) plus structured passes for PyPI wheels, NuGet packages, Maven POMs, and Docker bundle metadata, and writes `structured_build_artifacts/` plus a manifest, matching the deploy entrypoint’s detection phase. JFrog/build metadata is not required because detection only inspects file contents and copies into the structured tree.
 
 ## Prerequisites
 
 - Merged build tree on disk (for example from [`collect-build-artifacts`](../collect-build-artifacts) or a `download-artifact` step with the same layout).
-- `detect_types.sh` and sibling scripts (`package_utils.sh`, `type_registry.sh`, `upload_utils.sh`, `type_detection.sh`) available. Checkout **shared-workflows** at `gh-workflows-ref` (full or sparse-checkout including `.github/workflows/deploy-artifacts/`).
+- `detect_types.sh` and its sibling scripts (`package_utils.sh`, `type_registry.sh`, `upload_utils.sh`, `type_detection.sh`) plus `../lib/helm-helpers.sh` (sourced for Helm chart detection) available. Checkout **shared-workflows** at `gh-workflows-ref` (full or sparse-checkout including both `.github/workflows/deploy-artifacts/` and `.github/workflows/lib/`).
 
-Runner tools used by detectors: `jq`, `tar`, `unzip` (typical GitHub-hosted Ubuntu images include these).
+Runner tools used by detectors: `jq`, `tar`, `unzip`, `xmllint` (for Maven POM detection). Typical GitHub-hosted Ubuntu images include these.
 
 ## Inputs
 

--- a/.github/actions/promote-release-bundle/README.md
+++ b/.github/actions/promote-release-bundle/README.md
@@ -1,6 +1,6 @@
 # Promote Release Bundle
 
-Promote a JFrog release bundle to a target environment (DEV, TEST, STAGE, PROD, etc.).
+Promote a JFrog release bundle to a target promotion stage (DEV, TEST, STAGE, PROD, etc.).
 
 ## Prerequisites
 
@@ -8,12 +8,14 @@ JFrog CLI must be configured before calling this action (via `setup-jfrog-cli`).
 
 ## Inputs
 
-| Input         | Required | Description                                       |
-| ------------- | -------- | ------------------------------------------------- |
-| `bundle-name` | Yes      | Release bundle name                               |
-| `version`     | Yes      | Release bundle version to promote                 |
-| `environment` | Yes      | Target environment (DEV, TEST, STAGE, PROD, etc.) |
-| `jf-project`  | Yes      | JFrog project key                                 |
+| Input           | Required | Description                                                                     |
+| --------------- | -------- | ------------------------------------------------------------------------------- |
+| `bundle-name`   | Yes      | Release bundle name                                                             |
+| `version`       | Yes      | Release bundle version to promote                                               |
+| `environment`   | Yes      | Target promotion stage (DEV, TEST, STAGE, PROD, etc.)                           |
+| `jf-project`    | Yes      | JFrog project key                                                               |
+| `include-repos` | No       | Semicolon-separated list of target repos to include in promotion (limits scope) |
+| `exclude-repos` | No       | Semicolon-separated list of target repos to exclude from promotion              |
 
 ## Example Usage
 

--- a/.github/actions/setup-gpg/README.md
+++ b/.github/actions/setup-gpg/README.md
@@ -1,14 +1,31 @@
 # Setup GPG composite Action
 
-This composite action will setup your github action to use a supplied gpg key.
+This composite action imports a supplied GPG key and configures the runner for non-interactive GPG signing and RPM package signing in subsequent steps.
 
-## Supported Platforms
+## Requirements
 
-- GPG
-- rpmsign/rpm
-- debsign
+- **Ubuntu 22.04 only.** The action checks the runner OS and fails on any other version.
 
-If you need a platform not listed above, please contact the maintainers!
+## What it does
+
+- Installs `gnupg`, `rpm`, and supporting tools.
+- Imports the private key, sets it as the default key, and configures loopback pinentry plus a passphrase file for batch (non-interactive) signing.
+- Writes `~/.rpmmacros` so `rpm --addsign` works with the imported key.
+- Imports the public key for verification.
+
+## Inputs
+
+| Input             | Required | Description                                              |
+| ----------------- | -------- | -------------------------------------------------------- |
+| `gpg-private-key` | Yes      | GPG private key (ASCII-armored) to import for signing    |
+| `gpg-key-pass`    | Yes      | Passphrase for the private key                           |
+| `gpg-public-key`  | Yes      | GPG public key (ASCII-armored) imported for verification |
+
+The signing key name and fingerprint are extracted automatically from the imported key; there is no key-name input.
+
+## Outputs
+
+This action produces no outputs. It configures GPG, the RPM signing macros, and gpg-agent for use by later steps in the same job.
 
 ## Example Usage
 
@@ -16,42 +33,16 @@ If you need a platform not listed above, please contact the maintainers!
 on: [push]
 
 jobs:
-  hello_world_job:
-    runs-on: ubuntu-latest
-    name: A job to say hello
+  sign:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - id: foo
-        uses: aerospike/shared-workflows/devops/setup-gpg@latest
-        with:
-          gpg-private-key: ${{ secret.gpg_key }}
-          gpg-key-pass: ${{ secret.gpg_pass }}
-          gpg-key-name: "Aerospike"
-```
-
-### Example RPM and GPG usage
-
-```yaml
-name: GPG sign rpm
-on: workflow_dispatch
-jobs:
-  signing:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Install GPG
-        run: sudo apt-get update && sudo apt-get install gnupg -y
-      - name: setup GPG
-        uses: aerospike/shared-workflows/devops/setup-gpg@feat/setup-gpg-composite
+      - name: Set up GPG
+        uses: aerospike/shared-workflows/.github/actions/setup-gpg@v3
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-key-pass: ${{ secrets.GPG_PASS }}
-          gpg-key-name: "aerospiketest"
-      - name: Sign RPM Package
-        env:
-          GPG_TTY: no-tty
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASS }}
-        run: |
-          # sign a gpg
-          gpg --detach-sign --no-tty --batch --yes --passphrase "$GPG_PASSPHRASE" my.rpm
+          gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
+      - name: Sign an RPM
+        run: rpm --addsign my-package.rpm
 ```

--- a/.github/workflows/artifacts-cicd/README.md
+++ b/.github/workflows/artifacts-cicd/README.md
@@ -15,21 +15,23 @@ The other approach is the composable pipeline See [CICD-composable.md](https://g
 ```yaml
 jobs:
   ci:
-    uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@v2.0.3
+    uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@v3.2.0
     with:
-      gh-workflows-ref: v2.0.3
+      gh-workflows-ref: v3.2.0
       jf-project: my-project
       jf-build-name: my-app
       version: 1.2.3
       gh-artifact-directory: dist
-      build-script: |
+      oidc-audience: aerospike # Required
+      oidc-provider-name: gh-aerospike # Required
+      build-script: | # Provide build-script OR build-script-path, not both
         make build
       # Optional:
       build-type: release # Freeform label, applied as build.type target-prop
       internal: false # Set true to mark artifacts as internal-only
       # Java/Maven (passed through to execute-build):
       setup-java: true
-      java-version: "8"
+      java-version: "21"
       java-distribution: temurin
     secrets: inherit
 ```
@@ -48,7 +50,10 @@ The deploy stage automatically routes artifacts by file extension:
 | PyPI    | `pypi-dev-local`    | `version`, `package_name`, `pypi.name`, `pypi.version`                             |
 | Go      | `go-dev-local`      | `version`, `package_name`, `go.module`, `go.version`                               |
 | Helm    | `helm-dev-local`    | `version`, `package_name`, `helm.name`, `helm.version`                             |
+| Windows | `generic-dev-local` | `version`, `package_name`                                                          |
 | Generic | `generic-dev-local` | `version`, `package_name`                                                          |
+
+Windows executables (`.exe`, `.msi`, `.msix`) are detected by extension and routed to the generic repository; enable Authenticode signing for them with `sign-windows`. macOS `.pkg` installers produced by `sign-mac` are likewise uploaded as generic artifacts.
 
 Companion files (`.asc` signatures, `.pom` files, helm `.prov` provenance) are automatically gathered alongside their parent artifacts. Helm registers `.prov` (helm-native provenance signature) as its companion; the orphan `.tgz.asc` produced by GPG sign-artifacts is intentionally not gathered or uploaded for helm charts because `.prov` is the canonical chart signature.
 
@@ -74,7 +79,10 @@ Chart linting and unit testing are the user's responsibility. Suggestion is to r
 - When **`sign-windows: true`**, pass **`es_ov_username`**, **`es_ov_password`**, **`es_ov_credential_id`**, and **`es_ov_totp_secret`** into this workflow (for example from repository secrets **`ES_OV_USERNAME`**, **`ES_OV_PASSWORD`**, **`ES_OV_CREDENTIAL_ID`**, **`ES_OV_TOTP_SECRET`**). NuGet signing in the same pipeline still uses **`es-username`**, **`es-password`**, **`credential_id`**, and **`es-totp_secret`**.
 - The workflow generates a parent build-id automatically.
 - All artifacts get `version` and `package_name` target-props. Use `build-type` and `internal` for additional categorization.
-- **Java/Maven:** Set `setup-java: true` and optionally `java-version` (e.g. `"8"`, `"17"`), `java-distribution` (default `temurin`), and `java-cache` (default `maven`). These are passed through to the build step so Java is set up before your `build-script` runs. Matrix entries can override them per build (e.g. `setup-java: true`, `java-version: "17"`).
+- **OIDC:** `oidc-audience` and `oidc-provider-name` are required. Aerospike consumers normally use `oidc-audience: aerospike` and `oidc-provider-name: gh-aerospike`.
+- **Build script:** Provide either `build-script` (inline) or `build-script-path` (path to a script file), not both.
+- **build-env:** Optional semicolon-delimited `KEY=VALUE` pairs exported into the build script's environment (use `\;` for a literal semicolon). Matrix-level `build-env` merges with the top-level value rather than replacing it.
+- **Language/tool setup:** Set `setup-java: true` and optionally `java-version` (default `"21"`), `java-distribution` (default `temurin`), and `java-cache` (default `maven`). The same passthrough exists for `setup-dotnet` (`dotnet-version`, default `8.0`), `setup-python` (`python-version`, default `3.12`), and `setup-helm` (`helm-version`, default `latest`). Each toolchain is set up before your `build-script` runs. Matrix entries can override these per build.
 
 ## Testing
 

--- a/.github/workflows/create-release-bundle/README.md
+++ b/.github/workflows/create-release-bundle/README.md
@@ -8,19 +8,19 @@ This workflow creates JFrog release bundles by bundling one or more builds into 
 
 ## Inputs
 
-| Input                | Description                                                | Required | Default                         |
-| -------------------- | ---------------------------------------------------------- | -------- | ------------------------------- |
-| `jf-project`         | JFrog Artifactory project name                             | Yes      | -                               |
-| `jf-build-names`     | Comma-separated list of build names to include             | Yes      | -                               |
-| `jf-bundle-name`     | Name for the release bundle                                | Yes      | -                               |
-| `version`            | Version of the release bundle                              | Yes      | -                               |
-| `jf-url`             | JFrog Artifactory URL                                      | No       | `https://artifact.aerospike.io` |
-| `oidc-provider-name` | OIDC provider name for authentication                      | No       | `gh-aerospike`                  |
-| `oidc-audience`      | OIDC audience for authentication                           | No       | `aerospike`                     |
-| `runs-on`            | The runner to use for the build                            | No       | `ubuntu-22.04`                  |
-| `gh-checkout-path`   | Directory to checkout the shared-workflows repository into | No       | `shared-workflows`              |
-| `gh-workflows-ref`   | Git ref for shared-workflows (**should match `uses:`**)    | Yes      | -                               |
-| `dry-run`            | Whether to run in dry-run mode                             | No       | `false`                         |
+| Input                | Description                                                                                                 | Required | Default                         |
+| -------------------- | ----------------------------------------------------------------------------------------------------------- | -------- | ------------------------------- |
+| `jf-project`         | JFrog Artifactory project name                                                                              | Yes      | -                               |
+| `jf-build-names`     | Comma-separated list of `build-name:version` pairs to include (e.g. `"app-build:1.2.3,client-build:2.1.0"`) | Yes      | -                               |
+| `jf-bundle-name`     | Name for the release bundle                                                                                 | Yes      | -                               |
+| `version`            | Version of the release bundle                                                                               | Yes      | -                               |
+| `jf-url`             | JFrog Artifactory URL                                                                                       | No       | `https://artifact.aerospike.io` |
+| `oidc-provider-name` | OIDC provider name for authentication                                                                       | No       | `gh-aerospike`                  |
+| `oidc-audience`      | OIDC audience for authentication                                                                            | No       | `aerospike`                     |
+| `runs-on`            | The runner to use for the build                                                                             | No       | `ubuntu-22.04`                  |
+| `gh-checkout-path`   | Directory to checkout the shared-workflows repository into                                                  | No       | `shared-workflows`              |
+| `gh-workflows-ref`   | Git ref for shared-workflows (**should match `uses:`**)                                                     | Yes      | -                               |
+| `dry-run`            | Whether to run in dry-run mode                                                                              | No       | `false`                         |
 
 ## Example Usage
 
@@ -37,13 +37,13 @@ on:
 
 jobs:
   create-release-bundle:
-    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v2.0.2
+    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.2.0
     with:
       jf-project: database
-      jf-build-names: "database-build,client-build"
+      jf-build-names: "database-build:1.2.3,client-build:2.1.0"
       jf-bundle-name: database-release
       version: ${{ github.ref_name }}
-      gh-workflows-ref: v2.0.2 # Should match the version in your 'uses:' line
+      gh-workflows-ref: v3.2.0 # Should match the version in your 'uses:' line
       dry-run: false
 ```
 

--- a/.github/workflows/deploy-artifacts/README.md
+++ b/.github/workflows/deploy-artifacts/README.md
@@ -15,6 +15,7 @@ A reusable GitHub Actions workflow for uploading build artifacts to JFrog Artifa
 | npm (.tgz)                | `{project}-npm-dev-local`     | `.asc`                     | `version`, `package_name`                                                          |
 | PyPI (.whl/.tar.gz sdist) | `{project}-pypi-dev-local`    | `.asc`                     | `version`, `package_name`, `pypi.name`, `pypi.version`                             |
 | Go module (.zip)          | `{project}-go-dev-local`      | `.asc`                     | `version`, `package_name`, `go.module`, `go.version`                               |
+| Helm chart (.tgz)         | `{project}-helm-dev-local`    | `.prov`                    | `version`, `package_name`, `helm.name`, `helm.version`                             |
 | Windows (.exe/.msi/.msix) | `{project}-generic-dev-local` | `.asc`                     | `version`, `package_name` (same repo as generic)                                   |
 | Generic (everything else) | `{project}-generic-dev-local` | `.asc`                     | `version`, `package_name`                                                          |
 
@@ -42,25 +43,25 @@ The deploy pipeline uses a centralized type registry (`type_registry.sh`). To ad
 
 ## Inputs
 
-| Input                  | Description                                                                 | Required | Default                         |
-| ---------------------- | --------------------------------------------------------------------------- | -------- | ------------------------------- |
-| `jf-project`           | JFrog Artifactory project name                                              | Yes      | -                               |
-| `jf-build-name`        | JFrog build name                                                            | Yes      | -                               |
-| `jf-build-id`          | JFrog build ID for the overall build info                                   | Yes      | -                               |
-| `jf-metadata-build-id` | JFrog build ID for the build metadata                                       | Yes      | -                               |
-| `version`              | Version string for build info                                               | Yes      | -                               |
-| `gh-workflows-ref`     | Git ref for shared-workflows (**must match `uses:`**)                       | Yes      | -                               |
-| `build-type`           | Freeform label applied as `build.type` target-prop (e.g., release, nightly) | No       | `""`                            |
-| `internal`             | Mark artifacts as internal-only (`internal=true` target-prop)               | No       | `false`                         |
-| `dry-run`              | Show what would be uploaded without uploading                               | No       | `false`                         |
-| `jar-group-id`         | Maven group ID fallback for JAR artifacts                                   | No       | `""`                            |
-| `gh-artifact-name`     | Name of the artifacts to download                                           | No       | `signed-artifacts`              |
-| `gh-checkout-path`     | Directory to checkout shared-workflows into                                 | No       | `shared-workflows`              |
-| `gh-retention-days`    | Retention days for the artifacts                                            | No       | `1`                             |
-| `jf-url`               | JFrog Artifactory URL                                                       | No       | `https://artifact.aerospike.io` |
-| `oidc-provider-name`   | OIDC provider name for authentication                                       | No       | `gh-aerospike`                  |
-| `oidc-audience`        | OIDC audience for authentication                                            | No       | `aerospike`                     |
-| `runs-on`              | The runner to use                                                           | No       | `ubuntu-22.04`                  |
+| Input                  | Description                                                                                                                                                                                          | Required | Default                         |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------- |
+| `jf-project`           | JFrog Artifactory project name                                                                                                                                                                       | Yes      | -                               |
+| `jf-build-name`        | JFrog build name                                                                                                                                                                                     | Yes      | -                               |
+| `jf-build-id`          | JFrog build ID for the overall build info                                                                                                                                                            | Yes      | -                               |
+| `jf-metadata-build-id` | Build ID prefix used to discover child build-infos for aggregation (searches for `<prefix>*.json`). When empty, child build-info aggregation is skipped and only the parent build-info is published. | No       | `""`                            |
+| `version`              | Version string for build info                                                                                                                                                                        | Yes      | -                               |
+| `gh-workflows-ref`     | Git ref for shared-workflows (**must match `uses:`**)                                                                                                                                                | Yes      | -                               |
+| `build-type`           | Freeform label applied as `build.type` target-prop (e.g., release, nightly)                                                                                                                          | No       | `""`                            |
+| `internal`             | Mark artifacts as internal-only (`internal=true` target-prop)                                                                                                                                        | No       | `false`                         |
+| `dry-run`              | Show what would be uploaded without uploading                                                                                                                                                        | No       | `false`                         |
+| `jar-group-id`         | Maven group ID fallback for JAR artifacts                                                                                                                                                            | No       | `""`                            |
+| `gh-artifact-name`     | Name of the artifacts to download                                                                                                                                                                    | No       | `signed-artifacts`              |
+| `gh-checkout-path`     | Directory to checkout shared-workflows into                                                                                                                                                          | No       | `shared-workflows`              |
+| `gh-retention-days`    | Retention days for the artifacts                                                                                                                                                                     | No       | `1`                             |
+| `jf-url`               | JFrog Artifactory URL                                                                                                                                                                                | No       | `https://artifact.aerospike.io` |
+| `oidc-provider-name`   | OIDC provider name for authentication                                                                                                                                                                | No       | `gh-aerospike`                  |
+| `oidc-audience`        | OIDC audience for authentication                                                                                                                                                                     | No       | `aerospike`                     |
+| `runs-on`              | The runner to use                                                                                                                                                                                    | No       | `ubuntu-22.04`                  |
 
 ## Outputs
 
@@ -75,7 +76,7 @@ The deploy pipeline uses a centralized type registry (`type_registry.sh`). To ad
 Artifacts arrive in `build-artifacts/` as a flat collection from the sign stage. The structuring phase categorizes them by type and gathers companion files:
 
 - Types with unique extensions (DEB, RPM, JAR, NuGet, `.whl`, Windows `.exe`/`.msi`/`.msix`) are matched by extension
-- Gzipped tarballs (`.tgz` and `.tar.gz`) and zip archives (`.zip`) are inspected with content-based detectors to distinguish npm packages, PyPI source distributions, Go modules, and generic archives
+- Gzipped tarballs (`.tgz` and `.tar.gz`) and zip archives (`.zip`) are inspected with content-based detectors to distinguish npm packages, PyPI source distributions, Go modules, Helm charts (`.tgz` containing `Chart.yaml`), and generic archives
 - Companion files (defined per type in `TYPE_COMPANIONS`) are automatically copied alongside their primary artifact
 - Generic catches everything not claimed by the above
 
@@ -170,12 +171,34 @@ Uploaded to JFrog as:
   {module}/@v/{version}.info
 ```
 
+### Helm chart
+
+`.tgz` files are inspected for a top-level `Chart.yaml` (with `apiVersion`, `name`, `version`) to distinguish packaged Helm charts from npm/generic tarballs. The chart's `.prov` provenance file (produced by the sign stage) is gathered as the companion instead of a `.asc`.
+
+```text
+helm/
+  {chart}-{version}.tgz
+  {chart}-{version}.tgz.prov
+```
+
+### Windows
+
+`.exe`, `.msi`, and `.msix` files are matched by extension and uploaded to the generic repository.
+
+```text
+win/
+  {filename}.exe
+  {filename}.exe.asc
+```
+
 ## File layout
 
 ```text
 deploy-artifacts/
   entrypoint.sh          # Main script: arg parsing, upload functions, orchestration
   type_registry.sh       # Type config arrays + per-type props/flags functions
+  type_detection.sh      # Content-based detection predicates (is_npm_package, is_helm_chart, etc.)
+  detect_types.sh        # Standalone detection entrypoint (used by the detect-artifacts action)
   upload_utils.sh        # Shared helpers: jf_upload, upload_companions, discover_and_process, upload_type
   package_utils.sh       # Metadata extraction + process_* functions for structuring
   create-test-fixtures.sh

--- a/.github/workflows/docker-build-deploy/README.md
+++ b/.github/workflows/docker-build-deploy/README.md
@@ -37,8 +37,8 @@ jobs:
 - `jf-registry-base` (string, default `artifact.aerospike.io`): Registry hostname (no repo path)
 - `jf-url` (string, default `https://artifact.aerospike.io`): Base JFrog Artifactory URL
 - `labels-json` (string, default `{}`): JSON object of image labels (e.g., `{"com.aerospike.version":"7.0.0","com.aerospike.release":"stable","maintainer":"Aerospike"}`)
-- `oidc-audience` (string, default `aerospike/testing`): OIDC audience value for token
-- `oidc-provider-name` (string, default `gh-dev-test`): JFrog OIDC provider name
+- `oidc-audience` (string, default `aerospike`): OIDC audience value for token
+- `oidc-provider-name` (string, default `gh-aerospike`): JFrog OIDC provider name
 - `platforms` (string, default `linux/amd64,linux/arm64`): Comma-separated target platforms for buildx
 - `provenance` (string, default `mode=max`): BuildKit provenance setting (`''`, `'false'`, or `'mode=max'`)
 - `push` (boolean, default `true`): Whether to push the image
@@ -134,6 +134,7 @@ RUN --mount=type=secret,id=npm_token \
 ## Notes
 
 - The workflow automatically handles `v` prefix in version strings (e.g., `v1.2.3` becomes `1.2.3`)
+- OCI tags forbid the `+` character, but SemVer uses it for build metadata (e.g., `1.2.3+build-123`). The workflow replaces `+` with `-` in tags (`1.2.3+build-123` becomes `1.2.3-build-123`); the original version is preserved in the image's OCI labels.
 - OCI labels are automatically generated with image metadata (title, version, created, revision, source, url)
 - User-provided labels (via `labels-json`) override OCI labels when keys conflict
 - For Artifactory, the registry path includes the repository (e.g., `artifact.aerospike.io/database-docker-dev-local`)

--- a/.github/workflows/docs/CICD-composable.md
+++ b/.github/workflows/docs/CICD-composable.md
@@ -14,6 +14,7 @@ The orchestrated `reusable_artifacts-cicd.yaml` handles build → sign → deplo
 | ------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `reusable_execute-build.yaml`         | Run a build script, upload artifacts to GitHub Artifacts, publish build-info to JFrog        |
 | `reusable_sign-mac-artifacts.yaml`    | Apple codesign/productsign/notarize for .pkg, .dmg, Mach-O binaries (macOS runner)           |
+| `reusable_sign-win-artifacts.yaml`    | Authenticode signing for .exe, .msi, .msix via SSL.com eSigner CodeSignTool (Windows runner) |
 | `reusable_sign-artifacts.yaml`        | Download unsigned artifacts, GPG-sign deb/rpm/generic files, SSL.com-sign nupkg files        |
 | `reusable_deploy-artifacts.yaml`      | Download signed artifacts, upload to JFrog Artifactory (auto-routes by file extension)       |
 | `reusable_create-release-bundle.yaml` | Create JFrog release bundle from one or more builds (standalone, handles checkout and setup) |
@@ -25,7 +26,7 @@ The orchestrated `reusable_artifacts-cicd.yaml` handles build → sign → deplo
 | `collect-build-artifacts` | Merge per-matrix GitHub Artifacts into a single artifact for downstream jobs |
 | `create-release-bundle`   | Create a JFrog release bundle from one or more builds                        |
 | `delete-release-bundle`   | Delete an existing release bundle version (safe no-op if it doesn't exist)   |
-| `promote-release-bundle`  | Promote a release bundle to a target environment (DEV, TEST, PROD, etc.)     |
+| `promote-release-bundle`  | Promote a release bundle to a target promotion stage (DEV, TEST, PROD, etc.) |
 
 ## High-level flow
 
@@ -55,10 +56,10 @@ Internally, GitHub Actions artifacts are used for _in-runner handoff_ between st
 
 ## Composable artifact pipeline
 
-See [example_composable-matrix.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_composable-matrix.yaml) for the complete working example. It demonstrates DEB/RPM, npm, Java/Maven, Python/PyPI, and Go module builds with a custom test step inserted between build and sign:
+See [example_composable-matrix.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_composable-matrix.yaml) for the complete working example. It demonstrates DEB/RPM, npm, Java/Maven, Python/PyPI, Go module, and Helm chart builds with a custom test step inserted between build and sign:
 
 ```text
-extract-version  →  build (matrix + npm + java + python + go)  →  collect  →  [your tests]  →  sign-mac (optional)  →  sign  →  deploy
+extract-version  →  build (matrix + npm + java + python + go + helm)  →  collect  →  [your tests]  →  sign-mac (optional)  →  sign-windows (optional)  →  sign  →  deploy
 ```
 
 With release bundles (shown in the example for `workflow_dispatch`):
@@ -80,8 +81,9 @@ Deploy parent:     {run_id}-{run_attempt}
 
 **Artifact naming.** Each build job uploads with a distinct name (e.g., `build-artifacts-el9-x86_64`, `build-artifacts-npm-x86_64`). The `collect-build-artifacts` action merges these into a single `build-artifacts` artifact that sign and deploy consume.
 
-**Collecting matrix artifacts.** Use the `collect-build-artifacts` composite action after all build jobs complete. It downloads all artifacts matching a pattern (default `build-artifacts-*`) and re-uploads them as one merged artifact:
-**Signing secrets.** GPG keys (and SSL.com credentials if nupkg files are present) must be available. For Mac signing, provide Apple certificates and notarization credentials. See the [sign-mac-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-mac-artifacts/README.md).
+**Collecting matrix artifacts.** Use the `collect-build-artifacts` composite action after all build jobs complete. It downloads all artifacts matching a pattern (default `build-artifacts-*`) and re-uploads them as one merged artifact.
+
+**Signing secrets.** GPG keys (and SSL.com credentials if nupkg files or Windows executables are present) must be available. For Mac signing, provide Apple certificates and notarization credentials; for Windows signing, provide SSL.com eSigner credentials. See the [sign-mac-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-mac-artifacts/README.md) and [sign-win-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-win-artifacts/README.md).
 
 **Mac signing (optional).** If your build produces macOS artifacts, insert `reusable_sign-mac-artifacts.yaml` between collect and GPG sign. It downloads `build-artifacts`, Apple-signs the matched files, and re-uploads with `overwrite: true`. The GPG sign step then picks up the already-Apple-signed artifacts:
 
@@ -115,7 +117,41 @@ sign:
 
 The `if: always() && !cancelled() && !failure()` on the GPG sign job ensures it runs even when `sign-mac` is skipped (a skipped needed job would otherwise silently skip the downstream job too).
 
-**Java/Maven setup.** Pass `setup-java: true` to `reusable_execute-build.yaml` along with optional `java-version` (default `"21"`), `java-distribution` (default `temurin`), and `java-cache` (default `maven`). For JAR artifacts, pass `jar-group-id` to `reusable_deploy-artifacts.yaml` as a Maven group ID fallback when JAR metadata doesn't include one.
+**Windows signing (optional).** If your build produces Windows executables (.exe, .msi, .msix), insert `reusable_sign-win-artifacts.yaml` between collect and GPG sign. It downloads `build-artifacts`, Authenticode-signs the matched files via SSL.com CodeSignTool, and re-uploads with `overwrite: true`. The GPG sign step then picks up the already-signed executables. Place it after `sign-mac` so the GPG `sign` job needs both:
+
+```yaml
+sign-windows:
+  needs: collect
+  uses: aerospike/shared-workflows/.github/workflows/reusable_sign-win-artifacts.yaml@v3.2.0
+  with:
+    gh-unsigned-artifacts: build-artifacts
+    gh-workflows-ref: v3.2.0
+    runs-on: windows-2025
+    artifact-glob: "*.exe,*.msi,*.msix"
+    signing-identity: "My Product Inc." # Optional display name
+  secrets:
+    es_ov_username: ${{ secrets.ES_OV_USERNAME }}
+    es_ov_password: ${{ secrets.ES_OV_PASSWORD }}
+    es_ov_credential_id: ${{ secrets.ES_OV_CREDENTIAL_ID }}
+    es_ov_totp_secret: ${{ secrets.ES_OV_TOTP_SECRET }}
+
+sign:
+  needs: [collect, sign-mac, sign-windows]
+  if: always() && !cancelled() && !failure()
+  uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.2.0
+  with:
+    gh-unsigned-artifacts: build-artifacts
+    gh-workflows-ref: v3.2.0
+  secrets: inherit
+```
+
+See [example_win-signing.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_win-signing.yaml) for a full Windows-signing pipeline.
+
+**Language and tool setup.** Pass `setup-java: true` to `reusable_execute-build.yaml` along with optional `java-version` (default `"21"`), `java-distribution` (default `temurin`), and `java-cache` (default `maven`). The same workflow also exposes `setup-dotnet` (with `dotnet-version`, default `8.0`), `setup-python` (with `python-version`, default `3.12`), and `setup-helm` (with `helm-version`, default `latest`) to install the matching toolchain before your build script runs. For JAR artifacts, pass `jar-group-id` to `reusable_deploy-artifacts.yaml` as a Maven group ID fallback when JAR metadata doesn't include one.
+
+**Build environment.** `reusable_execute-build.yaml` accepts a `build-env` input: semicolon-delimited `KEY=VALUE` pairs exported into the build script's environment (use `\;` for a literal semicolon and `\\` for a literal backslash; parsed by `execute-build/parse-build-env.sh`). When both a top-level `build-env` and a matrix-level `build-env` are present, they are **merged** by concatenation (`{top-level};{matrix-level}`) with the matrix entry appended last, so matrix keys win on duplicates. It is not a replace. See [INFRA-482](https://aerospike.atlassian.net/browse/INFRA-482).
+
+**Matrix data (`MATRIX_JSON`).** `reusable_execute-build.yaml` also accepts a separate `matrix-json-data` input, exported to the build subprocess as the `MATRIX_JSON` environment variable (the jq-parseable JSON of the current matrix entry). This lets a build script branch on matrix properties (distro, arch, custom flags). `MATRIX_JSON` is a distinct input from `build-env` precisely so embedded semicolons in the JSON do not corrupt the `build-env` split (INFRA-482).
 
 ### Build-info architecture
 
@@ -160,7 +196,9 @@ At Aerospike, release bundles are the only way artifacts are promoted between en
 
 ## Full examples
 
-- [example_composable-matrix.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_composable-matrix.yaml): multi-ecosystem matrix builds (DEB/RPM, npm, Java, Python, Go) with custom test step, release bundle lifecycle, and promotion
+- [example_composable-matrix.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_composable-matrix.yaml): multi-ecosystem matrix builds (DEB/RPM, npm, Java, Python, Go, Helm) with custom test step, release bundle lifecycle, and promotion
+- [example_win-signing.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_win-signing.yaml): Windows Authenticode signing wired into a composable pipeline
+- [example_expanded-integration.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_expanded-integration.yaml): exhaustive composable showcase with custom packaging and downstream artifact consumption
 
 ---
 

--- a/.github/workflows/docs/CICD-standard.md
+++ b/.github/workflows/docs/CICD-standard.md
@@ -84,14 +84,18 @@ jobs:
 Notes:
 
 - `reusable_artifacts-cicd.yaml` generates a unique parent `jf-build-id` internally (`GITHUB_RUN_ID-GITHUB_RUN_ATTEMPT`) and uses a distinct metadata build-id (`{jf-build-id}-buildinfo`) for the build-info produced during the build.
-- Signing is always enabled; provide the required signing secrets (GPG, and SSL.com secrets if `.nupkg` files are present). Using `secrets: inherit` is simplest.
+- Signing is always enabled; provide the required signing secrets (GPG, plus SSL.com secrets if `.nupkg` files or Windows executables are present). Using `secrets: inherit` is simplest.
 - All artifacts get `version` and `package_name` target-props automatically. DEB/RPM also get distribution and architecture. Use `build-type` and `internal` for additional categorization.
 - **Mac signing** is optional. Set `sign-mac: true` and provide `mac-signing-identity` plus the Apple secrets to enable Apple code signing, package signing (productsign), and notarization for `.pkg`, `.dmg`, and Mach-O binaries. Mac signing runs before GPG signing in the pipeline. See [sign-mac-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-mac-artifacts/README.md) for secret setup.
+- **Windows signing** is optional. Set `sign-windows: true` and provide the SSL.com eSigner secrets to enable Authenticode signing of `.exe`, `.msi`, and `.msix` files. Windows signing runs after Mac signing and before GPG signing. See [sign-win-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-win-artifacts/README.md) for secret setup.
 - **Java/Maven:** Set `setup-java: true` to have Java installed before your build script runs. Optionally set `java-version` (default `"21"`), `java-distribution` (default `temurin`), and `java-cache` (default `maven`). Matrix entries can override all four fields per build.
 - **JAR artifacts:** Use `jar-group-id` to provide a Maven group ID fallback when the JAR metadata doesn't include one.
 - **Python/PyPI:** Set `setup-python: true` to install Python and build tools (`build`, `twine`) before your build script runs. Optionally set `python-version` (default `"3.12"`). The deploy stage auto-detects `.whl` and `.tar.gz` sdist files and routes them to the appropriate PyPI repository. Matrix entries can override `setup-python` and `python-version` per build.
 - **Go modules:** The deploy stage auto-detects Go module `.zip` archives (those containing `module@version/go.mod`) and routes them to the Go repository. At upload time, it extracts the `.mod` file and generates a `.info` JSON following the [GOPROXY protocol](https://go.dev/ref/mod#goproxy-protocol). No special setup inputs are needed. Your build script should produce a Go module zip with the standard `module@version/` prefix layout.
 - **Helm charts:** Set `setup-helm: true` (and optionally `helm-version`, default `latest`) to install the Helm CLI before the build script runs. Matrix entries can override per build. The deploy stage auto-detects packaged Helm chart `.tgz` files (those containing `<chart>/Chart.yaml` with `apiVersion`, `name`, and `version`) and routes them to the project's classic Helm repository (`{project}-helm-dev-local`). Build script runs `helm package`; deploy ingests the resulting `.tgz`. JFrog auto-generates `index.yaml` from uploaded charts, so consumers `helm repo add` the repo URL and `helm install` from it. Signing is automatic: `sign-artifacts` produces a helm-native `.prov` (GPG-clearsigned Chart.yaml plus the chart's sha256) for every chart, and the `.prov` rides alongside the chart through deploy. Build scripts should use plain `helm package` (no `--sign`). See [artifacts-cicd README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/artifacts-cicd/README.md) for the full Helm section including chart-testing pointers.
+- **NuGet:** The deploy stage auto-detects `.nupkg` and `.snupkg` packages (validated via the embedded `.nuspec`) and routes them to the project's NuGet repository (`{project}-nuget-dev-local`). NuGet packages are signed with SSL.com eSigner rather than GPG; set `nuget-environment` to choose the eSigner signing environment (default `PROD`). No special setup input is required.
+- **npm:** The deploy stage content-detects npm package tarballs (`.tgz` or `.tar.gz` containing a `package.json`) and routes them to the project's npm repository (`{project}-npm-dev-local`). No special setup input is required.
+- **Windows executables:** `.exe`, `.msi`, and `.msix` files are detected by extension and routed to the project's generic repository (`{project}-generic-dev-local`). Enable Authenticode signing for them with `sign-windows` (see Windows signing below).
 
 ### Mac signing (optional)
 
@@ -119,9 +123,37 @@ jobs:
     secrets: inherit
 ```
 
-The pipeline runs Mac signing before GPG signing: `collect -> sign-mac -> sign (GPG) -> deploy`. Apple signing modifies files in place, while GPG creates detached `.asc` signatures. Running Mac signing first ensures GPG signatures match the final file contents.
+The pipeline runs platform signing before GPG signing: `collect -> sign-mac -> sign-windows -> sign (GPG) -> deploy`. Apple and Authenticode signing modify files in place, while GPG creates detached `.asc` signatures. Running Mac and Windows signing first ensures the GPG signatures match the final file contents.
 
 Required secrets (set at org or repo level): `APPLE_APPLICATION_CERT`, `APPLE_CERT_PASSWORD`, `APPLE_ID`, `APPLE_INSTALLER_CERT`, `APPLE_NOTARIZATION_PASSWORD`, `APPLE_TEAM_ID`. See the [sign-mac-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-mac-artifacts/README.md) for setup instructions.
+
+### Windows signing (optional)
+
+To Authenticode-sign Windows executables (.exe, .msi, .msix) via SSL.com eSigner, add the `sign-windows` inputs:
+
+```yaml
+jobs:
+  ci:
+    uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@v3.2.0
+    with:
+      gh-workflows-ref: v3.2.0
+      jf-project: my-project
+      jf-build-name: my-app
+      version: 1.2.3
+      gh-artifact-directory: dist
+      build-script: make build-windows
+
+      # Windows signing
+      sign-windows: true
+      win-artifact-glob: "*.exe,*.msi,*.msix" # Default: **/*
+      win-signing-identity: "My Product Inc." # Optional display name for installers
+      win-runs-on: windows-2025 # Default: windows-2025
+    secrets: inherit
+```
+
+Windows signing runs after Mac signing and before GPG signing (`collect -> sign-mac -> sign-windows -> sign -> deploy`), so the signed executables flow through to deploy and any later GPG `.asc` signatures match the signed bytes. Signing uses SSL.com CodeSignTool with an OV certificate.
+
+Required secrets (set at org or repo level): `ES_OV_USERNAME`, `ES_OV_PASSWORD`, `ES_OV_CREDENTIAL_ID`, `ES_OV_TOTP_SECRET`. These are SSL.com eSigner account credentials. See the [sign-win-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-win-artifacts/README.md) for setup instructions.
 
 ### Build-info
 
@@ -301,6 +333,8 @@ For chart linting and unit tests in PRs, run [chart-testing (`ct`)](https://gith
 ## Full examples
 
 - [example_artifacts-cicd.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_artifacts-cicd.yaml): drop-in orchestrated pipeline with multi-ecosystem matrix (C, .NET, npm, Java, Python, Go, Helm)
+- [example_win-signing.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_win-signing.yaml): orchestrated pipeline with Windows Authenticode signing
+- [example_expanded-integration.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_expanded-integration.yaml): exhaustive multi-ecosystem integration showcase
 
 ---
 

--- a/.github/workflows/docs/artifacts-cicd-matrix.schema.json
+++ b/.github/workflows/docs/artifacts-cicd-matrix.schema.json
@@ -52,7 +52,7 @@
 					"build-env": {
 						"type": "string",
 						"minLength": 1,
-						"description": "Override build env for this matrix entry (semicolon-delimited KEY=VALUE; use \\; for semicolons)"
+						"description": "Build env for this matrix entry, merged with the top-level build-env (matrix appended after top-level, so matrix keys win on duplicates; not a replace). Semicolon-delimited KEY=VALUE; use \\; for literal semicolons and \\\\ for literal backslashes"
 					},
 					"setup-dotnet": {
 						"type": "boolean",
@@ -81,6 +81,24 @@
 						"type": "string",
 						"minLength": 1,
 						"description": "Override package manager cache for this matrix entry (maven, gradle, sbt)"
+					},
+					"setup-python": {
+						"type": "boolean",
+						"description": "Enable Python setup for this matrix entry"
+					},
+					"python-version": {
+						"type": "string",
+						"minLength": 1,
+						"description": "Override Python version for this matrix entry (e.g., 3.11, 3.12)"
+					},
+					"setup-helm": {
+						"type": "boolean",
+						"description": "Enable Helm CLI setup for this matrix entry"
+					},
+					"helm-version": {
+						"type": "string",
+						"minLength": 1,
+						"description": "Override Helm version for this matrix entry (e.g., v3.16.4, latest)"
 					}
 				}
 			}

--- a/.github/workflows/docs/release-bundles.md
+++ b/.github/workflows/docs/release-bundles.md
@@ -1,36 +1,36 @@
 # Release Bundles
 
-At Aerospike, release bundles are the **only way artifacts are promoted between environments**. Instead of promoting individual builds, we group all artifacts for a release into a [Release Bundle v2](https://jfrog.com/help/r/jfrog-artifactory-documentation/understanding-release-bundles-v2) and promote the bundle through DEV, TEST, STAGE, PREVIEW, and PROD.
+At Aerospike, release bundles are the **only way artifacts are promoted between promotion stages**. Instead of promoting individual builds, we group all artifacts for a release into a [Release Bundle v2](https://jfrog.com/help/r/jfrog-artifactory-documentation/understanding-release-bundles-v2) and promote the bundle through DEV, TEST, STAGE, PREVIEW, and PROD.
 
 ## Why bundles
 
 JFrog [Release Bundles v2](https://jfrog.com/help/r/jfrog-artifactory-documentation/understanding-release-bundles-v2) provide:
 
 - **Immutability**: once created, a bundle's contents cannot change. This guarantees that what was tested is what gets promoted.
-- **Promotion tracking**: each environment transition (DEV to TEST, TEST to STAGE, etc.) is recorded with who promoted and when, creating an auditable chain of custody.
+- **Promotion tracking**: each promotion-stage transition (DEV to TEST, TEST to STAGE, etc.) is recorded with who promoted and when, creating an auditable chain of custody.
 - **Multi-artifact grouping**: a single bundle can reference multiple builds (e.g., artifact pipeline + Docker pipeline), so everything for a release moves together.
 
 These properties make bundles the right unit for our SDLC promotion model.
 
 ## Aerospike's promotion pipeline
 
-Artifacts flow through gated environments. Each gate has an owner and requirements that must be met before promotion.
+Artifacts flow through gated promotion stages. Each gate has an owner and requirements that must be met before promotion.
 
 ```text
 CI/Build  ->  DEV  ->  TEST  ->  STAGE  ->  PREVIEW  ->  PROD
                                           ->  INTERNAL
 ```
 
-| Environment | Owner       | Gate requirement                         |
-| ----------- | ----------- | ---------------------------------------- |
-| DEV         | Engineering | Build + smoke tests pass                 |
-| TEST        | QE          | Basic integration tests pass             |
-| STAGE       | QE          | Deep integration and performance testing |
-| PREVIEW     | Product     | Customer preview validation              |
-| PROD        | Product     | Security review and production readiness |
-| INTERNAL    | Engineering | Internal-only artifacts (not public)     |
+| Promotion stage | Owner       | Gate requirement                         |
+| --------------- | ----------- | ---------------------------------------- |
+| DEV             | Engineering | Build + smoke tests pass                 |
+| TEST            | QE          | Basic integration tests pass             |
+| STAGE           | QE          | Deep integration and performance testing |
+| PREVIEW         | Product     | Customer preview validation              |
+| PROD            | Product     | Security review and production readiness |
+| INTERNAL        | Engineering | Internal-only artifacts (not public)     |
 
-The release bundle is created after deployment to DEV (at the DEV to TEST gate). From that point forward, the bundle carries all artifacts and metadata through the remaining environments.
+The release bundle is created after deployment to DEV (at the DEV to TEST gate). From that point forward, the bundle carries all artifacts and metadata through the remaining promotion stages.
 
 For the full gate definitions and evidence requirements, see:
 
@@ -54,7 +54,22 @@ release-bundle:
   secrets: inherit
 ```
 
-There is a composite action that may be used for promotion of bundles documented at [Promote Release Bundle Composite Action](https://github.com/aerospike/shared-workflows/blob/main/.github/actions/promote-release-bundle/README.md).
+Set `dry-run: true` to validate the configuration and JFrog authentication without actually creating the bundle. In dry-run mode the workflow echoes the commands it would run instead of calling `jf release-bundle-create`.
+
+There is a composite action that may be used for promotion of bundles documented at [Promote Release Bundle Composite Action](https://github.com/aerospike/shared-workflows/blob/main/.github/actions/promote-release-bundle/README.md). The `promote-release-bundle` action accepts `include-repos` and `exclude-repos` (semicolon-separated repo lists, e.g. `my-project-deb-dev-local;my-project-rpm-dev-local`) to scope which repositories are promoted. With neither set, all repositories in the bundle are promoted.
+
+### Deleting a bundle before re-deploy
+
+The `delete-release-bundle` composite action deletes a bundle version safely: it searches first, no-ops when the bundle is absent, and reports `existed=true/false` rather than failing. Wire it to run before deploy when you may re-run a pipeline against an already-promoted bundle (promoted bundles lock the underlying dev-local artifacts).
+
+```yaml
+delete-existing-bundle:
+  uses: aerospike/shared-workflows/.github/actions/delete-release-bundle@v3.2.0
+  with:
+    bundle-name: my-release
+    version: 1.2.3
+    jf-project: my-project
+```
 
 For a complete working example including bundle deletion and promotion, see [example_composable-matrix.yaml](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/example_composable-matrix.yaml).
 
@@ -62,9 +77,9 @@ For a complete working example including bundle deletion and promotion, see [exa
 
 **Bundle creation fails**: confirm the `jf-build-names` input is a comma-separated list of `name:version` pairs that exist in JFrog, and that your project permissions allow bundle creation. Bundle creation requires higher permissions than artifact upload.
 
-**Promoted bundle locks artifacts**: promoted bundles lock the underlying artifacts in dev-local repos, causing re-deploy uploads to fail with permission errors. Either delete the old bundle before deploying, or increment the version/build ID.
+**Promoted bundle locks artifacts**: promoted bundles lock the underlying artifacts in dev-local repos, causing re-deploy uploads to fail with permission errors. Either delete the old bundle before deploying (use the `delete-release-bundle` action), or increment the version/build ID.
 
-**Re-running a pipeline**: if the bundle already exists and has been promoted, you must delete it before deploying new artifacts with the same names/path.
+**Re-running a pipeline**: if the bundle already exists and has been promoted, delete it before deploying new artifacts with the same names/path. The `delete-release-bundle` action is safe to call unconditionally (it no-ops when the bundle is absent), so it can run on every pipeline before deploy.
 
 ## References
 

--- a/.github/workflows/execute-build/README.md
+++ b/.github/workflows/execute-build/README.md
@@ -20,7 +20,7 @@ This workflow executes a custom build script and uploads the resulting artifacts
 | `gh-artifact-directory` | Directory that will contain all artifacts from this build                                                                                  | Yes      | -                               |
 | `gh-artifact-name`      | Name for the uploaded artifacts                                                                                                            | No       | `build-artifacts`               |
 | `gh-retention-days`     | Retention days for the artifacts                                                                                                           | No       | `1`                             |
-| `working-directory`     | Working directory for build script execution                                                                                               | No       | -                               |
+| `working-directory`     | Working directory for build script execution                                                                                               | No       | `.`                             |
 | `jf-url`                | JFrog Artifactory URL                                                                                                                      | No       | `https://artifact.aerospike.io` |
 | `oidc-provider-name`    | OIDC provider name                                                                                                                         | No       | `gh-aerospike`                  |
 | `oidc-audience`         | OIDC audience                                                                                                                              | No       | `aerospike`                     |
@@ -29,9 +29,20 @@ This workflow executes a custom build script and uploads the resulting artifacts
 | `gh-workflows-ref`      | Git ref for shared-workflows (**should match your `uses:` version**)                                                                       | Yes      | -                               |
 | `gh-source-repository`  | Repository to checkout for source code (format owner/repo)                                                                                 | No       | `${{ github.repository }}`      |
 | `gh-source-ref`         | Reference to checkout for source repository (branch, tag, or commit)                                                                       | No       | -                               |
-| `gh-source-path`        | Directory to checkout the source repository into                                                                                           | No       | `local`                         |
+| `gh-source-path`        | Directory to checkout the source repository into. If set to an empty string, the source repository is not checked out.                     | No       | `local`                         |
 | `build-env`             | Semicolon-delimited `KEY=VALUE` pairs exported to the build script. Use `\;` for a literal `;`, `\\` for a backslash.                      | No       | -                               |
 | `matrix-json-data`      | JSON for the current matrix entry. Exported as `MATRIX_JSON` to the build subprocess. Set automatically by `reusable_artifacts-cicd.yaml`. | No       | -                               |
+| `publish-build-info`    | Whether to publish build-info to JFrog                                                                                                     | No       | `true`                          |
+| `setup-dotnet`          | Install the .NET SDK before the build script runs                                                                                          | No       | `false`                         |
+| `dotnet-version`        | .NET SDK version (when `setup-dotnet`)                                                                                                     | No       | `"8.0"`                         |
+| `setup-java`            | Install Java before the build script runs                                                                                                  | No       | `false`                         |
+| `java-version`          | Java version (when `setup-java`)                                                                                                           | No       | `"21"`                          |
+| `java-distribution`     | Java distribution (when `setup-java`)                                                                                                      | No       | `temurin`                       |
+| `java-cache`            | Package manager to cache (when `setup-java`)                                                                                               | No       | `maven`                         |
+| `setup-python`          | Install Python before the build script runs                                                                                                | No       | `false`                         |
+| `python-version`        | Python version (when `setup-python`)                                                                                                       | No       | `"3.12"`                        |
+| `setup-helm`            | Install the Helm CLI before the build script runs                                                                                          | No       | `false`                         |
+| `helm-version`          | Helm version (when `setup-helm`)                                                                                                           | No       | `latest`                        |
 | `dry-run`               | Whether to run in dry-run mode                                                                                                             | No       | `false`                         |
 
 \*Either `build-script` or `build-script-path` is required, but not both.
@@ -51,7 +62,7 @@ on:
 
 jobs:
   build:
-    uses: aerospike/shared-workflows/.github/workflows/reusable_execute-build.yaml@v2.0.2
+    uses: aerospike/shared-workflows/.github/workflows/reusable_execute-build.yaml@v3.2.0
     with:
       jf-project: my-project
       jf-build-name: my-app
@@ -60,7 +71,7 @@ jobs:
       gh-artifact-directory: dist
       gh-artifact-name: my-build-artifacts
       gh-retention-days: 7
-      gh-workflows-ref: v2.0.2 # Should match the version in your 'uses:' line
+      gh-workflows-ref: v3.2.0 # Should match the version in your 'uses:' line
       dry-run: false
 ```
 
@@ -69,7 +80,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    uses: aerospike/shared-workflows/.github/workflows/reusable_execute-build.yaml@v2.0.2
+    uses: aerospike/shared-workflows/.github/workflows/reusable_execute-build.yaml@v3.2.0
     with:
       jf-project: my-project
       jf-build-name: my-app
@@ -78,7 +89,7 @@ jobs:
       gh-artifact-directory: dist
       gh-artifact-name: my-build-artifacts
       gh-retention-days: 7
-      gh-workflows-ref: v2.0.2 # Should match the version in your 'uses:' line
+      gh-workflows-ref: v3.2.0 # Should match the version in your 'uses:' line
       dry-run: false
 ```
 

--- a/.github/workflows/pr-hygiene/README.md
+++ b/.github/workflows/pr-hygiene/README.md
@@ -11,7 +11,7 @@ type(scope): [JIRA-123] description
 ```
 
 - **type**: `feat|fix|refactor|docs|test|ci|chore|build|perf` (validated by commitlint)
-- **scope**: optional, lowercase (e.g., `workflows`, `deploy`, `actions`)
+- **scope**: optional, lowercase alphanumeric with hyphens and underscores (e.g., `workflows`, `deploy`, `actions`, `my-scope`, `my_scope`)
 - **JIRA**: uppercase project key in brackets, required for certain types (see [Types and Jira enforcement](#types-and-jira-enforcement))
 
 Examples:

--- a/.github/workflows/pr-hygiene/tests/helpers/setup.bash
+++ b/.github/workflows/pr-hygiene/tests/helpers/setup.bash
@@ -30,7 +30,7 @@ title_matches_patterns() {
 # Usage: extract_jira_ticket "PR title"
 extract_jira_ticket() {
         local title="$1"
-        echo "$title" | grep -oP '^[a-z]+(\([a-z0-9-]+\))?: \[\K[A-Z]{2,10}-[0-9]+(?=\] )' | head -1
+        echo "$title" | grep -oP '^[a-z]+(\([a-z0-9-_]+\))?: \[\K[A-Z]{2,10}-[0-9]+(?=\] )' | head -1
 }
 
 # Extract the conventional commit type from a PR title

--- a/.github/workflows/sign-artifacts/README.md
+++ b/.github/workflows/sign-artifacts/README.md
@@ -2,10 +2,11 @@
 
 > **Note:** This workflow is used internally by [`reusable_artifacts-cicd.yaml`](../artifacts-cicd/README.md). Most consumers should use the orchestrator rather than calling this directly.
 
-This is a reusable GitHub Actions workflow that signs binary artifacts using GPG. It supports `.deb`, `.rpm`, `.nupkg` (NuGet via SSL.com), and other file types passed via a glob pattern. It produces:
+This is a reusable GitHub Actions workflow that signs binary artifacts using GPG. It supports `.deb`, `.rpm`, `.nupkg` (NuGet via SSL.com), Helm charts, and other file types passed via a glob pattern. It produces:
 
-- GPG detached signature (`.asc`) for files that pass through the GPG stage
+- GPG detached signature (`.asc`) for generic files that pass through the GPG stage (e.g. `.jar`, `.zip`, plain tarballs)
 - Native signing for `.deb` and `.rpm` using `dpkg-sig` and `rpm --addsign`
+- Helm chart provenance (`.prov`) for packaged charts (`.tgz`/`.tar.gz` containing a `Chart.yaml`): a GPG-clearsigned message containing the chart's `Chart.yaml` plus a sha256 of the tarball, the same native format `helm package --sign` produces. The chart receives a `.prov` rather than a detached `.asc`, and consumers verify with `helm verify` or `helm install --verify`.
 
 **Not** GPG-signed here (same pattern as NuGet, which is moved out before GPG):
 
@@ -55,12 +56,12 @@ From another workflow:
 ```yaml
 jobs:
   sign:
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v2.0.2
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.2.0
     with:
       gh-unsigned-artifacts: test-fixtures
       gh-artifact-name: signed-artifacts # optional, defaults to signed-artifacts
       gh-retention-days: 7 # optional, defaults to 1
-      gh-workflows-ref: v2.0.2 # Should match the version in your 'uses:' line
+      gh-workflows-ref: v3.2.0 # Should match the version in your 'uses:' line
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}


### PR DESCRIPTION
## Summary

The in-repo CI/CD docs and per-workflow/action READMEs had drifted from the workflows. Several features shipped without doc updates (Windows signing, build-env/MATRIX_JSON decoupling, Helm and NuGet support), and a number of READMEs carried stale inputs, defaults, and version pins. This refresh brings the documentation back in line with the source.

Found via an audit pairing each doc and README against its source workflow/action.

## Changes

**docs/ guides**
- CICD-standard: Windows signing section, corrected pipeline order (sign-mac → sign-windows → sign), NuGet/npm/Windows-exe types, `nuget-environment`, example links.
- CICD-composable: build-env + MATRIX_JSON (INFRA-482 merge semantics), Windows signing, Helm/NuGet ecosystems, setup-* passthroughs, fixed a dangling bullet.
- matrix schema: added `setup-python`/`setup-helm` keys, corrected `build-env` from "override" to merge.
- release-bundles: `include-repos`/`exclude-repos`, `dry-run`, `delete-release-bundle`, "promotion stage" terminology.

**Workflow/action READMEs**
- artifacts-cicd, execute-build, deploy-artifacts, sign-artifacts, create-release-bundle: missing inputs, wrong defaults (`working-directory`, `jf-metadata-build-id`), Helm type/`.prov` signing, `jf-build-names` `name:version` format, version pins bumped to v3.2.0.
- setup-gpg: rewritten (corrected action path, real inputs, Ubuntu 22.04 constraint; dropped a nonexistent input and bogus platform).
- promote-release-bundle, detect-artifacts, pr-hygiene: missing inputs, detected types, scope wording.
- docker-build-deploy: corrected stale OIDC defaults and noted the SemVer `+` tag sanitization.

**One test fix**
- pr-hygiene jira-extraction test helper regex aligned with the workflow (allow `_` in scope, INFRA-504).

## Test plan
- `trunk fmt` and `trunk check` clean on all touched files.
- `bats .github/workflows/pr-hygiene/tests/` passes (34/34).

Note: `skip-jira` label applied; this is a documentation refresh with no associated ticket.
