### PR TITLE
ci: delete stale release bundles before artifact cleanup, relax Jira types to feat+fix

### DIFF
--- a/.github/workflows/example_expanded-integration.yaml
+++ b/.github/workflows/example_expanded-integration.yaml
@@ -28,7 +28,7 @@ jobs:
   # Manual dispatches should not take arguments.
   # here we use a file (VERSION.example) to set the test version that will be used.
   # Since this action actually produces an immutable release bundle you must remove it or change the version
-  # to remove the test bundle use the command `jf rbdell test-release --project test 1.2.3`
+  # to remove the test bundle use the command `jf release-bundle-delete-local test-release 1.2.9 --project=test`
   # In a real CI/CD pipeline you could trigger on version tag or commit also. Here we use the file so we can show the behaviour on demand.
   extract-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_pr-hygiene.yml
+++ b/.github/workflows/reusable_pr-hygiene.yml
@@ -23,7 +23,7 @@ on:
       types-requiring-jira:
         required: false
         type: string
-        default: feat, fix, docs, ci, refactor
+        default: feat, fix
         description: >
           Comma-separated list of conventional commit types that require a JIRA
           ticket in the PR title. Types not in this list skip JIRA validation.

--- a/.github/workflows/test_deploy-artifacts-integration.yaml
+++ b/.github/workflows/test_deploy-artifacts-integration.yaml
@@ -318,9 +318,8 @@ jobs:
 
       # --- cleanup (always runs) ---
       # The fixture script creates deb, rpm, jar, nupkg, snupkg, npm, and generic
-      # artifacts. Even though we only verify npm now, the deploy uploads everything.
 
-      - name: Cleanup release bundles locking test artifacts
+      - name: Cleanup test release bundles
         if: always()
         run: |
           # Promoted bundles lock their artifacts and block re-deployment to the same
@@ -335,7 +334,7 @@ jobs:
             jf release-bundle-delete-local test-release "$v" --project=test --quiet || true
           done
 
-      - name: Cleanup all test artifacts
+      - name: Cleanup test artifacts
         if: always()
         run: |
           echo "Cleaning up all test artifacts from JFrog..."

--- a/.github/workflows/test_deploy-artifacts-integration.yaml
+++ b/.github/workflows/test_deploy-artifacts-integration.yaml
@@ -320,6 +320,21 @@ jobs:
       # The fixture script creates deb, rpm, jar, nupkg, snupkg, npm, and generic
       # artifacts. Even though we only verify npm now, the deploy uploads everything.
 
+      - name: Cleanup release bundles locking test artifacts
+        if: always()
+        run: |
+          # Promoted bundles lock their artifacts and block re-deployment to the same
+          # paths. Delete all versions of test-release before wiping the repos so the
+          # artifact deletes below don't silently 409.
+          versions=$(jf release-bundle-search versions test-release \
+            --project=test --format=json 2>/dev/null \
+            || echo '{"release_bundles":[]}')
+          echo "$versions" | jq -r '.release_bundles[].release_bundle_version' \
+          | while read -r v; do
+            echo "Deleting bundle: test-release $v"
+            jf release-bundle-delete-local test-release "$v" --project=test --quiet || true
+          done
+
       - name: Cleanup all test artifacts
         if: always()
         run: |


### PR DESCRIPTION
## Summary

- Adds a release-bundle cleanup step before artifact deletion in the integration test workflow. Promoted bundles lock their artifacts and cause silent 409s on re-deployment; deleting all `test-release` bundle versions first unblocks the cleanup.
- Relaxes `types-requiring-jira` default in `reusable_pr-hygiene.yml` from `feat, fix, docs, ci, refactor` to `feat, fix` only.
- Corrects the `jf rbdell` command in a comment to the current `jf release-bundle-delete-local` syntax.

## Test plan

- [ ] Integration test run completes cleanup without 409 errors after a prior run that promoted bundles
- [ ] PRs of type `ci`, `docs`, `refactor` no longer require a Jira ticket in the title