### PR TITLE
feat(docker-build-deploy): [INFRA-560] native multi-arch build, per-leg OIDC tokens, layer cache

### DIFF
--- a/.github/workflows/docker-build-deploy/README.md
+++ b/.github/workflows/docker-build-deploy/README.md
@@ -155,6 +155,8 @@ RUN --mount=type=secret,id=npm_token \
     npm install
 ```
 
+Pass secrets only through `build-secrets-json`, never through `build-args-json`. With `provenance: mode=max` (the default), every build-arg value is recorded in the signed provenance attestation published alongside the image, and that attestation is world-readable for preview-public and public repos. `build-args-json` is for non-secret values only.
+
 ## Notes
 
 - The workflow automatically handles `v` prefix in version strings (e.g., `v1.2.3` becomes `1.2.3`)

--- a/.github/workflows/docker-build-deploy/README.md
+++ b/.github/workflows/docker-build-deploy/README.md
@@ -53,10 +53,32 @@ jobs:
 
 ## Outputs
 
-- `digest`: Image manifest digest
+- `digest`: Multi-platform manifest-list (index) digest
 - `image-ref`: Primary tag with `@digest`
 - `tags`: Comma separated list of tags used
 - `immutable-tag`: Immutable tag (registry/image:version_timestamp)
+
+## Multi-arch build and caching
+
+The workflow builds each requested platform **natively**: a setup step parses `platforms` into a matrix, each platform builds on its own runner (`linux/amd64` on `ubuntu-24.04`, `linux/arm64` on `ubuntu-24.04-arm`), and QEMU emulation is used only for a platform that has no native runner. Each leg pushes its image **by digest**; a final merge step assembles one multi-platform manifest index (`docker buildx imagetools create`) and applies the tags. A single-platform build still produces a manifest index. The four outputs (digest, image-ref, tags, immutable-tag) and the single build-info record are produced by the merge step; the build-info build number is `github.run_number`, unchanged, so release-bundle references of the form `<build-name>:${{ github.run_number }}` keep resolving. Each leg and the merge step mint their own short-lived OIDC token immediately before pushing, so total build time no longer has to fit inside one token's lifetime.
+
+Two independent caching levers reduce repeat work:
+
+1. **Base-image pull-through (primary).** Point your `FROM` lines at the JFrog virtual for your project rather than the public registry, so base layers are fetched from upstream once and then served from JFrog:
+
+   ```dockerfile
+   # instead of:  FROM ubuntu:24.04@sha256:...
+   FROM artifact.aerospike.io/<jf-project>-docker-virtual/library/ubuntu:24.04@sha256:...
+   # gcr.io/distroless/...  ->  artifact.aerospike.io/<jf-project>-docker-virtual/distroless/...
+   ```
+
+   Keep the `@sha256:` digest pins. The virtuals (Docker Hub, RedHat, Quay, ghcr.io, gcr.io, registry.k8s.io, public.ecr.aws, mcr.microsoft.com) are provided per project; your repo's OIDC grant must include read + cache-deploy on the public-mirror remotes for the first uncached pull to succeed (this is granted by the standard per-repo OIDC mapping; see OIDC below).
+
+2. **Build-step cache (secondary).** The workflow uses the GitHub Actions cache (`type=gha`, `mode=max`) so unchanged builder-stage layers are reused on warm runs. Nothing is written to JFrog. It is best-effort: the per-repo GHA cache quota is finite, so on large matrices a miss simply rebuilds.
+
+## OIDC
+
+Authenticate with the org-scoped provider (defaults: `oidc-provider-name: gh-aerospike`, `oidc-audience: aerospike`). Your repo needs a per-repo OIDC mapping in tf-artifactory granting write to the target project's dev locals plus read + cache-deploy on the public-mirror remotes (the standard consumer mapping; the legacy per-project-role providers like `gh-dev-test` are being retired). Without the cache-deploy grant, base-image pull-through (lever 1) cannot populate the cache on the first pull.
 
 ## Tag Generation
 
@@ -73,7 +95,7 @@ The registry is automatically constructed from `jf-registry` (if provided) or `{
 
 ## Build Secrets
 
-The workflow automatically injects the JFrog OIDC token as a Docker build secret (`jfrog_token`), available in every build without any configuration. This is in addition to the existing `JFROG_TOKEN` build-arg (which remains for backwards compatibility).
+The workflow automatically injects the JFrog OIDC token as a Docker build secret (`jfrog_token`), available in every build without any configuration. The token is provided **only** as a secret-mount: there is no `JFROG_TOKEN` build-arg. Build-args persist in image history and provenance, so the token is never passed that way.
 
 ### Using the JFrog token secret
 
@@ -83,7 +105,7 @@ RUN --mount=type=secret,id=jfrog_token \
     curl -H "Authorization: Bearer $TOKEN" https://artifact.aerospike.io/...
 ```
 
-Unlike the build-arg approach (`ARG JFROG_TOKEN`), secrets mounted via `--mount=type=secret` are never persisted in image layers or visible in `docker history`.
+Secrets mounted via `--mount=type=secret` are never persisted in image layers or visible in `docker history`. Do not read a secret into a variable that is then written into the image, and do not `COPY` or `ADD` a secret-derived file into any layer: the build-step cache (see Multi-arch build and caching) caches intermediate stages, so anything materialized into a layer is captured there.
 
 ### Private Go modules via GOPROXY
 

--- a/.github/workflows/docker-build-deploy/README.md
+++ b/.github/workflows/docker-build-deploy/README.md
@@ -58,6 +58,8 @@ jobs:
 - `tags`: Comma separated list of tags used
 - `immutable-tag`: Immutable tag (registry/image:version_timestamp)
 
+On a dry run (`push: false`), `digest` and `image-ref` are empty; `tags` and `immutable-tag` are still computed.
+
 ## Multi-arch build and caching
 
 The workflow builds each requested platform **natively**: a setup step parses `platforms` into a matrix, each platform builds on its own runner (`linux/amd64` on `ubuntu-24.04`, `linux/arm64` on `ubuntu-24.04-arm`), and QEMU emulation is used only for a platform that has no native runner. Each leg pushes its image **by digest**; a final merge step assembles one multi-platform manifest index (`docker buildx imagetools create`) and applies the tags. A single-platform build still produces a manifest index. The four outputs (digest, image-ref, tags, immutable-tag) and the single build-info record are produced by the merge step; the build-info build number is `github.run_number`, unchanged, so release-bundle references of the form `<build-name>:${{ github.run_number }}` keep resolving. Each leg and the merge step mint their own short-lived OIDC token immediately before pushing, so total build time no longer has to fit inside one token's lifetime.

--- a/.github/workflows/execute-build/test_apps/hi/Dockerfile
+++ b/.github/workflows/execute-build/test_apps/hi/Dockerfile
@@ -1,5 +1,5 @@
 # checkov:skip=CKV_DOCKER_2: Simple hello world app doesn't need healthcheck
-FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS builder
+FROM artifact.aerospike.io/test-docker-virtual/library/ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS builder
 
 # trunk-ignore(hadolint/DL3008)
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
@@ -16,6 +16,6 @@ ENV ARCH=x86_64
 RUN --mount=type=secret,id=jfrog_token test -f /run/secrets/jfrog_token
 RUN make build && chmod a+x build/jammy/x86_64/hi
 
-FROM gcr.io/distroless/cc-debian12:debug-nonroot@sha256:4b2ac73905e8d2f11d105bba3328a5cf549d099f1dac1bdda0a753ac97858c14
+FROM artifact.aerospike.io/test-docker-virtual/distroless/cc-debian12:debug-nonroot@sha256:4b2ac73905e8d2f11d105bba3328a5cf549d099f1dac1bdda0a753ac97858c14
 COPY --from=builder /work/build/jammy/x86_64/hi /usr/local/bin/hi
 ENTRYPOINT ["/usr/local/bin/hi"]

--- a/.github/workflows/execute-build/test_apps/hi/Dockerfile
+++ b/.github/workflows/execute-build/test_apps/hi/Dockerfile
@@ -1,5 +1,5 @@
 # checkov:skip=CKV_DOCKER_2: Simple hello world app doesn't need healthcheck
-FROM artifact.aerospike.io/test-docker-virtual/library/ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS builder
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS builder
 
 # trunk-ignore(hadolint/DL3008)
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
@@ -16,6 +16,6 @@ ENV ARCH=x86_64
 RUN --mount=type=secret,id=jfrog_token test -f /run/secrets/jfrog_token
 RUN make build && chmod a+x build/jammy/x86_64/hi
 
-FROM artifact.aerospike.io/test-docker-virtual/distroless/cc-debian12:debug-nonroot@sha256:4b2ac73905e8d2f11d105bba3328a5cf549d099f1dac1bdda0a753ac97858c14
+FROM gcr.io/distroless/cc-debian12:debug-nonroot@sha256:4b2ac73905e8d2f11d105bba3328a5cf549d099f1dac1bdda0a753ac97858c14
 COPY --from=builder /work/build/jammy/x86_64/hi /usr/local/bin/hi
 ENTRYPOINT ["/usr/local/bin/hi"]

--- a/.github/workflows/reusable_docker-build-deploy.yaml
+++ b/.github/workflows/reusable_docker-build-deploy.yaml
@@ -110,39 +110,95 @@ on:
           Each is available in Dockerfile via: RUN --mount=type=secret,id=name
     outputs:
       digest:
-        description: Image manifest digest
-        value: ${{ jobs.build.outputs.digest }}
+        description: Image manifest-list (index) digest
+        value: ${{ jobs.merge.outputs.digest }}
       image-ref:
         description: Primary tag with @digest
-        value: ${{ jobs.build.outputs.image-ref }}
+        value: ${{ jobs.merge.outputs.image-ref }}
       tags:
         description: Comma separated list of tags used
-        value: ${{ jobs.build.outputs.tags }}
+        value: ${{ jobs.merge.outputs.tags }}
       immutable-tag:
         description: Immutable tag (registry/image:version_timestamp)
-        value: ${{ jobs.build.outputs.immutable-tag }}
+        value: ${{ jobs.merge.outputs.immutable-tag }}
 
+# INFRA-560: the single build job is split into per-platform native legs plus a
+# merge job. Each platform is built on its own native runner (QEMU only for
+# platforms without one), each job mints its own short-lived OIDC token, legs
+# push by digest, and the merge job assembles one multi-platform manifest,
+# publishes one build-info record, and attests. Internal job names/topology are
+# NOT part of the workflow_call contract; the inputs/outputs surface above is.
 jobs:
+  # Parse the arbitrary `platforms` input into a build matrix, mapping each
+  # platform to a native runner (QEMU fallback for any without one). A static
+  # strategy.matrix cannot read an input at parse time, so we emit it here.
+  parse-platforms:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.parse.outputs.matrix }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Parse platforms into matrix
+        id: parse
+        shell: bash
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+        run: |
+          set -euo pipefail
+          entries=()
+          IFS=',' read -ra arr <<< "$PLATFORMS"
+          for p in "${arr[@]}"; do
+            # trim surrounding whitespace
+            p="$(echo "$p" | xargs)"
+            [ -z "$p" ] && continue
+            sanitized="${p//\//-}"
+            # Native runner mapping. arm64 and amd64 have GitHub-hosted native
+            # runners; anything else falls back to QEMU emulation on amd64.
+            case "$p" in
+              linux/amd64) runner="ubuntu-24.04";     qemu=false ;;
+              linux/arm64) runner="ubuntu-24.04-arm"; qemu=false ;;
+              *)           runner="ubuntu-24.04";     qemu=true  ;;
+            esac
+            entries+=("$(jq -nc \
+              --arg platform "$p" \
+              --arg runner "$runner" \
+              --arg sanitized "$sanitized" \
+              --argjson qemu "$qemu" \
+              '{platform: $platform, runner: $runner, sanitized: $sanitized, qemu: $qemu}')")
+          done
+          if [ "${#entries[@]}" -eq 0 ]; then
+            echo "::error::no platforms parsed from input '$PLATFORMS'"
+            exit 1
+          fi
+          matrix="$(printf '%s\n' "${entries[@]}" | jq -sc '.')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Parsed platform matrix: $matrix"
+
+  # Per-platform build leg. Builds one platform on its mapped runner, mints its
+  # own OIDC token, pushes the image BY DIGEST (no tags), and uploads the digest
+  # plus per-leg metadata as artifacts for the merge job. No build-info, no
+  # attestation here.
   build:
+    needs: parse-platforms
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.parse-platforms.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
     env:
       JFROG_CLI_BUILD_NAME: ${{ inputs.jf-build-name || github.workflow }}
       JFROG_CLI_LOG_LEVEL: INFO
-    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
-
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-      image-ref: ${{ steps.meta.outputs.image-ref }}
-      tags: ${{ steps.tags.outputs.tags }}
-      immutable-tag: ${{ steps.tags.outputs.immutable-tag }}
-
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 
@@ -160,6 +216,11 @@ jobs:
           oidc-provider-name: ${{ inputs.oidc-provider-name }}
           oidc-audience: ${{ inputs.oidc-audience }}
 
+      - name: Record token fetch time
+        id: token_time
+        shell: bash
+        run: echo "fetched_at=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Compute registry
         id: registry
         shell: bash
@@ -172,56 +233,16 @@ jobs:
           echo "registry=$reg" >> "$GITHUB_OUTPUT"
 
       - name: Docker login to Artifactory
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ steps.registry.outputs.registry }}
           username: ${{ steps.jf.outputs.oidc-user }}
           password: ${{ steps.jf.outputs.oidc-token }}
 
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - name: Set up QEMU
+        if: ${{ matrix.qemu }}
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - uses: step-security/setup-buildx-action@f931205d68723ad9589fd2a7e2ece238bf9de341 # v4.0.0
-      - name: Compute tags
-        id: tags
-        shell: bash
-        run: |
-          base="${{ steps.registry.outputs.registry }}/${{ inputs.image-name }}"
-          timestamp=$(date --utc +%Y%m%dT%H%M%SZ)
-
-          # Extract major version (handle 'v' prefix, take first number before first dot)
-          app_version="${{ inputs.app-version }}"
-          app_version="${app_version#v}"  # Strip 'v' prefix if present
-          # OCI tags forbid '+' but SemVer build metadata uses it (e.g. 1.2.3+abc).
-          # Replace with '-' so SemVer inputs still produce valid image tags.
-          app_version="${app_version//+/-}"
-          major_version="${app_version%%.*}"  # Extract first number before first dot
-
-          # Build immutable tag (always included)
-          immutable="${base}:${app_version}_${timestamp}"
-
-          # Build tags array: always start with immutable tag
-          tags_array=("${immutable}")
-
-          if [ -n "${{ inputs.versions-override }}" ]; then
-            # Parse comma-separated override tags and prepend base
-            IFS=',' read -ra override_tags <<< "${{ inputs.versions-override }}"
-            for tag in "${override_tags[@]}"; do
-              # Trim whitespace and prepend base
-              tag=$(echo "$tag" | xargs)
-              if [ -n "$tag" ]; then
-                tags_array+=("${base}:${tag}")
-              fi
-            done
-          else
-            # Default tags: immutable, version, major version, and latest
-            tags_array+=("${base}:${app_version}" "${base}:${major_version}" "${base}:latest")
-          fi
-
-          # Join tags with comma for output
-          IFS=','
-          tags="${tags_array[*]}"
-
-          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
-          echo "immutable-tag=${immutable}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare build args/labels
         shell: bash
@@ -254,7 +275,8 @@ jobs:
           echo '${{ inputs.build-args-json }}' | to_kv > /tmp/build_args
           echo "$merged_labels" | to_kv > /tmp/labels
 
-          # Add JFROG_TOKEN to build args automatically
+          # Add JFROG_TOKEN to build args automatically (INFRA-560 Task 3.1 will
+          # remove this build-arg path; preserved here pending the consumer grep).
           echo "JFROG_TOKEN=${{ steps.jf.outputs.oidc-token }}" >> /tmp/build_args
 
           # Use heredoc syntax so multi-line values are preserved in GITHUB_ENV
@@ -272,7 +294,7 @@ jobs:
         env:
           # Pass OIDC credentials via env (not command-line args) so the token
           # is never exposed in the process list, and so values are available
-          # to jq for safe URL-encoding below.
+          # to jq for safe URL-encoding below. Built from THIS leg's own token.
           OIDC_USER: ${{ steps.jf.outputs.oidc-user }}
           OIDC_TOKEN: ${{ steps.jf.outputs.oidc-token }}
         run: |
@@ -317,41 +339,249 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_ENV"
 
-      - name: Build and push
+      - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
-          platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.push }}
-          tags: ${{ steps.tags.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           provenance: ${{ inputs.provenance }}
           sbom: ${{ inputs.sbom }}
           build-args: ${{ env.BUILD_ARGS }}
           labels: ${{ env.LABELS }}
           secret-files: ${{ env.BUILD_SECRET_FILES }}
+          # GHA build-step cache (mode=max). Caches expensive builder stages;
+          # scoped per platform so legs do not collide. Nothing is written to
+          # JFrog (no dev-local cache-exposure surface).
+          cache-from: type=gha,scope=${{ matrix.sanitized }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.sanitized }}
+          # Push by digest, no tags. The merge job assembles the tagged manifest.
+          outputs: type=image,name=${{ steps.registry.outputs.registry }}/${{ inputs.image-name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
+
+      - name: Record push time
+        id: push_time
+        shell: bash
+        run: echo "pushed_at=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Cleanup build secrets
         if: always()
         shell: bash
         run: rm -rf /tmp/docker-secrets
+
+      - name: Export digest and leg metadata
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PLATFORM: ${{ matrix.platform }}
+          SANITIZED: ${{ matrix.sanitized }}
+          RUNNER_ARCH: ${{ runner.arch }}
+          FETCHED_AT: ${{ steps.token_time.outputs.fetched_at }}
+          PUSHED_AT: ${{ steps.push_time.outputs.pushed_at }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/digests" "${RUNNER_TEMP}/legmeta"
+          # buildx-by-digest convention: an empty file named after the digest.
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+          # Per-leg metadata for test assertions (runner arch, token timing).
+          jq -nc \
+            --arg platform "$PLATFORM" \
+            --arg digest "$DIGEST" \
+            --arg runner_arch "$RUNNER_ARCH" \
+            --arg fetched_at "$FETCHED_AT" \
+            --arg pushed_at "$PUSHED_AT" \
+            '{platform:$platform, digest:$digest, runner_arch:$runner_arch, token_fetched_at:($fetched_at|tonumber), push_completed_at:($pushed_at|tonumber)}' \
+            > "${RUNNER_TEMP}/legmeta/${SANITIZED}.json"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.sanitized }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload leg metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: legmeta-${{ matrix.sanitized }}
+          path: ${{ runner.temp }}/legmeta/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge job: assemble one multi-platform manifest from the per-leg digests,
+  # compute tags, publish one build-info record (under the unchanged build
+  # number), and attest the manifest-list digest. Output-producing job.
+  merge:
+    needs: [parse-platforms, build]
+    runs-on: ubuntu-24.04
+    env:
+      JFROG_CLI_BUILD_NAME: ${{ inputs.jf-build-name || github.workflow }}
+      JFROG_CLI_LOG_LEVEL: INFO
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.manifest.outputs.digest }}
+      image-ref: ${{ steps.manifest.outputs.image-ref }}
+      tags: ${{ steps.tags.outputs.tags }}
+      immutable-tag: ${{ steps.tags.outputs.immutable-tag }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install JFrog CLI
+        id: jf
+        uses: step-security/setup-jfrog-cli@3054b554c0fb4915b3d58847fb7730c593dbb934 # v5.0.0
+        env:
+          JF_URL: ${{ inputs.jf-url }}
+          JF_PROJECT: ${{ inputs.jf-project }}
+          JFROG_CLI_BUILD_NAME: ${{ inputs.jf-build-name || github.workflow }}
+        with:
+          version: 2.78.8
+          oidc-provider-name: ${{ inputs.oidc-provider-name }}
+          oidc-audience: ${{ inputs.oidc-audience }}
+
+      - name: Compute registry
+        id: registry
+        shell: bash
+        run: |
+          set -euo pipefail
+          reg='${{ inputs.jf-registry }}'
+          if [ -z "$reg" ]; then
+            reg='${{ inputs.jf-registry-base }}/${{ inputs.jf-project }}${{ inputs.repo-scope }}'
+          fi
+          echo "registry=$reg" >> "$GITHUB_OUTPUT"
+
+      - name: Docker login to Artifactory
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ steps.registry.outputs.registry }}
+          username: ${{ steps.jf.outputs.oidc-user }}
+          password: ${{ steps.jf.outputs.oidc-token }}
+
+      - uses: step-security/setup-buildx-action@f931205d68723ad9589fd2a7e2ece238bf9de341 # v4.0.0
+
+      - name: Compute tags
+        id: tags
+        shell: bash
+        run: |
+          base="${{ steps.registry.outputs.registry }}/${{ inputs.image-name }}"
+          timestamp=$(date --utc +%Y%m%dT%H%M%SZ)
+
+          # Extract major version (handle 'v' prefix, take first number before first dot)
+          app_version="${{ inputs.app-version }}"
+          app_version="${app_version#v}"  # Strip 'v' prefix if present
+          # OCI tags forbid '+' but SemVer build metadata uses it (e.g. 1.2.3+abc).
+          # Replace with '-' so SemVer inputs still produce valid image tags.
+          app_version="${app_version//+/-}"
+          major_version="${app_version%%.*}"  # Extract first number before first dot
+
+          # Build immutable tag (always included)
+          immutable="${base}:${app_version}_${timestamp}"
+
+          # Build tags array: always start with immutable tag
+          tags_array=("${immutable}")
+
+          if [ -n "${{ inputs.versions-override }}" ]; then
+            # Parse comma-separated override tags and prepend base
+            IFS=',' read -ra override_tags <<< "${{ inputs.versions-override }}"
+            for tag in "${override_tags[@]}"; do
+              # Trim whitespace and prepend base
+              tag=$(echo "$tag" | xargs)
+              if [ -n "$tag" ]; then
+                tags_array+=("${base}:${tag}")
+              fi
+            done
+          else
+            # Default tags: immutable, version, major version, and latest
+            tags_array+=("${base}:${app_version}" "${base}:${major_version}" "${base}:latest")
+          fi
+
+          # Join tags with comma for output
+          IFS=','
+          tags="${tags_array[*]}"
+
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+          echo "immutable-tag=${immutable}" >> "$GITHUB_OUTPUT"
+
+      - name: Download per-leg digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Create multi-platform manifest
+        id: manifest
+        shell: bash
+        env:
+          REGISTRY: ${{ steps.registry.outputs.registry }}
+          IMAGE: ${{ inputs.image-name }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+          IMMUTABLE_TAG: ${{ steps.tags.outputs.immutable-tag }}
+          PUSH: ${{ inputs.push }}
+        run: |
+          set -euo pipefail
+          if [ "$PUSH" != "true" ]; then
+            echo "push=false; skipping manifest assembly"
+            echo "image-ref=" >> "$GITHUB_OUTPUT"
+            echo "digest=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # -t for every requested tag
+          tag_args=()
+          IFS=',' read -ra TAGS_ARR <<< "$TAGS"
+          for t in "${TAGS_ARR[@]}"; do
+            tag_args+=("-t" "$t")
+          done
+
+          # source refs: registry/image@sha256:<digest> for each leg digest file
+          src_args=()
+          shopt -s nullglob
+          for f in "${RUNNER_TEMP}/digests"/*; do
+            src_args+=("${REGISTRY}/${IMAGE}@sha256:$(basename "$f")")
+          done
+          if [ "${#src_args[@]}" -eq 0 ]; then
+            echo "::error::no per-leg digests found to assemble"
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" "${src_args[@]}"
+
+          # The manifest-list (index) digest is what consumers pull and what we
+          # attest. Read it back from the immutable tag.
+          digest="$(docker buildx imagetools inspect "$IMMUTABLE_TAG" --format '{{json .Manifest}}' | jq -r '.digest')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "image-ref=${IMMUTABLE_TAG}@${digest}" >> "$GITHUB_OUTPUT"
+
       # TODO: Uncomment this when xray scan is ready
       #   - name: xray scan
       #     shell: bash
       #     run: |
-      #       echo "JFROG_CLI_BUILD_NAME=${{ env.JFROG_CLI_BUILD_NAME }}"
       #       jf docker pull ${{ steps.tags.outputs.immutable-tag }} --build-name="${{ env.JFROG_CLI_BUILD_NAME }}" --build-number="$JFROG_CLI_BUILD_NUMBER"
       #       jf docker scan ${{ steps.tags.outputs.immutable-tag }} --build-name="${{ env.JFROG_CLI_BUILD_NAME }}" --build-number="$JFROG_CLI_BUILD_NUMBER"
+
       - name: Create build info for docker image
-        id: meta
+        if: ${{ inputs.push }}
         shell: bash
         run: |
-          # Use primary tag with digest for build-info
-          image_ref="${{ steps.tags.outputs.immutable-tag }}@${{ steps.build.outputs.digest }}"
-          echo "image-ref=${image_ref}" >> "$GITHUB_OUTPUT"
+          # Build-info is created against the multi-platform manifest-list digest,
+          # under the unchanged build number (the setup-jfrog-cli default,
+          # github.run_number) so existing consumer release-bundle references of
+          # the form <name>:${{ github.run_number }} still resolve.
+          image_ref="${{ steps.manifest.outputs.image-ref }}"
           jf rt build-docker-create --image-file <(echo "$image_ref") "${{ inputs.jf-project }}${{ inputs.repo-scope }}"
 
       - name: Publish Build Info
+        if: ${{ inputs.push }}
         shell: bash
         run: |
           jf rt build-collect-env  "$JFROG_CLI_BUILD_NAME" "$JFROG_CLI_BUILD_NUMBER"
@@ -359,8 +589,8 @@ jobs:
           jf rt build-publish --detailed-summary "$JFROG_CLI_BUILD_NAME" "$JFROG_CLI_BUILD_NUMBER"
 
       - name: Attest OCI Image
-        if: ${{ inputs.attest }}
+        if: ${{ inputs.attest && inputs.push }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: oci://${{ steps.tags.outputs.immutable-tag }}
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}

--- a/.github/workflows/reusable_docker-build-deploy.yaml
+++ b/.github/workflows/reusable_docker-build-deploy.yaml
@@ -275,9 +275,9 @@ jobs:
           echo '${{ inputs.build-args-json }}' | to_kv > /tmp/build_args
           echo "$merged_labels" | to_kv > /tmp/labels
 
-          # Add JFROG_TOKEN to build args automatically (INFRA-560 Task 3.1 will
-          # remove this build-arg path; preserved here pending the consumer grep).
-          echo "JFROG_TOKEN=${{ steps.jf.outputs.oidc-token }}" >> /tmp/build_args
+          # NOTE: the JFrog/OIDC token is intentionally NOT passed as a build-arg.
+          # Build-args persist in image history and provenance. The token reaches
+          # the build only via the jfrog_token secret-file mount (see below).
 
           # Use heredoc syntax so multi-line values are preserved in GITHUB_ENV
           {
@@ -320,11 +320,21 @@ jobs:
           # Delta 3: Write consumer-provided secrets from JSON
           secrets_json='${{ secrets.build-secrets-json }}'
           if [ -n "$secrets_json" ] && [ "$secrets_json" != "{}" ]; then
+            # Validate key names before using them as filenames. Keys become
+            # paths under /tmp/docker-secrets, so reject anything outside a safe
+            # charset (no '/', '..', etc.). Reject, do not sanitize.
+            if echo "$secrets_json" | jq -r 'keys[]' | grep -qvE '^[a-zA-Z0-9_-]+$'; then
+              echo "::error::build-secrets-json contains an invalid key name; keys must match ^[a-zA-Z0-9_-]+$"
+              exit 1
+            fi
             echo "$secrets_json" | jq -r 'to_entries[] | "\(.key)\n\(.value)"' | \
               while IFS= read -r key && IFS= read -r value; do
                 echo -n "$value" > "/tmp/docker-secrets/$key"
               done
           fi
+
+          # Lock down secret files: readable only by the runner process user.
+          chmod 600 /tmp/docker-secrets/* 2>/dev/null || true
 
           # Generate secret-files lines (only file paths, not values)
           secret_files=""

--- a/.github/workflows/reusable_docker-build-deploy.yaml
+++ b/.github/workflows/reusable_docker-build-deploy.yaml
@@ -77,7 +77,7 @@ on:
       push:
         type: boolean
         default: true
-        description: Whether to push the image
+        description: Whether to push the image. On a dry run (push=false) the digest and image-ref outputs are empty; tags and immutable-tag are still computed.
       repo-scope:
         type: string
         default: -docker-dev-local
@@ -150,11 +150,20 @@ jobs:
         run: |
           set -euo pipefail
           entries=()
+          declare -A seen
           IFS=',' read -ra arr <<< "$PLATFORMS"
           for p in "${arr[@]}"; do
             # trim surrounding whitespace
             p="$(echo "$p" | xargs)"
             [ -z "$p" ] && continue
+            # Dedupe by platform. A repeated platform would otherwise produce
+            # two legs with the same sanitized name and colliding digest/legmeta
+            # artifact uploads (a hard 409: same artifact name twice in one run).
+            if [ -n "${seen[$p]:-}" ]; then
+              echo "::warning::duplicate platform '$p' ignored"
+              continue
+            fi
+            seen[$p]=1
             sanitized="${p//\//-}"
             # Native runner mapping. arm64 and amd64 have GitHub-hosted native
             # runners; anything else falls back to QEMU emulation on amd64. The

--- a/.github/workflows/reusable_docker-build-deploy.yaml
+++ b/.github/workflows/reusable_docker-build-deploy.yaml
@@ -403,10 +403,16 @@ jobs:
             '{platform:$platform, digest:$digest, runner_arch:$runner_arch, token_fetched_at:($fetched_at|tonumber), push_completed_at:($pushed_at|tonumber)}' \
             > "${RUNNER_TEMP}/legmeta/${SANITIZED}.json"
 
+      # Artifact names are namespaced by image-name so the workflow can be
+      # invoked more than once in a single run (e.g. several images, or a
+      # multi-platform plus a single-platform build) without colliding. The
+      # `--` delimiter avoids glob prefix-collision between names where one is a
+      # prefix of another (e.g. "test-image" vs "test-image-single"). image-name
+      # must not contain `--` or characters illegal in artifact names.
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digests-${{ matrix.sanitized }}
+          name: digests-${{ inputs.image-name }}--${{ matrix.sanitized }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -414,7 +420,7 @@ jobs:
       - name: Upload leg metadata
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: legmeta-${{ matrix.sanitized }}
+          name: legmeta-${{ inputs.image-name }}--${{ matrix.sanitized }}
           path: ${{ runner.temp }}/legmeta/*
           if-no-files-found: error
           retention-days: 1
@@ -525,7 +531,8 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-*
+          # Scoped to this invocation's image-name (see upload namespacing note).
+          pattern: digests-${{ inputs.image-name }}--*
           merge-multiple: true
 
       - name: Create multi-platform manifest

--- a/.github/workflows/reusable_docker-build-deploy.yaml
+++ b/.github/workflows/reusable_docker-build-deploy.yaml
@@ -157,7 +157,11 @@ jobs:
             [ -z "$p" ] && continue
             sanitized="${p//\//-}"
             # Native runner mapping. arm64 and amd64 have GitHub-hosted native
-            # runners; anything else falls back to QEMU emulation on amd64.
+            # runners; anything else falls back to QEMU emulation on amd64. The
+            # mapping is internal (consumers only pass `platforms`); the QEMU
+            # fallback is intentional. Do NOT add a hard-fail guard for
+            # unrecognized platforms: consumers may pass exotic platforms
+            # expecting emulation.
             case "$p" in
               linux/amd64) runner="ubuntu-24.04";     qemu=false ;;
               linux/arm64) runner="ubuntu-24.04-arm"; qemu=false ;;

--- a/.github/workflows/test_docker-build-deploy-workflow.yaml
+++ b/.github/workflows/test_docker-build-deploy-workflow.yaml
@@ -40,6 +40,7 @@ jobs:
       version: ${{ steps.extract.outputs.version }}
       git_tag: ${{ steps.extract.outputs.git_tag }}
 
+  # Multi-platform build (default platforms = linux/amd64,linux/arm64).
   test-docker-build-deploy:
     uses: ./.github/workflows/reusable_docker-build-deploy.yaml
     needs: extract-version
@@ -52,3 +53,198 @@ jobs:
       jf-build-name: test-container
       oidc-provider-name: gh-dev-test
       oidc-audience: aerospike/testing
+
+  # Single-platform build (AC5 single-platform / Task 1.3): a single-platform
+  # call must still publish a multi-platform manifest index. Distinct image-name
+  # and build-name so its artifacts and build-info do not collide with the
+  # multi-platform job in the same run.
+  test-docker-build-deploy-single:
+    uses: ./.github/workflows/reusable_docker-build-deploy.yaml
+    needs: extract-version
+    with:
+      jf-project: test
+      image-name: test-image-single
+      app-version: ${{ needs.extract-version.outputs.version }}
+      platforms: linux/amd64
+      context: ./.github/workflows/execute-build/test_apps/hi
+      file: ./.github/workflows/execute-build/test_apps/hi/Dockerfile
+      jf-build-name: test-container-single
+      oidc-provider-name: gh-dev-test
+      oidc-audience: aerospike/testing
+
+  # AC12 (negative): attestation runs only in the merge job. A definition-level
+  # lint so re-adding attest to a leg fails fast, no build needed.
+  ac12-no-per-leg-attest:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Assert exactly one attest-build-provenance, in the merge job
+        shell: bash
+        run: |
+          set -euo pipefail
+          wf=.github/workflows/reusable_docker-build-deploy.yaml
+          count=$(grep -c "attest-build-provenance@" "$wf" || true)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected exactly 1 attest-build-provenance use in $wf, found $count"
+            exit 1
+          fi
+          # It must live under the merge job, not a build leg. Assert the only
+          # occurrence appears after the 'merge:' job header.
+          attest_line=$(grep -n "attest-build-provenance@" "$wf" | cut -d: -f1)
+          merge_line=$(grep -n "^  merge:" "$wf" | cut -d: -f1)
+          if [ -z "$merge_line" ] || [ "$attest_line" -lt "$merge_line" ]; then
+            echo "::error::attest-build-provenance is not inside the merge job"
+            exit 1
+          fi
+          echo "AC12 negative: ok (1 attest, in merge job)"
+
+  verify:
+    needs:
+      [
+        extract-version,
+        test-docker-build-deploy,
+        test-docker-build-deploy-single,
+      ]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    env:
+      MULTI_IMMUTABLE: ${{ needs.test-docker-build-deploy.outputs.immutable-tag }}
+      MULTI_DIGEST: ${{ needs.test-docker-build-deploy.outputs.digest }}
+      MULTI_IMAGE_REF: ${{ needs.test-docker-build-deploy.outputs.image-ref }}
+      MULTI_TAGS: ${{ needs.test-docker-build-deploy.outputs.tags }}
+      SINGLE_IMMUTABLE: ${{ needs.test-docker-build-deploy-single.outputs.immutable-tag }}
+      BUILD_NAME: test-container
+      BUILD_NUMBER: ${{ github.run_number }}
+      JF_URL: https://artifact.aerospike.io
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install JFrog CLI
+        id: jf
+        uses: step-security/setup-jfrog-cli@3054b554c0fb4915b3d58847fb7730c593dbb934 # v5.0.0
+        env:
+          JF_URL: ${{ env.JF_URL }}
+          JF_PROJECT: test
+        with:
+          version: 2.78.8
+          oidc-provider-name: gh-dev-test
+          oidc-audience: aerospike/testing
+
+      - name: Docker login to Artifactory
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: artifact.aerospike.io
+          username: ${{ steps.jf.outputs.oidc-user }}
+          password: ${{ steps.jf.outputs.oidc-token }}
+
+      - uses: step-security/setup-buildx-action@f931205d68723ad9589fd2a7e2ece238bf9de341 # v4.0.0
+
+      - name: AC - outputs are populated and well formed
+        shell: bash
+        run: |
+          set -euo pipefail
+          for v in MULTI_IMMUTABLE MULTI_DIGEST MULTI_IMAGE_REF MULTI_TAGS SINGLE_IMMUTABLE; do
+            if [ -z "${!v}" ]; then echo "::error::output $v is empty"; exit 1; fi
+          done
+          case "$MULTI_IMAGE_REF" in
+            *@sha256:*) : ;;
+            *) echo "::error::image-ref missing @sha256 digest: $MULTI_IMAGE_REF"; exit 1 ;;
+          esac
+          echo "outputs ok"
+
+      - name: AC5 - multi-platform result is a manifest index with both arches
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(docker buildx imagetools inspect "$MULTI_IMMUTABLE" --format '{{json .}}')
+          mt=$(echo "$out" | jq -r '.manifest.mediaType')
+          echo "media type: $mt"
+          case "$mt" in
+            *image.index*|*manifest.list*) : ;;
+            *) echo "::error::multi result is not a manifest index: $mt"; exit 1 ;;
+          esac
+          for arch in amd64 arm64; do
+            echo "$out" | jq -e --arg a "$arch" '.manifest.manifests[]?.platform | select(.os=="linux" and .architecture==$a)' >/dev/null \
+              || { echo "::error::manifest index missing linux/$arch"; exit 1; }
+          done
+          echo "AC5 multi: ok (index with amd64+arm64)"
+
+      - name: AC5 - single-platform result is still a manifest index
+        shell: bash
+        run: |
+          set -euo pipefail
+          mt=$(docker buildx imagetools inspect "$SINGLE_IMMUTABLE" --format '{{json .}}' | jq -r '.manifest.mediaType')
+          echo "single media type: $mt"
+          case "$mt" in
+            *image.index*|*manifest.list*) echo "AC5 single: ok (index)";;
+            *) echo "::error::single-platform result is not a manifest index: $mt"; exit 1 ;;
+          esac
+
+      - name: Download per-leg metadata (multi)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/legmeta
+          pattern: legmeta-test-image--*
+          merge-multiple: true
+
+      - name: AC2/AC8 + token-timing - native runner per arch, push within token lifetime
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=("${RUNNER_TEMP}/legmeta"/*.json)
+          if [ "${#files[@]}" -eq 0 ]; then echo "::error::no leg metadata found"; exit 1; fi
+          for f in "${files[@]}"; do
+            platform=$(jq -r '.platform' "$f")
+            arch=$(jq -r '.runner_arch' "$f")
+            fetched=$(jq -r '.token_fetched_at' "$f")
+            pushed=$(jq -r '.push_completed_at' "$f")
+            echo "leg $platform: runner_arch=$arch, push-minus-fetch=$((pushed - fetched))s"
+            case "$platform" in
+              linux/amd64) [ "$arch" = "X64" ]   || { echo "::error::amd64 leg not on X64 runner ($arch)"; exit 1; } ;;
+              linux/arm64) [ "$arch" = "ARM64" ] || { echo "::error::arm64 leg not on ARM64 runner ($arch)"; exit 1; } ;;
+            esac
+            if [ "$((pushed - fetched))" -ge 1800 ]; then
+              echo "::error::$platform push was not within the 30-min token lifetime"; exit 1
+            fi
+          done
+          echo "AC2/AC8 + token-timing: ok"
+
+      - name: AC6 - one build-info record references the manifest-list digest
+        shell: bash
+        env:
+          TOKEN: ${{ steps.jf.outputs.oidc-token }}
+        run: |
+          set -euo pipefail
+          code=$(curl -s -o /tmp/bi.json -w '%{http_code}' \
+            -H "Authorization: Bearer $TOKEN" \
+            "$JF_URL/artifactory/api/build/${BUILD_NAME}/${BUILD_NUMBER}")
+          echo "build-info HTTP $code"
+          [ "$code" = "200" ] || { echo "::error::build-info $BUILD_NAME/$BUILD_NUMBER not found ($code)"; cat /tmp/bi.json; exit 1; }
+          digest="${MULTI_DIGEST#sha256:}"
+          if ! grep -q "$digest" /tmp/bi.json; then
+            echo "::error::build-info does not reference the manifest-list digest $MULTI_DIGEST"; exit 1
+          fi
+          echo "AC6: ok (record present, references manifest-list digest)"
+
+      - name: AC11 - no JFROG_TOKEN build-arg in image history
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "$MULTI_IMMUTABLE" >/dev/null
+          if docker history --no-trunc --format '{{.CreatedBy}}' "$MULTI_IMMUTABLE" | grep -q "JFROG_TOKEN"; then
+            echo "::error::JFROG_TOKEN found in image history"; exit 1
+          fi
+          echo "AC11: ok (no JFROG_TOKEN in history)"

--- a/.github/workflows/test_docker-build-deploy-workflow.yaml
+++ b/.github/workflows/test_docker-build-deploy-workflow.yaml
@@ -51,8 +51,8 @@ jobs:
       context: ./.github/workflows/execute-build/test_apps/hi
       file: ./.github/workflows/execute-build/test_apps/hi/Dockerfile
       jf-build-name: test-container
-      oidc-provider-name: gh-dev-test
-      oidc-audience: aerospike/testing
+      oidc-provider-name: gh-aerospike
+      oidc-audience: aerospike
 
   # Single-platform build (AC5 single-platform / Task 1.3): a single-platform
   # call must still publish a multi-platform manifest index. Distinct image-name
@@ -69,8 +69,8 @@ jobs:
       context: ./.github/workflows/execute-build/test_apps/hi
       file: ./.github/workflows/execute-build/test_apps/hi/Dockerfile
       jf-build-name: test-container-single
-      oidc-provider-name: gh-dev-test
-      oidc-audience: aerospike/testing
+      oidc-provider-name: gh-aerospike
+      oidc-audience: aerospike
 
   # AC12 (negative): attestation runs only in the merge job. A definition-level
   # lint so re-adding attest to a leg fails fast, no build needed.
@@ -139,8 +139,8 @@ jobs:
           JF_PROJECT: test
         with:
           version: 2.78.8
-          oidc-provider-name: gh-dev-test
-          oidc-audience: aerospike/testing
+          oidc-provider-name: gh-aerospike
+          oidc-audience: aerospike
 
       - name: Docker login to Artifactory
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/test_docker-build-deploy-workflow.yaml
+++ b/.github/workflows/test_docker-build-deploy-workflow.yaml
@@ -228,9 +228,14 @@ jobs:
           TOKEN: ${{ steps.jf.outputs.oidc-token }}
         run: |
           set -euo pipefail
+          # Build-info published under a JFrog project must be queried with the
+          # project param; the global /api/build/<name>/<number> path 404s for
+          # project-scoped builds. The build number is github.run_number (the
+          # setup-jfrog-cli default), which is what consumer release-bundle
+          # references rely on.
           code=$(curl -s -o /tmp/bi.json -w '%{http_code}' \
             -H "Authorization: Bearer $TOKEN" \
-            "$JF_URL/artifactory/api/build/${BUILD_NAME}/${BUILD_NUMBER}")
+            "$JF_URL/artifactory/api/build/${BUILD_NAME}/${BUILD_NUMBER}?project=test")
           echo "build-info HTTP $code"
           [ "$code" = "200" ] || { echo "::error::build-info $BUILD_NAME/$BUILD_NUMBER not found ($code)"; cat /tmp/bi.json; exit 1; }
           digest="${MULTI_DIGEST#sha256:}"


### PR DESCRIPTION
Reworks `reusable_docker-build-deploy.yaml` internals so multi-arch images build natively per platform, the OIDC token used at push is always fresh, and warm builds reuse layers. The `workflow_call` inputs/outputs surface is unchanged.

[INFRA-560](https://aerospike.atlassian.net/browse/INFRA-560)

## Changes
- `parse-platforms` job emits a dynamic matrix: `linux/amd64` -> `ubuntu-24.04`, `linux/arm64` -> `ubuntu-24.04-arm`, anything else -> QEMU.
- Per-platform `build` legs each mint their own OIDC token and push by digest, with `type=gha,mode=max` layer cache scoped per platform.
- `merge` job assembles one multi-platform manifest via `imagetools create`, publishes one build-info record under the unchanged `github.run_number`, and attests the manifest-list digest. The four workflow outputs resolve from it.
- The internal `JFROG_TOKEN` build-arg is removed; the token reaches the build only via the `jfrog_token` secret-mount. It was never a `workflow_call` input and no consumer Dockerfile declares `ARG JFROG_TOKEN`, so this is not a breaking change.
- Per-leg secret hardening (chmod 600, key-name validation) and test-app `FROM` lines repointed through the JFrog virtual.

## Scope
Full rework: native legs, per-leg OIDC, merge/manifest, build-info, attestation, layer caching, secret hardening, docs, tests. Deferred: the INFRA-553 token-expiry revert in `tf-artifactory`, gated on aerospike-client-c adopting this workflow (tracked separately).

## Test plan
- [x] `trunk check` (actionlint + yamllint) clean.
- [x] Multi-platform CI run: manifest index has both arch entries, native runners used, build-info discoverable by `<name>:<run_number>`, attestation on the manifest-list digest (runs 26980975765, 27045884476).
- [x] Single-platform run still yields a manifest index.
- [x] No `JFROG_TOKEN` in image history (AC11) verified in CI.


[INFRA-560]: https://aerospike.atlassian.net/browse/INFRA-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ