### PR TITLE
feat(deploy-artifacts): [CLIENT-4300] expose jf-build-id as workflow output

### DIFF
--- a/.github/workflows/reusable_deploy-artifacts.yaml
+++ b/.github/workflows/reusable_deploy-artifacts.yaml
@@ -92,6 +92,11 @@ on:
         required: false
         type: string
         default: ubuntu-22.04
+
+    outputs:
+      jf-build-id:
+        description: JFrog build ID echoed back from the deploy job
+        value: ${{ jobs.deploy.outputs.jf-build-id }}
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/test_deploy-artifacts-workflow.yaml
+++ b/.github/workflows/test_deploy-artifacts-workflow.yaml
@@ -45,6 +45,32 @@ jobs:
       gh-artifact-name: test-fixtures
       dry-run: true
 
+  verify-workflow-outputs:
+    needs: test-deploy-workflow
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Verify jf-build-id output is exposed to callers
+        env:
+          ACTUAL_BUILD_ID: ${{ needs.test-deploy-workflow.outputs.jf-build-id }}
+          EXPECTED_BUILD_ID: ${{ github.run_number }}
+        run: |
+          echo "Expected jf-build-id: ${EXPECTED_BUILD_ID}"
+          echo "Actual jf-build-id:   ${ACTUAL_BUILD_ID}"
+          if [[ -z "${ACTUAL_BUILD_ID}" ]]; then
+            echo "::error::jf-build-id output is empty - workflow_call output is not exposed to callers"
+            exit 1
+          fi
+          if [[ "${ACTUAL_BUILD_ID}" != "${EXPECTED_BUILD_ID}" ]]; then
+            echo "::error::jf-build-id output mismatch: expected '${EXPECTED_BUILD_ID}', got '${ACTUAL_BUILD_ID}'"
+            exit 1
+          fi
+          echo "jf-build-id output verified successfully"
+
   run-tests:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
  Expose `jf-build-id` as a `workflow_call` output on `reusable_deploy-artifacts.yaml`,
  wired from the `deploy` job, so callers can reference the JFrog build ID after
  invoking the workflow.

  ## Issue

  [CLIENT-4300] Callers of the composable `deploy-artifacts` workflow had no way to
  read back the JFrog build ID it used. Exposing it as an output lets downstream
  jobs consume it without hardcoding or recomputing the value.
  
  ## Test Result:
https://github.com/aerospike/shared-workflows/actions/runs/27198068378/job/80294730016


[CLIENT-4300]: https://aerospike.atlassian.net/browse/CLIENT-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ