### PR TITLE
fix(collect): [INFRA-597] Refactor merging to catch same file names

### DIFF
--- a/.github/actions/collect-build-artifacts/README.md
+++ b/.github/actions/collect-build-artifacts/README.md
@@ -2,6 +2,12 @@
 
 Download per-matrix build artifacts and merge them into a single artifact for downstream jobs (sign, deploy). This is the standard collect step in the composable pipeline pattern.
 
+## Behavior
+
+1. **Download** all artifacts matching the glob with **`merge-multiple: false`**, so each named artifact is extracted under its own subdirectory (see [download-artifact](https://github.com/actions/download-artifact)). That avoids concurrent unpack into the same basename, which can **corrupt** binary artifacts (for example invalid ZIPs / bad CRC inside wheels).
+2. **Merge** every file under those subdirectories into one flat output directory using `merge_flat.sh` (`cp -p`, sequential). If two files would map to the same **basename**, the step **fails** with a clear message instead of silently overwriting.
+3. **Upload** the flat directory as a single artifact (`output-name`, default `build-artifacts`).
+
 ## Inputs
 
 | Input            | Required | Default             | Description                                  |
@@ -25,3 +31,5 @@ collect:
 ```
 
 All inputs have defaults matching the standard pipeline conventions. If your build jobs upload artifacts as `build-artifacts-{distro}-{arch}`, this action works with no configuration.
+
+Ensure matrix jobs do not emit different files with the **same filename** into their artifact directories; if they do, the collect step will error until filenames or layout are fixed.

--- a/.github/actions/collect-build-artifacts/action.yaml
+++ b/.github/actions/collect-build-artifacts/action.yaml
@@ -16,12 +16,23 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download matrix artifacts
+    # merge-multiple: false isolates each matrix artifact under its own subdirectory so
+    # the Actions runtime never extracts multiple zips into the same basename in parallel
+    # (which can corrupt wheels and other binaries). merge_flat.sh then copies files
+    # sequentially into one flat directory and fails fast on basename collisions.
+    - name: Download matrix artifacts (isolated per artifact)
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: ${{ inputs.pattern }}
-        path: ${{ inputs.output-name }}
-        merge-multiple: true
+        path: ${{ inputs.output-name }}.collect-staging
+        merge-multiple: false
+    - name: Merge into flat directory (sequential, duplicate-safe)
+      shell: bash
+      run: bash "${{ github.action_path }}/merge_flat.sh" "${{ inputs.output-name }}.collect-staging" "${{ inputs.output-name }}"
+    - name: Remove staging directory
+      shell: bash
+      if: always()
+      run: rm -rf "${{ inputs.output-name }}.collect-staging"
     - name: Upload merged artifacts
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:

--- a/.github/actions/collect-build-artifacts/merge_flat.sh
+++ b/.github/actions/collect-build-artifacts/merge_flat.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Merge per-artifact staging trees (from download-artifact with merge-multiple: false)
+# into a single flat directory. Sequential copies avoid concurrent writes to the same
+# basename, which can corrupt binaries (e.g. wheels) when merge-multiple: true is used.
+#
+# Usage: merge_flat.sh <staging_dir> <output_dir>
+# Env: STRICT_DUPLICATE_BASENAMES=true (default) — exit 1 if two files map to the same basename.
+
+set -euo pipefail
+
+STAGING="${1:?usage: merge_flat.sh <staging_dir> <output_dir>}"
+OUT="${2:?usage: merge_flat.sh <staging_dir> <output_dir>}"
+
+if [[ ! -d $STAGING ]]; then
+    echo "collect merge: staging directory not found: $STAGING" >&2
+    exit 1
+fi
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+file_count=0
+while IFS= read -r -d '' f; do
+    base=$(basename "$f")
+    dest="$OUT/$base"
+    if [[ -e $dest ]]; then
+        echo "collect merge: duplicate basename (refuse to overwrite). Use unique filenames across matrix artifacts." >&2
+        echo "  already: $dest" >&2
+        echo "  also:    $f" >&2
+        exit 1
+    fi
+    cp -p "$f" "$dest"
+    file_count=$((file_count + 1))
+done < <(find "$STAGING" -type f -print0)
+
+if [[ $file_count -eq 0 ]]; then
+    echo "collect merge: no files under $STAGING (check artifact pattern and upstream uploads)" >&2
+    exit 1
+fi
+
+echo "collect merge: copied $file_count file(s) into $OUT" >&2

--- a/.github/workflows/docs/CICD-composable.md
+++ b/.github/workflows/docs/CICD-composable.md
@@ -83,7 +83,9 @@ Deploy parent:     {run_id}-{run_attempt}
 
 **Artifact naming.** Each build job uploads with a distinct name (e.g., `build-artifacts-el9-x86_64`, `build-artifacts-npm-x86_64`). The `collect-build-artifacts` action merges these into a single `build-artifacts` artifact that sign and deploy consume.
 
-**Collecting matrix artifacts.** Use the `collect-build-artifacts` composite action after all build jobs complete. It downloads all artifacts matching a pattern (default `build-artifacts-*`) and re-uploads them as one merged artifact.
+**Collecting matrix artifacts.** Use the `collect-build-artifacts` composite action after all build jobs complete. It downloads all artifacts matching a pattern (default `build-artifacts-*`) with **`merge-multiple: false`** (each artifact isolated), runs `merge_flat.sh` to copy files **sequentially** into one flat directory (avoids corrupting binaries when the same basename is unpacked concurrently), **fails fast** if two files would share the same basename, then re-uploads as one merged artifact.
+
+**Why not `merge-multiple: true`?** Flat-merging multiple artifact zips into one directory can interleave or partially overwrite the same path under load, producing damaged archives (for example ZIP CRC errors inside wheels). Isolated download plus sequential copy prevents that class of failure.
 
 **Signing secrets.** GPG keys (and SSL.com credentials if nupkg files or Windows executables are present) must be available. For Mac signing, provide Apple certificates and notarization credentials; for Windows signing, provide SSL.com eSigner credentials. See the [sign-mac-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-mac-artifacts/README.md) and [sign-win-artifacts README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/sign-win-artifacts/README.md).
 

--- a/.github/workflows/reusable_artifacts-cicd.yaml
+++ b/.github/workflows/reusable_artifacts-cicd.yaml
@@ -404,12 +404,32 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Download matrix artifacts
+      - name: Checkout shared-workflows (collect merge script only)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: aerospike/shared-workflows
+          ref: ${{ inputs.gh-workflows-ref }}
+          path: _shared-workflows-collect
+          sparse-checkout: |
+            .github/actions/collect-build-artifacts
+          sparse-checkout-cone-mode: true
+
+      - name: Download matrix artifacts (isolated per artifact)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: build-artifacts-*
-          path: build-artifacts
-          merge-multiple: true
+          path: build-artifacts.collect-staging
+          merge-multiple: false
+
+      - name: Merge into flat directory (sequential, duplicate-safe)
+        shell: bash
+        run: bash "$GITHUB_WORKSPACE/_shared-workflows-collect/.github/actions/collect-build-artifacts/merge_flat.sh" build-artifacts.collect-staging build-artifacts
+
+      - name: Remove staging directory
+        if: always()
+        shell: bash
+        run: rm -rf build-artifacts.collect-staging
+
       - name: Print build-artifacts contents
         run: |
           echo Downloaded collected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,9 @@ The `reusable_artifacts-cicd.yaml` orchestrator runs 5 jobs. Understanding the a
 
 ### Collect stage (`collect-matrix-artifacts` job)
 
-- `download-artifact` with `pattern: build-artifacts-*` and `merge-multiple: true`
-- All files from all matrix artifacts merge flat into `build-artifacts/`
-- **Collision risk**: if two matrix builds produce files with the same name, one silently overwrites the other
+- `download-artifact` with `pattern: build-artifacts-*` and **`merge-multiple: false`** so each matrix artifact extracts under its own subdirectory (avoids parallel unpack races into the same basename, which can corrupt zips such as wheels)
+- `merge_flat.sh` copies every file **sequentially** into a flat `build-artifacts/` tree (`cp -p`)
+- **Duplicate basename** across matrix artifacts is a hard error (exit 1 with paths) instead of silent overwrite; fix matrix outputs or artifact layout if this triggers
 - Re-uploads as single `build-artifacts` artifact
 
 ### Sign stage (`reusable_sign-artifacts.yaml`)


### PR DESCRIPTION
With merge-multiple: true, every matched artifact is unpacked into one directory. If the same basename exists in more than one artifact (or the runner unpacks in parallel), you can get interleaved or partial writes to the same path. Wheels are ZIPs; that shows up as bad CRC on members like _aerospike_async_native.cp310-win_amd64.pyd.

- merge-multiple: false
Each matrix artifact is extracted under its own subdirectory under a staging path (see [download-artifact](https://github.com/actions/download-artifact): with merge-multiple: false, each artifact is under a named folder inside path).

- merge_flat.sh
Walks the staging tree with find … -print0, copies each file into the flat output with cp -p, one after another. No concurrent writers on the same path.

- Duplicate basenames → hard fail
If a second file would use the same basename as one already copied, the script exits 1 and prints both paths, instead of silently overwriting (which hid collisions and could still yield garbage).