### PR TITLE
fix(sign): [CLIENT-4299] skip GPG when no signable files remain after NuGet/Windows isolation

### DIFF
--- a/.github/workflows/reusable_sign-artifacts.yaml
+++ b/.github/workflows/reusable_sign-artifacts.yaml
@@ -109,6 +109,20 @@ jobs:
           done < <(find unsigned-artifacts -type f \( -name '*.exe' -o -name '*.msi' -o -name '*.msix' \) -print0 2>/dev/null || true)
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "Isolated $count Windows installer file(s) from GPG (Authenticode-only, mirrors NuGet isolation)"
+      - name: Check for GPG-signable artifacts
+        id: gpg-artifacts
+        run: |
+          set -euo pipefail
+          # Count files left in unsigned-artifacts/ after NuGet and Windows
+          # Authenticode isolation. Exclude detached signatures so an orphan
+          # .asc never makes us spin up GPG with nothing to actually sign.
+          count=$(find unsigned-artifacts -type f ! -name '*.asc' 2>/dev/null | wc -l | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" -eq 0 ]; then
+            echo "No GPG-signable artifacts remain after NuGet/Windows isolation; skipping GPG signing."
+          else
+            echo "Found $count file(s) for GPG signing."
+          fi
       - name: Checkout shared-workflows repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -118,6 +132,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up GPG
+        if: steps.gpg-artifacts.outputs.count != '0'
         uses: aerospike/shared-workflows/.github/actions/setup-gpg@bd168dedaa4fc0b17a560541779d815540eded2d # v3.7.0
         with:
           gpg-private-key: ${{ secrets.gpg-private-key }}
@@ -148,9 +163,11 @@ jobs:
           signing_method: v1
 
       - name: Install dpkg-sig
+        if: steps.gpg-artifacts.outputs.count != '0'
         run: |
           sudo apt-get update && sudo apt-get install dpkg-sig dpkg-dev -y
       - name: Sign Artifacts
+        if: steps.gpg-artifacts.outputs.count != '0'
         run: |
           entrypoint="${{ inputs.gh-checkout-path }}/.github/workflows/sign-artifacts/entrypoint.sh"
           chmod +x "$entrypoint"

--- a/.github/workflows/sign-artifacts/README.md
+++ b/.github/workflows/sign-artifacts/README.md
@@ -43,6 +43,7 @@ Notes:
 
 - NuGet signing runs only if `.nupkg` files are present in the unsigned artifacts.
 - If `.nupkg` files are found, all four SSL.com secrets above must be provided or the workflow fails.
+- GPG setup and signing are skipped automatically when no GPG-signable files remain after NuGet and Windows Authenticode isolation (e.g. a NuGet-only or Windows-only build). The job still uploads the signed NuGet/Windows outputs.
 - **macOS `.pkg` / `.dmg`** are not isolated by this workflow; they still receive GPG detached signatures if present under `unsigned-artifacts`. Use the orchestrator’s `sign-mac` job for Apple signing before this job when you need Apple-only treatment.
 
 ---


### PR DESCRIPTION
**Issue :**

**Git Run failed during signing**
https://github.com/aerospike/aerospike-client-c/actions/runs/27842750042/job/82464469143

```
Run entrypoint="shared-workflows/.github/workflows/sign-artifacts/entrypoint.sh"
Expanding glob pattern: unsigned-artifacts/**/*
No matching artifacts found for pattern: unsigned-artifacts/**/*
Error: Process completed with exit code 1.
```

**Failure Cause:**

The [sign nupkg job](https://github.com/aerospike/aerospike-client-c/actions/runs/27842750042/job/82464469143) calls reusable_sign-artifacts.yaml@v3.6.0, which:

Downloads win-unsigned-nupkg → unsigned-artifacts/
Moves all `.nupkg` files to `unsigned-nuget-packages/` for` SSL.com` signing
Signs them with `SSL.com` → win-signed-nupkg/nuget/
Since our Windows artifact contains only `.nupkg` files  so `unsigned-artifacts/` left empty after moving out `nupkg` files and eventually fails here during `GPG` step

**Solution:**
skipping the GPG step when` unsigned-artifacts/` is empty after NuGet/Windows isolation.

