### PR TITLE
fix: [INFRA-629] Fix permissions for metadata upload

### DIFF
--- a/.github/workflows/artifacts-cicd/README.md
+++ b/.github/workflows/artifacts-cicd/README.md
@@ -10,6 +10,18 @@ This orchestrator is the simpler of two supported approaches: it handles the ful
 
 The other approach is the composable pipeline See [CICD-composable.md](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/docs/CICD-composable.md) for that workflow. (Hint if you want to integrate tests or custom steps between stages, the composable pipeline is the right choice rather than this one.)
 
+## Workflow permissions
+
+Grant at least `contents: read` and `id-token: write` on your caller workflow (or calling job):
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+If your build produces Maven/JAR artifacts and you rely on bundle metadata for release bundles, also add `actions: write` so the deploy stage can upload `.maven-bundle-metadata.json` as a GitHub artifact. See [deploy-artifacts README](../deploy-artifacts/README.md#permissions).
+
 ## Usage
 
 ```yaml

--- a/.github/workflows/deploy-artifacts/README.md
+++ b/.github/workflows/deploy-artifacts/README.md
@@ -216,6 +216,21 @@ deploy-artifacts/
 
 The `gh-workflows-ref` input is **required** and must match the version in your `uses:` line. See [Why gh-workflows-ref is required](../docs/why-gh-workflows-ref.md) for details.
 
+## Permissions
+
+Workflow-level permissions are `contents: read` and `id-token: write` so nested calls from `reusable_artifacts-cicd.yaml` validate without extra caller grants.
+
+The `deploy` job requests `actions: write` at **job scope** only, for the optional Maven bundle metadata upload (`gh-upload-bundle-metadata`, default `true`). At runtime, that upload succeeds only when the **top-level caller workflow** also grants `actions: write`:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+  actions: write # required when gh-upload-bundle-metadata is true and Maven metadata is produced
+```
+
+If you do not use Maven bundle metadata (no `.maven-bundle-metadata.json`, or `gh-upload-bundle-metadata: false`), callers can omit `actions: write`; deploy to JFrog still works and only the metadata upload step is skipped or not attempted.
+
 ## Prerequisites
 
 - JFrog Artifactory instance with OIDC authentication configured

--- a/.github/workflows/docs/CICD-composable.md
+++ b/.github/workflows/docs/CICD-composable.md
@@ -70,6 +70,8 @@ deploy  →  create-release-bundle  →  promote
 
 When you use `reusable_deploy-artifacts.yaml` followed by `reusable_create-release-bundle.yaml`, pass `gh-bundle-metadata-artifact-name: ${{ needs.<deploy-job>.outputs.bundle-metadata-artifact-name }}` so Maven bundle metadata (`.maven-bundle-metadata.json`) is carried between jobs as a small artifact; the deploy workflow sets `bundle-metadata-available` when that upload ran.
 
+**Permissions:** caller workflows need `contents: read` and `id-token: write`. When using Maven bundle metadata upload (`gh-upload-bundle-metadata`, default `true`), also grant `actions: write` on the top-level workflow or job. Set `gh-upload-bundle-metadata: false` on the deploy call if you do not need the metadata artifact and cannot grant `actions: write`.
+
 ### Key concepts
 
 **Build IDs.** The `jf-build-id` ties build-info together across stages. Use `${{ github.run_id }}-${{ github.run_attempt }}` as the base. Each build job adds a unique suffix; the deploy job uses the base without the suffix.
@@ -212,6 +214,8 @@ See [Why gh-workflows-ref is required](https://github.com/aerospike/shared-workf
 
 ## Troubleshooting tips
 
+- **Workflow validation: "requesting 'actions: write', but is only allowed 'actions: none'"** → upgrade shared-workflows to a release where deploy scopes `actions: write` to the deploy job only. Add `actions: write` to your caller `permissions` when using Maven bundle metadata upload.
+- **Deploy fails on "Upload Maven bundle metadata"** → add `actions: write` to your caller workflow, or set `gh-upload-bundle-metadata: false` on deploy.
 - **Deploy fails (auth)** → confirm GitHub→JFrog **OIDC** trust/policy is configured and that the workflow's identity has deploy permission to the target project/repo. Common mistakes: wrong audience or incorrect token permissions.
 - **Docker push fails** → ensure `tag` includes the full registry path (e.g., `artifact.aerospike.io/project-docker-dev-local/image:tag`). Verify JFrog registry permissions and OIDC authentication.
 - **Bundle issues** → see the troubleshooting section in [Release Bundles](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/docs/release-bundles.md#troubleshooting).

--- a/.github/workflows/docs/CICD-standard.md
+++ b/.github/workflows/docs/CICD-standard.md
@@ -35,6 +35,18 @@ The architecture follows an ecosystem-specific build & sign pattern, where artif
 
 **Create Release Bundle** → combine artifacts and/or docker builds into a single distributable release bundle
 
+## Workflow permissions
+
+Caller workflows need at least:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+Since v3.8.0, deploy can upload optional Maven bundle metadata (`.maven-bundle-metadata.json`) for release-bundle annotation. If your pipeline builds Maven/JAR artifacts and chains into `reusable_create-release-bundle.yaml` via that metadata artifact, add `actions: write` to the caller workflow (or job) permissions. Without it, deploy to JFrog still succeeds; only the metadata upload step fails when metadata is produced.
+
 ## Standard Workflows for your project
 
 - `reusable_artifacts-cicd.yaml`: **Artifacts pipeline** (build → sign → deploy). [README](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/artifacts-cicd/README.md)
@@ -48,6 +60,11 @@ The lower-level workflows (`reusable_execute-build.yaml`, `reusable_sign-artifac
 This orchestrates the full build → sign → deploy lifecycle internally.
 
 ```yaml
+permissions:
+  contents: read
+  id-token: write
+  # actions: write  # add when building Maven/JAR artifacts and using bundle metadata upload
+
 jobs:
   ci:
     uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@v3.2.0
@@ -344,6 +361,8 @@ See [Why gh-workflows-ref is required](https://github.com/aerospike/shared-workf
 
 ## Troubleshooting tips
 
+- **Workflow validation: "requesting 'actions: write', but is only allowed 'actions: none'"** → upgrade shared-workflows to a release where deploy scopes `actions: write` to the deploy job only (workflow-level permissions stay `contents: read` + `id-token: write`). If you use Maven bundle metadata upload, your caller workflow still needs `actions: write` at runtime.
+- **Deploy fails on "Upload Maven bundle metadata"** → add `actions: write` to your caller workflow permissions, or set `gh-upload-bundle-metadata: false` on the deploy call if you do not need release-bundle metadata handoff.
 - **Deploy fails (auth)** → confirm GitHub→JFrog **OIDC** trust/policy is configured and that the workflow's identity has deploy permission to the target project/repo. (example mistakes often around wrong audience or incorrect token permissions)
 - **Docker push fails** → ensure `tag` includes the full registry path (e.g., `artifact.aerospike.io/project-docker-dev-local/image:tag`). Verify JFrog registry permissions and OIDC authentication.
 - **Bundle issues** → see the troubleshooting section in [Release Bundles](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/docs/release-bundles.md#troubleshooting).

--- a/.github/workflows/docs/release-bundles.md
+++ b/.github/workflows/docs/release-bundles.md
@@ -77,6 +77,8 @@ For a complete working example including bundle deletion and promotion, see [exa
 
 After deploy, `reusable_deploy-artifacts.yaml` can upload `structured_build_artifacts/.maven-bundle-metadata.json` as a separate GitHub artifact (see outputs `bundle-metadata-artifact-name` / `bundle-metadata-available`). Pass that name to `reusable_create-release-bundle.yaml` as `gh-bundle-metadata-artifact-name` so the bundle job downloads the JSON and runs `jf release-bundle-annotate` without checking out the consumer repository. Alternatively, set `bundle-metadata-path` when the JSON is already on disk in that job.
 
+The metadata upload requires `actions: write` on your **top-level** caller workflow (or job). Grant it alongside `contents: read` and `id-token: write`, or set `gh-upload-bundle-metadata: false` on deploy when metadata handoff is not needed.
+
 ## Troubleshooting
 
 **Bundle creation fails**: confirm the `jf-build-names` input is a comma-separated list of `name:version` pairs that exist in JFrog, and that your project permissions allow bundle creation. Bundle creation requires higher permissions than artifact upload.

--- a/.github/workflows/example_composable-matrix.yaml
+++ b/.github/workflows/example_composable-matrix.yaml
@@ -52,6 +52,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: write # Maven bundle metadata upload in deploy → release bundle
 
 concurrency:
   group: jfrog-test-deploy

--- a/.github/workflows/example_expanded-integration.yaml
+++ b/.github/workflows/example_expanded-integration.yaml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   packages: write
   attestations: write
+  actions: write # Maven bundle metadata upload in deploy → release bundle
 
 concurrency:
   group: jfrog-test-deploy

--- a/.github/workflows/reusable_deploy-artifacts.yaml
+++ b/.github/workflows/reusable_deploy-artifacts.yaml
@@ -120,11 +120,14 @@ on:
 permissions:
   contents: read
   id-token: write
-  actions: write
 
 jobs:
   deploy:
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+      id-token: write
+      actions: write
     outputs:
       jf-build-id: ${{ steps.deploy.outputs.jf-build-id }}
       bundle-metadata-artifact-name: ${{ steps.bundle-metadata-state.outputs.artifact-name }}

--- a/.github/workflows/test_deploy-artifacts-integration.yaml
+++ b/.github/workflows/test_deploy-artifacts-integration.yaml
@@ -191,7 +191,7 @@ jobs:
       - name: Verify non-npm .tgz IS in generic repo
         if: needs.deploy.result == 'success'
         run: |
-          result=$(jf rt search "test-generic-dev-local/generic-archive.tgz" --project=test)
+          result=$(jf rt search "test-generic-dev-local/${{ env.BUILD_NAME }}/${{ env.VERSION }}/generic-archive.tgz" --project=test)
           echo "Search result: $result"
           count=$(echo "$result" | jq 'length')
           if [[ "$count" -lt 1 ]]; then

--- a/.github/workflows/test_deploy-artifacts-integration.yaml
+++ b/.github/workflows/test_deploy-artifacts-integration.yaml
@@ -12,6 +12,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: write # integration fixtures include JAR/POM; deploy may upload bundle metadata
 
 concurrency:
   group: jfrog-test-deploy


### PR DESCRIPTION
## Bug Fixes
deploy-artifacts: scope actions: write to the deploy job so reusable_artifacts-cicd callers validate without workflow-level actions: write

## Upgrade notes
Fixes workflow validation failure since v3.8.0

Consumers calling reusable_artifacts-cicd.yaml may have seen:

The workflow is requesting 'actions: write', but is only allowed 'actions: none'.
v3.8.0 added Maven bundle metadata upload in reusable_deploy-artifacts.yaml, which declared actions: write at workflow scope. Nested reusable workflows validate against the caller's granted permissions; reusable_artifacts-cicd only grants contents: read and id-token: write, so the deploy call failed at parse time.

## What changed

reusable_deploy-artifacts.yaml now declares actions: write at job scope on the deploy job only. Workflow-level permissions remain contents: read and id-token: write, matching the orchestrator and unblocking validation for existing consumers.

## Consumer action required

- Standard orchestrated pipeline (DEB/RPM/npm/etc.)
  - Upgrade to v3.8.2 — no permission changes needed
- Maven/JAR builds using bundle metadata → release bundle
  - Add actions: write to your caller workflow permissions
- Composable deploy without metadata handoff
  - Set gh-upload-bundle-metadata: false on the deploy call