### PR TITLE
fix: [CLIENT-5076] route volume-loader image through JFrog instead of Docker Hub

### DIFF
--- a/.github/actions/setup-aerospike-server/action.yaml
+++ b/.github/actions/setup-aerospike-server/action.yaml
@@ -214,10 +214,12 @@ runs:
         TLS_VOLUME_DEST_DIR=/etc/aerospike/tls
         echo "tls_volume_dest_dir=$TLS_VOLUME_DEST_DIR" >> "$GITHUB_OUTPUT"
 
+        # Pull the volume-loader via JFrog's database-docker-virtual, not docker.io (bare "alpine" times out on Docker Hub).
+        LOADER_IMAGE="${{ inputs.container-repo-url }}/database-docker-virtual/alpine:3.20"
         docker run --name "$CONTAINER_NAME_TO_LOAD_VOLUME" -d \
           -v "$CONFIG_FILES_VOLUME_NAME:$VOLUME_DEST_DIR" \
           -v "$TLS_VOLUME_NAME:$TLS_VOLUME_DEST_DIR" \
-          alpine tail -f /dev/null
+          "$LOADER_IMAGE" tail -f /dev/null
       shell: bash
       env:
         # Prevents volume directories from being expanded since they start with /


### PR DESCRIPTION
**Issue**

The volume-loader step currently runs `docker run ... alpine`, which resolves to `docker.io/library/alpine:latest` and pulls directly from Docker Hub. This bypasses the JFrog registry the action already authenticates to and prevents the image from benefiting from JFrog's authenticated pull-through cache. As a result, Docker Hub rate limits or timeouts can fail the build-linux job [here](https://github.com/aerospike/aerospike-client-c/actions/runs/29484722078/job/87576435298)

**Fix**

Route the volume-loader image through the JFrog Docker Hub mirror `(${container-repo-url}/docker-remote/alpine:3.20)` so it benefits from the existing authenticated pull-through cache instead of pulling directly from `Docker Hub`. This removes the last remaining Docker Hub dependency from the action.