### PR TITLE
fix: [INFRA-629] Fix bundle permissions

### DIFF
--- a/.github/workflows/create-release-bundle/README.md
+++ b/.github/workflows/create-release-bundle/README.md
@@ -53,6 +53,21 @@ jobs:
 
 The `gh-workflows-ref` input is **required** and must match the version in your `uses:` line. See [Why gh-workflows-ref is required](../docs/why-gh-workflows-ref.md) for details.
 
+## Permissions
+
+Workflow-level permissions are `contents: read` and `id-token: write` so composable callers validate without extra grants.
+
+The `create-release-bundle` job requests `actions: read` at **job scope** only, for the optional Maven bundle metadata download (`gh-bundle-metadata-artifact-name`). At runtime, that download succeeds only when the **top-level caller workflow** also grants `actions: read`:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+  actions: read # required when gh-bundle-metadata-artifact-name is set
+```
+
+If you do not pass `gh-bundle-metadata-artifact-name` (and use `bundle-metadata-path` on disk instead, or skip metadata annotation), callers can omit `actions: read`; bundle creation still works and only the metadata download step is skipped.
+
 ## Prerequisites
 
 - JFrog Artifactory instance with OIDC authentication configured

--- a/.github/workflows/docs/CICD-composable.md
+++ b/.github/workflows/docs/CICD-composable.md
@@ -70,7 +70,7 @@ deploy  →  create-release-bundle  →  promote
 
 When you use `reusable_deploy-artifacts.yaml` followed by `reusable_create-release-bundle.yaml`, pass `gh-bundle-metadata-artifact-name: ${{ needs.<deploy-job>.outputs.bundle-metadata-artifact-name }}` so Maven bundle metadata (`.maven-bundle-metadata.json`) is carried between jobs as a small artifact; the deploy workflow sets `bundle-metadata-available` when that upload ran.
 
-**Permissions:** caller workflows need `contents: read` and `id-token: write`. When using Maven bundle metadata upload (`gh-upload-bundle-metadata`, default `true`), also grant `actions: write` on the top-level workflow or job. Set `gh-upload-bundle-metadata: false` on the deploy call if you do not need the metadata artifact and cannot grant `actions: write`.
+**Permissions:** caller workflows need `contents: read` and `id-token: write`. When using Maven bundle metadata upload (`gh-upload-bundle-metadata`, default `true`), also grant `actions: write` on the top-level workflow or job. When passing `gh-bundle-metadata-artifact-name` to create-release-bundle, also grant `actions: read`. Set `gh-upload-bundle-metadata: false` on deploy if you do not need the metadata artifact and cannot grant `actions: write`.
 
 ### Key concepts
 
@@ -215,7 +215,9 @@ See [Why gh-workflows-ref is required](https://github.com/aerospike/shared-workf
 ## Troubleshooting tips
 
 - **Workflow validation: "requesting 'actions: write', but is only allowed 'actions: none'"** → upgrade shared-workflows to a release where deploy scopes `actions: write` to the deploy job only. Add `actions: write` to your caller `permissions` when using Maven bundle metadata upload.
+- **Workflow validation: "requesting 'actions: read', but is only allowed 'actions: none'"** → upgrade shared-workflows to a release where create-release-bundle scopes `actions: read` to the create-release-bundle job only. Add `actions: read` to your caller `permissions` when passing `gh-bundle-metadata-artifact-name`.
 - **Deploy fails on "Upload Maven bundle metadata"** → add `actions: write` to your caller workflow, or set `gh-upload-bundle-metadata: false` on deploy.
+- **Create-release-bundle fails on "Download Maven bundle metadata artifact"** → add `actions: read` to your caller workflow, or omit `gh-bundle-metadata-artifact-name`.
 - **Deploy fails (auth)** → confirm GitHub→JFrog **OIDC** trust/policy is configured and that the workflow's identity has deploy permission to the target project/repo. Common mistakes: wrong audience or incorrect token permissions.
 - **Docker push fails** → ensure `tag` includes the full registry path (e.g., `artifact.aerospike.io/project-docker-dev-local/image:tag`). Verify JFrog registry permissions and OIDC authentication.
 - **Bundle issues** → see the troubleshooting section in [Release Bundles](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/docs/release-bundles.md#troubleshooting).

--- a/.github/workflows/docs/CICD-standard.md
+++ b/.github/workflows/docs/CICD-standard.md
@@ -45,7 +45,7 @@ permissions:
   id-token: write
 ```
 
-Since v3.8.0, deploy can upload optional Maven bundle metadata (`.maven-bundle-metadata.json`) for release-bundle annotation. If your pipeline builds Maven/JAR artifacts and chains into `reusable_create-release-bundle.yaml` via that metadata artifact, add `actions: write` to the caller workflow (or job) permissions. Without it, deploy to JFrog still succeeds; only the metadata upload step fails when metadata is produced.
+Since v3.8.0, deploy can upload optional Maven bundle metadata (`.maven-bundle-metadata.json`) for release-bundle annotation. If your pipeline builds Maven/JAR artifacts and chains into `reusable_create-release-bundle.yaml` via that metadata artifact, add `actions: write` (deploy upload) and `actions: read` (create-release-bundle download) to the caller workflow (or job) permissions. Without them, deploy to JFrog and bundle creation still succeed; only the metadata handoff steps fail when metadata is produced.
 
 ## Standard Workflows for your project
 
@@ -362,7 +362,9 @@ See [Why gh-workflows-ref is required](https://github.com/aerospike/shared-workf
 ## Troubleshooting tips
 
 - **Workflow validation: "requesting 'actions: write', but is only allowed 'actions: none'"** → upgrade shared-workflows to a release where deploy scopes `actions: write` to the deploy job only (workflow-level permissions stay `contents: read` + `id-token: write`). If you use Maven bundle metadata upload, your caller workflow still needs `actions: write` at runtime.
+- **Workflow validation: "requesting 'actions: read', but is only allowed 'actions: none'"** → upgrade shared-workflows to a release where create-release-bundle scopes `actions: read` to the create-release-bundle job only. Add `actions: read` at runtime when passing `gh-bundle-metadata-artifact-name`.
 - **Deploy fails on "Upload Maven bundle metadata"** → add `actions: write` to your caller workflow permissions, or set `gh-upload-bundle-metadata: false` on the deploy call if you do not need release-bundle metadata handoff.
+- **Create-release-bundle fails on metadata artifact download** → add `actions: read` to your caller workflow permissions, or omit `gh-bundle-metadata-artifact-name`.
 - **Deploy fails (auth)** → confirm GitHub→JFrog **OIDC** trust/policy is configured and that the workflow's identity has deploy permission to the target project/repo. (example mistakes often around wrong audience or incorrect token permissions)
 - **Docker push fails** → ensure `tag` includes the full registry path (e.g., `artifact.aerospike.io/project-docker-dev-local/image:tag`). Verify JFrog registry permissions and OIDC authentication.
 - **Bundle issues** → see the troubleshooting section in [Release Bundles](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/docs/release-bundles.md#troubleshooting).

--- a/.github/workflows/docs/release-bundles.md
+++ b/.github/workflows/docs/release-bundles.md
@@ -77,7 +77,9 @@ For a complete working example including bundle deletion and promotion, see [exa
 
 After deploy, `reusable_deploy-artifacts.yaml` can upload `structured_build_artifacts/.maven-bundle-metadata.json` as a separate GitHub artifact (see outputs `bundle-metadata-artifact-name` / `bundle-metadata-available`). Pass that name to `reusable_create-release-bundle.yaml` as `gh-bundle-metadata-artifact-name` so the bundle job downloads the JSON and runs `jf release-bundle-annotate` without checking out the consumer repository. Alternatively, set `bundle-metadata-path` when the JSON is already on disk in that job.
 
-The metadata upload requires `actions: write` on your **top-level** caller workflow (or job). Grant it alongside `contents: read` and `id-token: write`, or set `gh-upload-bundle-metadata: false` on deploy when metadata handoff is not needed.
+Deploy metadata upload requires `actions: write` on your **top-level** caller workflow (or job). Grant it alongside `contents: read` and `id-token: write`, or set `gh-upload-bundle-metadata: false` on deploy when metadata handoff is not needed.
+
+When passing `gh-bundle-metadata-artifact-name` to create-release-bundle, the caller also needs `actions: read` at runtime (scoped to the create-release-bundle job in the reusable workflow). Omit it when you do not download bundle metadata from a GitHub artifact.
 
 ## Troubleshooting
 

--- a/.github/workflows/lib/check_reusable_workflow_permissions.sh
+++ b/.github/workflows/lib/check_reusable_workflow_permissions.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Validate permission scoping on reusable_*.yaml workflows.
+#
+# Policy:
+# - Workflow-level permissions may only grant contents: read and id-token: write.
+# - Elevated permissions (actions, packages, attestations, ...) must be job-scoped.
+# - reusable_*.yaml files with no workflow-level permissions block are allowed
+#   (e.g. reusable_docker-build-deploy.yaml inherits caller grants).
+
+set -euo pipefail
+
+WORKFLOWS_DIR="${1:-.github/workflows}"
+ALLOWED_WORKFLOW_KEYS=(contents id-token)
+
+is_allowed_workflow_key() {
+    local key="$1"
+    local allowed
+    for allowed in "${ALLOWED_WORKFLOW_KEYS[@]}"; do
+        if [[ $key == "$allowed" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Extract permission keys declared at workflow scope (root permissions: block).
+# Prints one key per line, or nothing when no workflow-level block exists.
+extract_workflow_permission_keys() {
+    local file="$1"
+    awk '
+    BEGIN { in_perms = 0 }
+    /^permissions:[[:space:]]*$/ { in_perms = 1; next }
+    in_perms {
+      if ($0 ~ /^[^[:space:]]/) { exit }
+      if ($0 ~ /^  [A-Za-z0-9_-]+:[[:space:]]*/) {
+        key = $1
+        sub(/:$/, "", key)
+        print key
+      }
+    }
+  ' "$file"
+}
+
+# Return 0 when the file declares job-level permissions for the given key.
+has_job_scoped_permission() {
+    local file="$1"
+    local perm_key="$2"
+    awk -v want="$perm_key" '
+    BEGIN { in_jobs = 0; in_job_perms = 0; found = 0 }
+    /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+    in_jobs {
+      if ($0 ~ /^[^[:space:]]/) { exit }
+      if ($0 ~ /^    permissions:[[:space:]]*$/) {
+        in_job_perms = 1
+        next
+      }
+      if (in_job_perms && $0 ~ /^      [A-Za-z0-9_-]+:[[:space:]]*/) {
+        key = $1
+        sub(/:$/, "", key)
+        if (key == want) {
+          found = 1
+        }
+      }
+      if (in_job_perms && $0 ~ /^    [A-Za-z0-9_-]+:[[:space:]]*$/ && $0 !~ /^      /) {
+        in_job_perms = 0
+      }
+    }
+    END {
+      if (found) {
+        exit 0
+      }
+      exit 1
+    }
+  ' "$file"
+}
+
+errors=0
+
+while IFS= read -r file; do
+    [[ -n $file ]] || continue
+    basename="$(basename "$file")"
+    has_workflow_keys=false
+
+    while IFS= read -r key; do
+        [[ -n $key ]] || continue
+        has_workflow_keys=true
+        if ! is_allowed_workflow_key "$key"; then
+            echo "ERROR: $basename declares workflow-level permission '$key' (only contents and id-token are allowed at workflow scope)" >&2
+            errors=$((errors + 1))
+        fi
+    done < <(extract_workflow_permission_keys "$file" || true)
+
+    if [[ $has_workflow_keys == false ]]; then
+        continue
+    fi
+
+    case "$basename" in
+    reusable_deploy-artifacts.yaml)
+        if ! has_job_scoped_permission "$file" "actions"; then
+            echo "ERROR: $basename must declare job-scoped actions: write on the deploy job" >&2
+            errors=$((errors + 1))
+        fi
+        ;;
+    reusable_create-release-bundle.yaml)
+        if ! has_job_scoped_permission "$file" "actions"; then
+            echo "ERROR: $basename must declare job-scoped actions: read on the create-release-bundle job" >&2
+            errors=$((errors + 1))
+        fi
+        ;;
+    esac
+done < <(find "$WORKFLOWS_DIR" -maxdepth 1 -name 'reusable_*.yaml' | sort)
+
+if ((errors > 0)); then
+    echo "Found $errors reusable workflow permission issue(s)." >&2
+    exit 1
+fi
+
+echo "All reusable workflow permission scopes are valid."

--- a/.github/workflows/lib/tests/test_reusable_workflow_permissions.bats
+++ b/.github/workflows/lib/tests/test_reusable_workflow_permissions.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+CHECKER="$GIT_ROOT/.github/workflows/lib/check_reusable_workflow_permissions.sh"
+WORKFLOWS_DIR="$GIT_ROOT/.github/workflows"
+
+setup_file() {
+  chmod +x "$CHECKER"
+}
+
+@test "reusable workflow permission checker passes on repository workflows" {
+  run "$CHECKER" "$WORKFLOWS_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All reusable workflow permission scopes are valid."* ]]
+}
+
+@test "reusable_create-release-bundle has no workflow-scoped actions: read" {
+  file="$WORKFLOWS_DIR/reusable_create-release-bundle.yaml"
+  run awk '
+    BEGIN { in_perms = 0; bad = 0 }
+    /^permissions:[[:space:]]*$/ { in_perms = 1; next }
+    in_perms {
+      if ($0 ~ /^[^[:space:]]/) { exit }
+      if ($0 ~ /^  actions:[[:space:]]*/) { bad = 1 }
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "reusable_deploy-artifacts has no workflow-scoped actions: write" {
+  file="$WORKFLOWS_DIR/reusable_deploy-artifacts.yaml"
+  run awk '
+    BEGIN { in_perms = 0; bad = 0 }
+    /^permissions:[[:space:]]*$/ { in_perms = 1; next }
+    in_perms {
+      if ($0 ~ /^[^[:space:]]/) { exit }
+      if ($0 ~ /^  actions:[[:space:]]*/) { bad = 1 }
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "reusable_create-release-bundle declares job-scoped actions: read" {
+  file="$WORKFLOWS_DIR/reusable_create-release-bundle.yaml"
+  run awk '
+    BEGIN { in_jobs = 0; in_job_perms = 0; found = 0 }
+    /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+    in_jobs {
+      if ($0 ~ /^[^[:space:]]/) { exit }
+      if ($0 ~ /^    permissions:[[:space:]]*$/) { in_job_perms = 1; next }
+      if (in_job_perms && $0 ~ /^      actions:[[:space:]]*read[[:space:]]*$/) { found = 1 }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "reusable_deploy-artifacts declares job-scoped actions: write" {
+  file="$WORKFLOWS_DIR/reusable_deploy-artifacts.yaml"
+  run awk '
+    BEGIN { in_jobs = 0; in_job_perms = 0; found = 0 }
+    /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+    in_jobs {
+      if ($0 ~ /^[^[:space:]]/) { exit }
+      if ($0 ~ /^    permissions:[[:space:]]*$/) { in_job_perms = 1; next }
+      if (in_job_perms && $0 ~ /^      actions:[[:space:]]*write[[:space:]]*$/) { found = 1 }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "checker rejects workflow-scoped actions permissions in a synthetic workflow" {
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+  cat >"$tmpdir/reusable_bad-example.yaml" <<'YAML'
+name: Bad Example
+on:
+  workflow_call:
+    inputs:
+      gh-workflows-ref:
+        required: true
+        type: string
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+jobs:
+  example:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo bad
+YAML
+  run "$CHECKER" "$tmpdir"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"workflow-level permission 'actions'"* ]]
+}

--- a/.github/workflows/reusable_create-release-bundle.yaml
+++ b/.github/workflows/reusable_create-release-bundle.yaml
@@ -81,11 +81,14 @@ on:
 permissions:
   contents: read
   id-token: write
-  actions: read
 
 jobs:
   create-release-bundle:
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/test_composable-minimal-permissions.yaml
+++ b/.github/workflows/test_composable-minimal-permissions.yaml
@@ -1,0 +1,99 @@
+name: "Test: Composable minimal permissions"
+
+# Mirrors composable consumer pipelines (e.g. aerospike-server sign-build-deploy.yaml):
+# sign -> deploy -> create-release-bundle with only contents: read + id-token: write
+# at workflow scope. Catches startup_failure regressions from workflow-scoped actions:*.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/reusable_sign-artifacts.yaml
+      - .github/workflows/reusable_deploy-artifacts.yaml
+      - .github/workflows/reusable_create-release-bundle.yaml
+      - .github/workflows/test_composable-minimal-permissions.yaml
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  upload-fixtures:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Create test fixtures
+        run: .github/workflows/deploy-artifacts/create-test-fixtures.sh composable-minimal-fixtures
+
+      - name: Upload unsigned fixtures
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: composable-minimal-fixtures
+          path: composable-minimal-fixtures
+          retention-days: 1
+
+  sign:
+    if: github.actor != 'dependabot[bot]'
+    needs: upload-fixtures
+    uses: ./.github/workflows/reusable_sign-artifacts.yaml
+    secrets:
+      gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+      gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
+      gpg-key-pass: ${{ secrets.GPG_PASS }}
+    with:
+      gh-unsigned-artifacts: composable-minimal-fixtures
+      gh-artifact-name: signed-composable-minimal
+      gh-workflows-ref: ${{ github.sha }}
+
+  deploy:
+    if: github.actor != 'dependabot[bot]'
+    needs: sign
+    uses: ./.github/workflows/reusable_deploy-artifacts.yaml
+    with:
+      gh-workflows-ref: ${{ github.sha }}
+      gh-checkout-path: .
+      gh-artifact-name: signed-composable-minimal
+      gh-upload-bundle-metadata: false
+      jf-project: test
+      jf-build-name: composable-minimal-permissions
+      jf-build-id: ${{ github.run_id }}-${{ github.run_attempt }}
+      jf-metadata-build-id: ${{ github.run_id }}-${{ github.run_attempt }}-metadata
+      version: v1.0.0-composable-minimal
+      oidc-provider-name: gh-aerospike
+      oidc-audience: aerospike
+      dry-run: true
+
+  create-release-bundle:
+    if: github.actor != 'dependabot[bot]'
+    needs: deploy
+    uses: ./.github/workflows/reusable_create-release-bundle.yaml
+    with:
+      gh-workflows-ref: ${{ github.sha }}
+      jf-project: test
+      jf-build-names: composable-minimal-permissions:v1.0.0-composable-minimal
+      jf-bundle-name: composable-minimal-test
+      version: v1.0.0-composable-minimal
+      oidc-provider-name: gh-aerospike
+      oidc-audience: aerospike
+      dry-run: true
+
+  verify-chain:
+    if: github.actor != 'dependabot[bot]'
+    needs: [sign, deploy, create-release-bundle]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - run: echo "Composable minimal-permissions chain completed without startup_failure."

--- a/.github/workflows/test_reusable-workflow-permissions.yaml
+++ b/.github/workflows/test_reusable-workflow-permissions.yaml
@@ -1,0 +1,33 @@
+name: "Test: Reusable workflow permission scoping"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/reusable_*.yaml
+      - .github/workflows/lib/**
+      - .github/workflows/test_reusable-workflow-permissions.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  permission-scope-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install bats
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo /tmp/bats-core/install.sh /usr/local
+
+      - name: Run reusable workflow permission bats tests
+        run: bats .github/workflows/lib/tests/test_reusable_workflow_permissions.bats


### PR DESCRIPTION
This PR fixes additional permission issues introduced in the process of implementing MAVEN GAV scanning and metadata upload.

Additionally, workflow audit was conducted to double check similar permission need in other shared workflows

### Summary
- Scope actions: read to the create-release-bundle job in reusable_create-release-bundle.yaml (same pattern as PR #267 deploy fix) so composable callers with only contents: read + id-token: write no longer hit startup_failure.
- Add permission regression tests: local bats checker, CI workflow for static scoping, and composable minimal-permissions integration workflow (sign → deploy → create-release-bundle).
- Update create-release-bundle and CICD docs with caller permission notes.