### PR TITLE
feat: [INFRA-608] Add Rust package support

### DIFF
--- a/.github/workflows/artifacts-cicd/README.md
+++ b/.github/workflows/artifacts-cicd/README.md
@@ -62,10 +62,11 @@ The deploy stage automatically routes artifacts by file extension:
 | PyPI    | `pypi-dev-local`    | `version`, `package_name`, `pypi.name`, `pypi.version`                             |
 | Go      | `go-dev-local`      | `version`, `package_name`, `go.module`, `go.version`                               |
 | Helm    | `helm-dev-local`    | `version`, `package_name`, `helm.name`, `helm.version`                             |
+| Rust    | `generic-dev-local` | `version`, `package_name`, `cargo.name`, `cargo.version`                           |
 | Windows | `generic-dev-local` | `version`, `package_name`                                                          |
 | Generic | `generic-dev-local` | `version`, `package_name`                                                          |
 
-Windows executables (`.exe`, `.msi`, `.msix`) are detected by extension and routed to the generic repository; enable Authenticode signing for them with `sign-windows`. macOS `.pkg` installers produced by `sign-mac` are likewise uploaded as generic artifacts.
+Windows executables (`.exe`, `.msi`, `.msix`) are detected by extension and routed to the generic repository; enable Authenticode signing for them with `sign-windows`. Rust crates (`.crate`) are validated via `Cargo.toml`, structured under `crate/`, and uploaded to the same generic repository with `cargo.name` / `cargo.version` properties. macOS `.pkg` installers produced by `sign-mac` are likewise uploaded as generic artifacts.
 
 Companion files (`.asc` signatures, `.pom` files, helm `.prov` provenance) are automatically gathered alongside their parent artifacts. Helm registers `.prov` (helm-native provenance signature) as its companion; the orphan `.tgz.asc` produced by GPG sign-artifacts is intentionally not gathered or uploaded for helm charts because `.prov` is the canonical chart signature.
 

--- a/.github/workflows/deploy-artifacts/README.md
+++ b/.github/workflows/deploy-artifacts/README.md
@@ -16,6 +16,7 @@ A reusable GitHub Actions workflow for uploading build artifacts to JFrog Artifa
 | PyPI (.whl/.tar.gz sdist) | `{project}-pypi-dev-local`    | `.asc`                     | `version`, `package_name`, `pypi.name`, `pypi.version`                             |
 | Go module (.zip)          | `{project}-go-dev-local`      | `.asc`                     | `version`, `package_name`, `go.module`, `go.version`                               |
 | Helm chart (.tgz)         | `{project}-helm-dev-local`    | `.prov`                    | `version`, `package_name`, `helm.name`, `helm.version`                             |
+| Rust crate (`.crate`)     | `{project}-generic-dev-local` | `.asc`                     | `version`, `package_name`, `cargo.name`, `cargo.version`                           |
 | Windows (.exe/.msi/.msix) | `{project}-generic-dev-local` | `.asc`                     | `version`, `package_name` (same repo as generic)                                   |
 | Generic (everything else) | `{project}-generic-dev-local` | `.asc`                     | `version`, `package_name`                                                          |
 
@@ -79,7 +80,8 @@ The deploy pipeline uses a centralized type registry (`type_registry.sh`). To ad
 
 Artifacts arrive in `build-artifacts/` as a flat collection from the sign stage. The structuring phase categorizes them by type and gathers companion files:
 
-- Types with unique extensions (DEB, RPM, JAR, NuGet, `.whl`, Windows `.exe`/`.msi`/`.msix`) are matched by extension
+- Types with unique extensions (DEB, RPM, JAR, NuGet, `.whl`, Rust `.crate`, Windows `.exe`/`.msi`/`.msix`) are matched by extension
+- `.crate` files are validated with `is_crate_package()` (Cargo.toml `[package]` name and version) before structuring; invalid archives are skipped
 - Gzipped tarballs (`.tgz` and `.tar.gz`) and zip archives (`.zip`) are inspected with content-based detectors to distinguish npm packages, PyPI source distributions, Go modules, Helm charts (`.tgz` containing `Chart.yaml`), and generic archives
 - Companion files (defined per type in `TYPE_COMPANIONS`) are automatically copied alongside their primary artifact
 - Generic catches everything not claimed by the above
@@ -89,7 +91,7 @@ Artifacts arrive in `build-artifacts/` as a flat collection from the sign stage.
 Each type directory is uploaded to its respective repository with appropriate properties. The upload functions are driven by the type registry:
 
 - Simple types (DEB, RPM) use the generic `upload_type()` dispatch which calls `get_TYPE_props()` and `get_TYPE_extra_flags()` by convention
-- Types with custom path layouts (JAR, NuGet, npm, PyPI, Go, win, generic) define `upload_TYPE_*` overrides in `entrypoint.sh`
+- Types with custom path layouts (JAR, NuGet, npm, PyPI, Go, crate, win, generic) define `upload_TYPE_*` overrides in `entrypoint.sh`
 - All uploads go through `jf_upload()` or `run jf rt upload` which adds standard flags (`--build-name`, `--build-number`, `--project`)
 
 ### 3. Build info
@@ -185,6 +187,24 @@ helm/
   {chart}-{version}.tgz.prov
 ```
 
+### Rust crate
+
+`.crate` files are matched by extension and validated via `Cargo.toml` inside the archive (`is_crate_package`). Metadata (`cargo.name`, `cargo.version`) is read from the `[package]` section. Upload uses the same generic-repository layout as Windows and other generic artifacts (`{build-name}/{version}/{filename}`), not JFrog's Cargo registry path.
+
+```text
+crate/
+  aerospike-3.0.0-alpha.1.crate
+  aerospike-3.0.0-alpha.1.crate.asc
+```
+
+Uploaded to JFrog as:
+
+```text
+{project}-generic-dev-local/
+  {build-name}/{version}/aerospike-3.0.0-alpha.1.crate
+  {build-name}/{version}/aerospike-3.0.0-alpha.1.crate.asc
+```
+
 ### Windows
 
 `.exe`, `.msi`, and `.msix` files are matched by extension and uploaded to the generic repository.
@@ -201,7 +221,7 @@ win/
 deploy-artifacts/
   entrypoint.sh          # Main script: arg parsing, upload functions, orchestration
   type_registry.sh       # Type config arrays + per-type props/flags functions
-  type_detection.sh      # Content-based detection predicates (is_npm_package, is_helm_chart, etc.)
+  type_detection.sh      # Content-based detection predicates (is_npm_package, is_crate_package, is_helm_chart, etc.)
   detect_types.sh        # Standalone detection entrypoint (used by the detect-artifacts action); writes
                          # structured_build_artifacts/.maven-bundle-metadata.json (Maven GAV scan)
   upload_utils.sh        # Shared helpers: jf_upload, upload_companions, discover_and_process, upload_type

--- a/.github/workflows/deploy-artifacts/create-test-fixtures.sh
+++ b/.github/workflows/deploy-artifacts/create-test-fixtures.sh
@@ -388,6 +388,22 @@ echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.msi.asc"
 head -c 2048 /dev/zero >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix"
 echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix.asc"
 
+# Rust crate (.crate): cargo pack layout with Cargo.toml [package] name/version
+mkdir -p "$BUILD_ARTIFACTS_DIR/temp-crate/aerospike-3.0.0-alpha.1/src"
+cat >"$BUILD_ARTIFACTS_DIR/temp-crate/aerospike-3.0.0-alpha.1/Cargo.toml" <<'CARGO'
+[package]
+name = "aerospike"
+version = "3.0.0-alpha.1"
+edition = "2021"
+CARGO
+echo 'pub fn placeholder() {}' >"$BUILD_ARTIFACTS_DIR/temp-crate/aerospike-3.0.0-alpha.1/src/lib.rs"
+cd "$BUILD_ARTIFACTS_DIR/temp-crate" && tar -czf "../aerospike-3.0.0-alpha.1.crate" aerospike-3.0.0-alpha.1/ && cd - >/dev/null
+rm -rf "$BUILD_ARTIFACTS_DIR/temp-crate"
+echo "  Created aerospike-3.0.0-alpha.1.crate (Rust crate)"
+echo "FAKE-GPG-SIGNATURE" >"$BUILD_ARTIFACTS_DIR/aerospike-3.0.0-alpha.1.crate.asc"
+# Invalid .crate (wrong extension content) for validation tests
+echo "not-a-valid-crate-archive" >"$BUILD_ARTIFACTS_DIR/invalid-fixture.crate"
+
 # Create unsigned-artifacts/ prefix to simulate sign stage output
 # The sign stage uses cp --parents which creates: signed-artifacts/unsigned-artifacts/...
 # Deploy receives this as: build-artifacts/unsigned-artifacts/...

--- a/.github/workflows/deploy-artifacts/entrypoint.sh
+++ b/.github/workflows/deploy-artifacts/entrypoint.sh
@@ -181,6 +181,26 @@ structure_generic_files() {
     done < <(find build-artifacts \( "${exclude_args[@]}" \) -type f -print0)
 }
 
+structure_crate_files() {
+    local dest="./structured_build_artifacts/${TYPE_STRUCT_DIR[crate]}"
+    while IFS= read -r -d '' file; do
+        [[ -f $file ]] || continue
+        if ! is_crate_package "$file"; then
+            echo "Notice: skipping crate structuring (validation failed): $file" >&2
+            continue
+        fi
+        echo "Processing CRATE: $file" >&2
+        local target_path
+        target_path=$(process_crate "$file" "$dest")
+        if [[ -n $target_path ]]; then
+            gather_companions "$file" "$(dirname "$target_path")" "crate"
+            manifest_add "$target_path" "crate"
+        else
+            echo "Warning: process_crate returned no target path; artifact not copied: $file" >&2
+        fi
+    done < <(find build-artifacts -name "*.crate" -type f -print0 2>/dev/null)
+}
+
 structure_build_artifacts() {
     echo "Structuring build artifacts..." >&2
     # The deploy step might be preceded by a step that runs detect_types.sh,
@@ -194,6 +214,8 @@ structure_build_artifacts() {
 
     # Extension-based types: unambiguous file extension maps directly to type
     for type in "${!TYPE_EXTENSIONS[@]}"; do
+        # crate uses structure_crate_files() for Cargo.toml validation
+        [[ $type == "crate" ]] && continue
         local dest="./structured_build_artifacts/${TYPE_STRUCT_DIR[$type]}"
         local label="${type^^}"
         local processor="process_${type}"
@@ -205,6 +227,8 @@ structure_build_artifacts() {
             discover_and_process "$pat" "$label" "$processor" "$dest" "$type"
         done < <(emit_type_extension_globs "${TYPE_EXTENSIONS[$type]}")
     done
+
+    structure_crate_files
 
     # Content-detected types: ambiguous extensions need inspection to determine type
     echo "Note: Content detection moved to separate step of 'Detect artifact types'" >&2
@@ -600,6 +624,49 @@ upload_helm_packages() {
     }
 
     manifest_for_type "helm" _upload_helm_entry
+}
+
+upload_crate_files() {
+    echo "Uploading Rust crate artifacts..." >&2
+
+    # shellcheck disable=SC2329  # invoked indirectly via manifest_for_type
+    _upload_crate_entry() {
+        local file="$1"
+        [[ -f $file ]] || return 0
+
+        if ! is_crate_package "$file"; then
+            echo "Warning: skipping invalid Rust crate: $file" >&2
+            return 0
+        fi
+
+        local filename
+        filename=$(basename "$file")
+        local props
+        props=$(get_crate_props "$file")
+
+        local target_path="${BUILD_NAME}/${VERSION}/${filename}"
+
+        echo "  Uploading Rust crate: $file" >&2
+        echo "    Target: $target_path" >&2
+        run jf rt upload "$file" "$PROJECT-generic-dev-local/${target_path}" \
+            --build-name="$BUILD_NAME" \
+            --build-number="$ARTIFACT_BUILD_NUMBER" \
+            --project="$PROJECT" \
+            --target-props "$props"
+
+        local companions="${TYPE_COMPANIONS[crate]-}"
+        for suffix in $companions; do
+            if [[ -f "$file$suffix" ]]; then
+                echo "  Uploading companion: $file$suffix" >&2
+                run jf rt upload "$file$suffix" "$PROJECT-generic-dev-local/${target_path}${suffix}" \
+                    --build-name="$BUILD_NAME" \
+                    --build-number="$ARTIFACT_BUILD_NUMBER" \
+                    --project="$PROJECT"
+            fi
+        done
+    }
+
+    manifest_for_type "crate" _upload_crate_entry
 }
 
 upload_win_files() {

--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -527,6 +527,96 @@ get_helm_metadata() {
 # Returns: target path on stdout.
 process_helm() { copy_to_structured "$1" "$2"; }
 
+# --- Rust crate functions ---
+
+# Validate a Rust crate package name (Cargo [package].name).
+# Rejects names that could inject JFrog target-props (semicolons, etc.).
+# Args: <name>
+# Exits with error if invalid.
+_validate_crate_name() {
+    local name="$1"
+    if [[ ! $name =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        error "Invalid crate name: '$name'"
+    fi
+}
+
+# Locate Cargo.toml inside a .crate tarball (single top-level directory).
+# Args: <crate_file>
+# Returns: member path on stdout, or return 1.
+_find_crate_cargo_toml_member() {
+    local file="$1"
+    tar -tzf "$file" 2>/dev/null | awk '/^[^/]+\/Cargo\.toml$/ {print; exit}'
+}
+
+# Extract Cargo.toml content from a .crate tarball.
+# Args: <crate_file>
+# Returns: Cargo.toml on stdout, or return 1.
+_extract_crate_cargo_toml() {
+    local file="$1"
+    local cargo_member
+    cargo_member=$(_find_crate_cargo_toml_member "$file") || return 1
+    [[ -n $cargo_member ]] || return 1
+    tar -xOzf "$file" "$cargo_member" 2>/dev/null
+}
+
+# Read a scalar field from the [package] section of Cargo.toml content.
+# Args: <cargo_toml_content> <field_name>
+# Returns: the value on stdout, or empty string.
+_cargo_toml_package_field() {
+    local content="$1" field="$2"
+    awk -v f="$field" '
+        /^\[package\]/ { in_pkg=1; next }
+        /^\[/ { in_pkg=0 }
+        in_pkg && $0 ~ "^" f "[[:space:]]*=" {
+            sub("^" f "[[:space:]]*=[[:space:]]*", "")
+            sub(/[[:space:]]+#.*$/, "")
+            sub(/[[:space:]]+$/, "")
+            sub(/^"/, "")
+            sub(/"$/, "")
+            sub(/^'\''/, "")
+            sub(/'\''$/, "")
+            print
+            exit
+        }
+    ' <<<"$content"
+}
+
+# Extract Rust crate metadata (name and version) from a .crate file.
+# Reads [package] name/version from Cargo.toml; falls back to filename parsing.
+# Args: <crate_file>
+# Returns: "name version" on stdout.
+get_crate_metadata() {
+    local crate="$1"
+    local filename="${crate##*/}"
+    local pkgname="" version=""
+    local cargo_toml
+
+    cargo_toml=$(_extract_crate_cargo_toml "$crate" 2>/dev/null || true)
+    if [[ -n $cargo_toml ]]; then
+        pkgname=$(_cargo_toml_package_field "$cargo_toml" "name")
+        version=$(_cargo_toml_package_field "$cargo_toml" "version")
+    fi
+
+    if [[ -z $pkgname || -z $version ]]; then
+        local base="${filename%.crate}"
+        if [[ $base =~ ^(.+)-([0-9]+.*)$ ]]; then
+            [[ -z $pkgname ]] && pkgname="${BASH_REMATCH[1]}"
+            [[ -z $version ]] && version="${BASH_REMATCH[2]}"
+        else
+            [[ -z $pkgname ]] && pkgname="$base"
+            [[ -z $version ]] && version="unknown"
+        fi
+    fi
+
+    _validate_crate_name "$pkgname"
+    echo "$pkgname $version"
+}
+
+# Structure a Rust crate into the destination directory.
+# Args: <file> <dest_dir>
+# Returns: target path on stdout.
+process_crate() { process_generic "$1" "$2"; }
+
 # Structure a generic file into the destination directory.
 # Strips the "unsigned-artifacts" prefix leaked from the sign stage's cp --parents.
 # Args: <file> <dest_dir>

--- a/.github/workflows/deploy-artifacts/tests/README.md
+++ b/.github/workflows/deploy-artifacts/tests/README.md
@@ -49,7 +49,7 @@ bats .github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
 
 ### Structuring tests (verify file routing and companion co-location)
 
-- `test_structuring.bats` - Artifact routing to correct dirs, companion gathering, prefix stripping, Windows → `win/` + `generic-dev-local` uploads; Maven flat + nested GAV layout
+- `test_structuring.bats` - Artifact routing to correct dirs, companion gathering, prefix stripping, Windows → `win/` + `generic-dev-local` uploads, Rust `.crate` → `crate/` + `generic-dev-local`; Maven flat + nested GAV layout
 - `test_maven_structuring.bats` - Maven detect_types + deploy structuring for jar+pom, parent+children, and pom-only (JFrog layout)
 - `test_maven_bundle_metadata.bats` - `.maven-bundle-metadata.json` and detect-time standalone / reactor structuring
 
@@ -59,6 +59,7 @@ bats .github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
 - `test_java_upload.bats` - JAR/Maven artifact uploads
 - `test_nupkg_upload.bats` - NuGet package uploads and metadata parsing
 - `test_all_files_upload.bats` - JAR/generic routing and NuGet-not-in-generic safety check
+- `test_crate_upload.bats` - Rust `.crate` validation, `crate/` structuring, generic-dev-local upload path, and `cargo.*` target-props
 - `test_error_handling.bats` - Missing arguments and invalid options
 
 ### Regression tests (codify production bugs so they never regress)

--- a/.github/workflows/deploy-artifacts/tests/bats/test_crate_upload.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_crate_upload.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+DEPLOY_ARTIFACTS_DIR="$GIT_ROOT/.github/workflows/deploy-artifacts"
+HELPERS_DIR="$DEPLOY_ARTIFACTS_DIR/tests/helpers"
+
+load "$HELPERS_DIR/setup.bash"
+load "$HELPERS_DIR/command_parsers.bash"
+load "$HELPERS_DIR/assertions.bash"
+
+setup_file() {
+    setup_test_artifacts
+
+    if [[ ! -f "$BUILD_ARTIFACTS_DIR/aerospike-3.0.0-alpha.1.crate" ]]; then
+        echo "Error: Missing expected crate fixture: aerospike-3.0.0-alpha.1.crate" >&2
+        return 1
+    fi
+}
+
+teardown_file() {
+    teardown_test_artifacts
+}
+
+@test "is_crate_package accepts valid aerospike crate fixture" {
+    source "$DEPLOY_ARTIFACTS_DIR/package_utils.sh"
+    source "$DEPLOY_ARTIFACTS_DIR/type_detection.sh"
+    set +eu
+    trap - ERR
+
+    is_crate_package "$BUILD_ARTIFACTS_DIR/aerospike-3.0.0-alpha.1.crate"
+}
+
+@test "is_crate_package rejects invalid .crate fixture" {
+    source "$DEPLOY_ARTIFACTS_DIR/package_utils.sh"
+    source "$DEPLOY_ARTIFACTS_DIR/type_detection.sh"
+    set +eu
+    trap - ERR
+
+    ! is_crate_package "$BUILD_ARTIFACTS_DIR/invalid-fixture.crate"
+}
+
+@test "get_crate_metadata reads aerospike name and version from Cargo.toml" {
+    source "$DEPLOY_ARTIFACTS_DIR/package_utils.sh"
+    set +eu
+    trap - ERR
+
+    local metadata
+    metadata=$(get_crate_metadata "$BUILD_ARTIFACTS_DIR/aerospike-3.0.0-alpha.1.crate")
+    [[ "$metadata" == "aerospike 3.0.0-alpha.1" ]]
+}
+
+@test "valid crate routes to crate dir with .asc companion after structuring" {
+    run_entrypoint_dry_run >/dev/null 2>&1 || true
+
+    [[ -f "structured_build_artifacts/crate/aerospike-3.0.0-alpha.1.crate" ]]
+    [[ -f "structured_build_artifacts/crate/aerospike-3.0.0-alpha.1.crate.asc" ]]
+
+    local generic_crate_count
+    generic_crate_count=$(find structured_build_artifacts/generic -name "*.crate" 2>/dev/null | wc -l | tr -d ' ')
+    [[ "$generic_crate_count" -eq 0 ]]
+}
+
+@test "invalid .crate is not structured into crate or generic dirs" {
+    run_entrypoint_dry_run >/dev/null 2>&1 || true
+
+    [[ ! -f "structured_build_artifacts/crate/invalid-fixture.crate" ]]
+    [[ ! -f "structured_build_artifacts/generic/invalid-fixture.crate" ]]
+}
+
+@test "crate is uploaded to generic-dev-local with BUILD_NAME/VERSION path" {
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+    local upload_commands
+    upload_commands=$(extract_upload_commands "$output")
+
+    local found=false
+    while IFS= read -r cmd; do
+        if [[ $cmd =~ aerospike-3\.0\.0-alpha\.1\.crate[[:space:]] && $cmd =~ generic-dev-local ]]; then
+            found=true
+            [[ $cmd =~ generic-dev-local/test-build/v1\.0\.0/aerospike-3\.0\.0-alpha\.1\.crate ]] || \
+                (echo "Wrong target path for crate: $cmd" >&2 && return 1)
+            [[ $cmd =~ --build-name=test-build ]] || (echo "Missing --build-name: $cmd" >&2 && return 1)
+            [[ $cmd =~ --project=test-project ]] || (echo "Missing --project: $cmd" >&2 && return 1)
+        fi
+    done <<< "$upload_commands"
+
+    [[ $found == true ]] || (echo "No crate upload command found" >&2 && return 1)
+}
+
+@test "crate upload includes cargo.name and cargo.version target-props" {
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+    local upload_commands
+    upload_commands=$(extract_upload_commands "$output")
+
+    local found=false
+    while IFS= read -r cmd; do
+        if [[ $cmd =~ aerospike-3\.0\.0-alpha\.1\.crate[[:space:]] && $cmd =~ generic-dev-local ]]; then
+            [[ $cmd =~ --target-props ]] || (echo "Missing --target-props on crate upload: $cmd" >&2 && return 1)
+            [[ $cmd =~ cargo\.name=aerospike ]] || (echo "Missing cargo.name prop: $cmd" >&2 && return 1)
+            [[ $cmd =~ cargo\.version=3\.0\.0-alpha\.1 ]] || (echo "Missing cargo.version prop: $cmd" >&2 && return 1)
+            [[ $cmd =~ package_name=aerospike ]] || (echo "Missing package_name prop: $cmd" >&2 && return 1)
+            found=true
+        fi
+    done <<< "$upload_commands"
+
+    [[ $found == true ]] || (echo "No crate upload with target-props found" >&2 && return 1)
+}
+
+@test "crate .asc companion is uploaded beside crate in generic-dev-local" {
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+    local upload_commands
+    upload_commands=$(extract_upload_commands "$output")
+
+    local found=false
+    while IFS= read -r cmd; do
+        if [[ $cmd =~ aerospike-3\.0\.0-alpha\.1\.crate\.asc && $cmd =~ generic-dev-local ]]; then
+            found=true
+            [[ $cmd =~ generic-dev-local/test-build/v1\.0\.0/aerospike-3\.0\.0-alpha\.1\.crate\.asc ]] || \
+                (echo "Wrong target path for crate .asc: $cmd" >&2 && return 1)
+        fi
+    done <<< "$upload_commands"
+
+    [[ $found == true ]] || (echo "No .asc companion upload found for crate" >&2 && return 1)
+}
+
+@test "invalid .crate is not uploaded to generic-dev-local" {
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+    local upload_commands
+    upload_commands=$(extract_upload_commands "$output")
+
+    [[ "$upload_commands" != *"invalid-fixture.crate"* ]]
+}

--- a/.github/workflows/deploy-artifacts/tests/bats/test_structured_artifacts.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_structured_artifacts.bats
@@ -58,6 +58,7 @@ teardown_file() {
   [[ -d "$TEST_DIR/structured_build_artifacts/deb" ]]
   [[ -d "$TEST_DIR/structured_build_artifacts/rpm" ]]
   [[ -d "$TEST_DIR/structured_build_artifacts/win" ]]
+  [[ -d "$TEST_DIR/structured_build_artifacts/crate" ]]
   [[ -d "$TEST_DIR/structured_build_artifacts/generic" ]]
 }
 

--- a/.github/workflows/deploy-artifacts/tests/bats/test_structuring.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_structuring.bats
@@ -89,6 +89,24 @@ teardown() {
     [[ "$cmds" != *win-dev-local* ]]
 }
 
+@test "Rust .crate routes to crate dir not generic; dry-run upload targets generic-dev-local" {
+    local output
+    output=$(run_entrypoint_dry_run "test-project" "test-build" "v1.0.0" "12345" "12345-metadata")
+
+    [[ -f "structured_build_artifacts/crate/aerospike-3.0.0-alpha.1.crate" ]]
+    [[ -f "structured_build_artifacts/crate/aerospike-3.0.0-alpha.1.crate.asc" ]]
+    local generic_crate_count
+    generic_crate_count=$(find structured_build_artifacts/generic -name "*.crate" 2>/dev/null | wc -l | tr -d ' ')
+    [[ "$generic_crate_count" -eq 0 ]]
+
+    local cmds
+    cmds=$(extract_upload_commands "$output")
+    echo "$cmds" | grep -qF "aerospike-3.0.0-alpha.1.crate"
+    echo "$cmds" | grep -qF "aerospike-3.0.0-alpha.1.crate.asc"
+    echo "$cmds" | grep -qF "generic-dev-local"
+    [[ "$cmds" != *crate-dev-local* ]]
+}
+
 @test "All standard type directories are created" {
     run_entrypoint_dry_run >/dev/null 2>&1 || true
     [[ -d "structured_build_artifacts/deb" ]]
@@ -97,6 +115,7 @@ teardown() {
     [[ -d "structured_build_artifacts/nupkg" ]]
     [[ -d "structured_build_artifacts/npm" ]]
     [[ -d "structured_build_artifacts/pypi" ]]
+    [[ -d "structured_build_artifacts/crate" ]]
     [[ -d "structured_build_artifacts/win" ]]
     [[ -d "structured_build_artifacts/generic" ]]
 }

--- a/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats
@@ -24,6 +24,7 @@ setup() {
     [[ "${TYPE_EXTENSIONS[nupkg]}" == "*.nupkg" ]]
     [[ "${TYPE_EXTENSIONS[snupkg]}" == "*.snupkg" ]]
     [[ "${TYPE_EXTENSIONS[pypi]}" == "*.whl" ]]
+    [[ "${TYPE_EXTENSIONS[crate]}" == "*.crate" ]]
     [[ "${TYPE_EXTENSIONS[win]}" == "*.exe,*.msi,*.msix" ]]
     # npm uses content detection (*.tgz is ambiguous), not in TYPE_EXTENSIONS
     [[ -z "${TYPE_EXTENSIONS[npm]}" ]]
@@ -40,6 +41,7 @@ setup() {
     [[ "${TYPE_REPO[pypi]}" == "pypi-dev-local" ]]
     [[ "${TYPE_REPO[go]}" == "go-dev-local" ]]
     [[ "${TYPE_REPO[helm]}" == "helm-dev-local" ]]
+    [[ "${TYPE_REPO[crate]}" == "generic-dev-local" ]]
     [[ "${TYPE_REPO[win]}" == "generic-dev-local" ]]
     [[ "${TYPE_REPO[generic]}" == "generic-dev-local" ]]
 }
@@ -51,6 +53,7 @@ setup() {
     [[ "${TYPE_COMPANIONS[npm]}" == ".asc" ]]
     [[ "${TYPE_COMPANIONS[pypi]}" == ".asc" ]]
     [[ "${TYPE_COMPANIONS[helm]}" == ".prov" ]]
+    [[ "${TYPE_COMPANIONS[crate]}" == ".asc" ]]
     [[ "${TYPE_COMPANIONS[win]}" == ".asc" ]]
     [[ "${TYPE_COMPANIONS[generic]}" == ".asc" ]]
 }
@@ -75,10 +78,11 @@ setup() {
     [[ "${CONTENT_DETECT_ORDER[3]}" == "helm" ]]
 }
 
-@test "UPLOAD_ORDER has jar, pypi, go, win and helm before generic" {
+@test "UPLOAD_ORDER has jar, pypi, go, crate, win and helm before generic" {
     local jar_idx=-1
     local pypi_idx=-1
     local go_idx=-1
+    local crate_idx=-1
     local helm_idx=-1
     local win_idx=-1
     local generic_idx=-1
@@ -86,6 +90,7 @@ setup() {
         [[ "${UPLOAD_ORDER[$i]}" == "jar" ]] && jar_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "pypi" ]] && pypi_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "go" ]] && go_idx=$i
+        [[ "${UPLOAD_ORDER[$i]}" == "crate" ]] && crate_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "helm" ]] && helm_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "win" ]] && win_idx=$i
         [[ "${UPLOAD_ORDER[$i]}" == "generic" ]] && generic_idx=$i
@@ -93,8 +98,10 @@ setup() {
     [[ $jar_idx -lt $generic_idx ]]
     [[ $pypi_idx -lt $generic_idx ]]
     [[ $helm_idx -lt $generic_idx ]]
+    [[ $crate_idx -lt $generic_idx ]]
     [[ $win_idx -lt $generic_idx ]]
     [[ $go_idx -lt $win_idx ]]
+    [[ $crate_idx -lt $win_idx ]]
     [[ $pypi_idx -gt 0 ]]
 }
 
@@ -113,6 +120,7 @@ setup() {
     [[ "$exts" == *"*.exe"* ]]
     [[ "$exts" == *"*.msi"* ]]
     [[ "$exts" == *"*.msix"* ]]
+    [[ "$exts" == *"*.crate"* ]]
 }
 
 @test "emit_type_extension_globs splits on comma and trims spaces" {
@@ -291,6 +299,30 @@ setup() {
 }
 
 # --- get_helm_props ---
+
+@test "get_crate_props returns correct props for Rust crate" {
+    local test_dir
+    test_dir=$(mktemp -d)
+    mkdir -p "$test_dir/aerospike-3.0.0-alpha.1/src"
+    cat >"$test_dir/aerospike-3.0.0-alpha.1/Cargo.toml" <<'CARGO'
+[package]
+name = "aerospike"
+version = "3.0.0-alpha.1"
+edition = "2021"
+CARGO
+    echo 'pub fn placeholder() {}' >"$test_dir/aerospike-3.0.0-alpha.1/src/lib.rs"
+    cd "$test_dir" && tar -czf "aerospike-3.0.0-alpha.1.crate" aerospike-3.0.0-alpha.1/ && cd - >/dev/null
+    VERSION="3.0.0-alpha.1"
+    BUILD_TYPE=""
+    INTERNAL="false"
+    local props
+    props=$(get_crate_props "$test_dir/aerospike-3.0.0-alpha.1.crate" 2>/dev/null)
+    [[ "$props" == *"version=3.0.0-alpha.1"* ]]
+    [[ "$props" == *"package_name=aerospike"* ]]
+    [[ "$props" == *"cargo.name=aerospike"* ]]
+    [[ "$props" == *"cargo.version=3.0.0-alpha.1"* ]]
+    rm -rf "$test_dir"
+}
 
 @test "get_helm_props returns correct props for Helm chart" {
     local test_dir

--- a/.github/workflows/deploy-artifacts/tests/helpers/setup.bash
+++ b/.github/workflows/deploy-artifacts/tests/helpers/setup.bash
@@ -89,6 +89,9 @@ setup_test_artifacts() {
                 "$BUILD_ARTIFACTS_DIR/ci-win-fixture.msi.asc"
                 "$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix"
                 "$BUILD_ARTIFACTS_DIR/ci-win-fixture.msix.asc"
+                "$BUILD_ARTIFACTS_DIR/aerospike-3.0.0-alpha.1.crate"
+                "$BUILD_ARTIFACTS_DIR/aerospike-3.0.0-alpha.1.crate.asc"
+                "$BUILD_ARTIFACTS_DIR/invalid-fixture.crate"
         )
 
         for file in "${TEST_FILES[@]}"; do

--- a/.github/workflows/deploy-artifacts/type_detection.sh
+++ b/.github/workflows/deploy-artifacts/type_detection.sh
@@ -211,7 +211,7 @@ is_nuget_package() {
 is_crate_package() {
     local file="$1"
     [[ -n $file && -f $file && -r $file ]] || return 1
-    case "${file,,}" in
+    case "$file" in
     *.crate) ;;
     *)
         echo "Not a Rust crate: $file (expected *.crate)" >&2

--- a/.github/workflows/deploy-artifacts/type_detection.sh
+++ b/.github/workflows/deploy-artifacts/type_detection.sh
@@ -18,7 +18,7 @@
 # (.nupkg / .snupkg by extension, validated with is_nuget_package from artifact-publisher).
 #
 # Content predicates (is_npm_package, is_pypi_package, is_go_module, is_maven_package,
-# is_nuget_package, is_helm_chart) live here; package_utils keeps metadata extractors.
+# is_nuget_package, is_helm_chart, is_crate_package) live here; package_utils keeps metadata extractors.
 
 # --- npm --------------------------------------------------------------------------------------
 
@@ -201,6 +201,35 @@ is_nuget_package() {
         return 0
     fi
     echo "Not a NuGet package: $f (.nuspec missing id or version)" >&2
+    return 1
+}
+
+# --- Rust crate --------------------------------------------------------------------------------
+
+# is_crate_package <path>
+# Returns 0 if the file is a *.crate gzip tar with Cargo.toml [package] name and version.
+is_crate_package() {
+    local file="$1"
+    [[ -n $file && -f $file && -r $file ]] || return 1
+    case "${file,,}" in
+    *.crate) ;;
+    *)
+        echo "Not a Rust crate: $file (expected *.crate)" >&2
+        return 1
+        ;;
+    esac
+
+    local cargo_toml pkgname version
+    cargo_toml=$(_extract_crate_cargo_toml "$file" 2>/dev/null) || {
+        echo "Not a Rust crate: $file (missing Cargo.toml)" >&2
+        return 1
+    }
+    pkgname=$(_cargo_toml_package_field "$cargo_toml" "name")
+    version=$(_cargo_toml_package_field "$cargo_toml" "version")
+    if [[ -n $pkgname && -n $version ]]; then
+        return 0
+    fi
+    echo "Not a Rust crate: $file (Cargo.toml missing name or version)" >&2
     return 1
 }
 

--- a/.github/workflows/deploy-artifacts/type_registry.sh
+++ b/.github/workflows/deploy-artifacts/type_registry.sh
@@ -95,6 +95,8 @@ register_type go --repo "go-dev-local" --detect "is_go_module"
 # companions=".prov" carries the helm-native provenance signature
 # (GPG-clearsigned Chart.yaml + sha256) produced by sign-artifacts.
 register_type helm --repo "helm-dev-local" --detect "is_helm_chart" --companions ".prov"
+# Rust crates (.crate); structured and uploaded to generic-dev-local like win.
+register_type crate --extension "*.crate" --repo "generic-dev-local"
 # Windows installers / packages (exe, msi, msix); structured and uploaded like generic.
 register_type win --extensions "*.exe,*.msi,*.msix" --repo "generic-dev-local"
 register_type generic --repo "generic-dev-local"
@@ -106,7 +108,7 @@ register_type generic --repo "generic-dev-local"
 CONTENT_DETECT_EXTENSIONS=("*.tgz" "*.tar.gz" "*.zip")
 
 # Upload order matters: jar before generic (jar can move files to generic)
-UPLOAD_ORDER=(rpm deb jar nupkg npm pypi go win helm generic)
+UPLOAD_ORDER=(rpm deb jar nupkg npm pypi go helm crate win generic)
 
 # --- helpers ---
 
@@ -252,6 +254,16 @@ get_generic_props() {
     local filename
     filename=$(basename "$file")
     echo "$(get_base_props);package_name=$filename"
+}
+
+get_crate_props() {
+    local file="$1"
+    local -a metadata
+    read -r -a metadata < <(get_crate_metadata "$file")
+    local pkgname="${metadata[0]}"
+    local pkgversion="${metadata[1]}"
+    echo "  Crate: $pkgname, Version: $pkgversion" >&2
+    echo "$(get_base_props);package_name=$pkgname;cargo.name=$pkgname;cargo.version=$pkgversion"
 }
 
 get_win_props() {


### PR DESCRIPTION
## Summary

Adds first-class detection, structuring, and upload support for Rust `.crate` artifacts in the deploy-artifacts pipeline. Crates are validated via `Cargo.toml`, routed to a dedicated `crate/` structured directory, and uploaded to `{project}-generic-dev-local` (same repo layout as other generic artifacts — e.g. `database-generic-dev-local/{build-name}/{version}/aerospike-3.0.0-alpha.1.crate`). GPG `.asc` companions upload beside the crate.

## Changes

- **Registry:** new `crate` type (`*.crate`, `.asc` companion, `generic-dev-local` repo)
- **Metadata:** `get_crate_metadata()` reads `[package] name` / `version` from `Cargo.toml` (e.g. `aerospike` @ `3.0.0-alpha.1`)
- **Validation:** `is_crate_package()` rejects invalid `.crate` archives before structuring/upload
- **Deploy:** `structure_crate_files()` + `upload_crate_files()` with `cargo.name` / `cargo.version` target props
- **Tests:** new `test_crate_upload.bats` fixture + registry/structuring coverage
- **Docs:** deploy-artifacts and artifacts-cicd README updates

## Test plan

- [x] `bats .github/workflows/deploy-artifacts/tests/bats/test_crate_upload.bats`
- [x] `bats .github/workflows/deploy-artifacts/tests/bats/test_type_registry.bats`
- [x] `bats .github/workflows/deploy-artifacts/tests/bats/test_structuring.bats`
- [x] Verify `aerospike-client-rust` crate lands under `artifacts/generic/...` in release bundles with `.asc` beside `.crate`