### PR TITLE
feat!: [INFRA-649] Major release on breaking API changes

### DIFF
--- a/.github/workflows/pr-hygiene/test_pr-hygiene.yaml
+++ b/.github/workflows/pr-hygiene/test_pr-hygiene.yaml
@@ -44,6 +44,12 @@ jobs:
     with:
       pr_title: "chore: update readme"
 
+  # End-to-end test: breaking change title with JIRA should pass
+  test-breaking-change-title:
+    uses: ./.github/workflows/reusable_pr-hygiene.yml
+    with:
+      pr_title: "feat!: [INFRA-649] Major release on breaking API changes"
+
   # Unit tests via bats
   run-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-hygiene/tests/helpers/setup.bash
+++ b/.github/workflows/pr-hygiene/tests/helpers/setup.bash
@@ -30,7 +30,7 @@ title_matches_patterns() {
 # Usage: extract_jira_ticket "PR title"
 extract_jira_ticket() {
         local title="$1"
-        echo "$title" | grep -oP '^[a-z]+(\([a-z0-9-_]+\))?: \[\K[A-Z]{2,10}-[0-9]+(?=\] )' | head -1
+        echo "$title" | grep -oP '^[a-z]+(\([a-z0-9-_]+\))?(!)?: \[\K[A-Z]{2,10}-[0-9]+(?=\] )' | head -1
 }
 
 # Extract the conventional commit type from a PR title

--- a/.github/workflows/pr-hygiene/tests/test_allowlist.bats
+++ b/.github/workflows/pr-hygiene/tests/test_allowlist.bats
@@ -81,6 +81,18 @@ load "$HELPERS_DIR/setup.bash"
     [ "$ticket" = "INFRA-378" ]
 }
 
+@test "breaking change title without scope extracts JIRA ticket" {
+    local ticket
+    ticket=$(extract_jira_ticket "feat!: [INFRA-649] Major release on breaking API changes")
+    [ "$ticket" = "INFRA-649" ]
+}
+
+@test "breaking change title with scope extracts JIRA ticket" {
+    local ticket
+    ticket=$(extract_jira_ticket "feat(workflows)!: [INFRA-649] Major release on breaking API changes")
+    [ "$ticket" = "INFRA-649" ]
+}
+
 @test "missing JIRA ticket returns empty" {
     local ticket
     ticket=$(extract_jira_ticket "feat: missing jira ticket")

--- a/.github/workflows/reusable_pr-hygiene.yml
+++ b/.github/workflows/reusable_pr-hygiene.yml
@@ -73,9 +73,10 @@ jobs:
 
           echo "allowed=false" >> "$GITHUB_OUTPUT"
 
-      # PR title must follow: type(scope): [JIRA-123] description
+      # PR title must follow: type(scope)[!]: [JIRA-123] description
       #   type:  feat|fix|refactor|docs|test|ci|chore|build|perf (validated by commitlint)
       #   scope: optional, lowercase (e.g., workflows, deploy, actions)
+      #   !:     optional breaking-change marker (e.g., feat!: or feat(scope)!:)
       #   JIRA:  uppercase project key in brackets, before the description
       # Example: feat(workflows): [INFRA-370] add artifacts-cicd integration tests
       - name: Validate PR title is conventional commit
@@ -127,7 +128,7 @@ jobs:
             exit 0
           fi
 
-          JIRA_TICKET=$(echo "$PR_TITLE" | grep -oP '^[a-z]+(\([a-z0-9-_]+\))?: \[\K[A-Z]{2,10}-[0-9]+(?=\] )' | head -1)
+          JIRA_TICKET=$(echo "$PR_TITLE" | grep -oP '^[a-z]+(\([a-z0-9-_]+\))?(!)?: \[\K[A-Z]{2,10}-[0-9]+(?=\] )' | head -1)
           if [ -z "$JIRA_TICKET" ]; then
             echo "❌ ERROR: No JIRA ticket found in PR title!"
             echo "PR title must follow: type(scope): [JIRA-123] description"


### PR DESCRIPTION
## Summary
Major release since **v3.8.0**. Most consumer updates are permission grants or pipeline behavior adjustments — no input renames. Review the caller setup that matches your repo and apply the corresponding change before upgrading.
## Client-side API changes
### Permissions (most common)
| Your setup | Action |
| --- | --- |
| Composable `reusable_deploy-artifacts` with Maven metadata (default `gh-upload-bundle-metadata: true`) | Add `actions: write` to the top-level caller workflow |
| Orchestrated `reusable_artifacts-cicd` with Maven/JAR artifacts | Add `actions: write` to the top-level caller workflow |
| Deploy → `reusable_create-release-bundle` via `gh-bundle-metadata-artifact-name` | Add `actions: write` **and** `actions: read` |
| Composable deploy, metadata not needed | No permission change — set `gh-upload-bundle-metadata: false` |

Minimal caller permissions when metadata handoff is required:
```yaml
permissions:
  contents: read
  id-token: write
  actions: write   # deploy metadata upload
  actions: read    # create-release-bundle metadata download
  ```