### PR TITLE
fix(deploy): [INFRA-673] guard sibling-POM metadata against inherited fields

### DIFF
--- a/.github/workflows/deploy-artifacts/package_utils.sh
+++ b/.github/workflows/deploy-artifacts/package_utils.sh
@@ -37,9 +37,17 @@ get_jar_metadata() {
     local sibling_pom="$jar_dir/${base_no_ext}.pom"
     if [[ -z $group_id && -f $sibling_pom ]]; then
         if command -v xmllint >/dev/null 2>&1; then
-            pkgname=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='artifactId'])" "$sibling_pom" 2>/dev/null)
-            version=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='version'])" "$sibling_pom" 2>/dev/null)
-            group_id=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='groupId'])" "$sibling_pom" 2>/dev/null)
+            local pom_value field
+            for field in artifactId version groupId; do
+                pom_value=$(xmllint --xpath "string(//*[local-name()='project']/*[local-name()='$field'])" "$sibling_pom" 2>/dev/null)
+                # A POM inheriting the field from <parent> resolves empty; it must not clobber a value already found.
+                [[ -n $pom_value ]] || continue
+                case "$field" in
+                artifactId) pkgname="$pom_value" ;;
+                version) version="$pom_value" ;;
+                groupId) group_id="$pom_value" ;;
+                esac
+            done
         fi
     fi
 

--- a/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_metadata.bats
@@ -492,3 +492,45 @@ YAML
 @test "_validate_helm_name accepts name with dots" {
     _validate_helm_name "my.chart"
 }
+
+# --- get_jar_metadata (flat jar + sibling POM) ---
+
+# Builds "$1/test.jar" with no pom.properties plus a sibling test.pom holding $2 as its body.
+make_flat_jar_with_pom() {
+    local dir="$1" pom_body="$2"
+    printf 'placeholder' >"$dir/payload.txt"
+    (cd "$dir" && zip -q test.jar payload.txt)
+    cat >"$dir/test.pom" <<POM
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+$pom_body
+</project>
+POM
+}
+
+@test "get_jar_metadata reads name, version and group from a sibling POM" {
+    set -e
+    local dir="$BATS_TEST_TMPDIR/direct"
+    mkdir -p "$dir"
+    make_flat_jar_with_pom "$dir" "  <artifactId>my-app</artifactId>
+  <version>2.1.0</version>
+  <groupId>com.example.direct</groupId>"
+
+    result=$(get_jar_metadata "$dir/test.jar")
+    [[ $result == "my-app 2.1.0 com.example.direct" ]]
+}
+
+@test "get_jar_metadata keeps the filename-derived name when the sibling POM inherits groupId from a parent" {
+    set -e
+    local dir="$BATS_TEST_TMPDIR/inherited"
+    mkdir -p "$dir"
+    make_flat_jar_with_pom "$dir" "  <parent>
+    <groupId>com.example.parent</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.0.0</version>
+  </parent>"
+
+    # groupId, artifactId and version all resolve empty from this POM. An unguarded
+    # assignment would leave the package name blank and route the jar to the wrong path.
+    result=$(get_jar_metadata "$dir/test.jar")
+    [[ $(echo "$result" | awk '{print $1}') == "test" ]]
+}


### PR DESCRIPTION
`get_jar_metadata` reads a sibling POM when a JAR has no `pom.properties` inside it. It reads `artifactId`, `version` and `groupId` as direct children of `<project>`, so a POM that inherits any of them from `<parent>` resolves to an empty string and overwrites the value already derived from the filename. A child module JAR in a flat layout then structures and uploads with an empty version or package name.

Inheriting `groupId` and `version` from a parent is the normal multi-module shape, so this hits any flat layout. Each field is now assigned only when the POM actually supplies it.

[INFRA-673](https://aerospike.atlassian.net/browse/INFRA-673)

Guards the sibling-POM branch added by #287, now merged.

Test plan: the new inherited-POM test fails without the guard and passes with it.


[INFRA-673]: https://aerospike.atlassian.net/browse/INFRA-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ