### PR TITLE
fix: [INFRA-678] Fix upload step, add tests and safeguards

### DIFF
--- a/.github/workflows/example_composable-matrix.yaml
+++ b/.github/workflows/example_composable-matrix.yaml
@@ -413,7 +413,7 @@ jobs:
       version: ${{ needs.extract-version.outputs.version }}
       oidc-provider-name: gh-dev-test
       oidc-audience: aerospike/testing
-      gh-bundle-metadata-artifact-name: ${{ needs.deploy.outputs.bundle-metadata-artifact-name }}
+      gh-bundle-metadata-artifact-name: ${{ needs.deploy.outputs.bundle-metadata-available == 'true' && needs.deploy.outputs.bundle-metadata-artifact-name || '' }}
 
   # Promote to DEV after bundle creation. Promotion is only available as a
   # composite action, so this must be a steps-based job.

--- a/.github/workflows/example_expanded-integration.yaml
+++ b/.github/workflows/example_expanded-integration.yaml
@@ -500,4 +500,4 @@ jobs:
       oidc-provider-name: gh-dev-test
       oidc-audience: aerospike/testing
       dry-run: false
-      gh-bundle-metadata-artifact-name: ${{ needs.deploy-artifacts.outputs.bundle-metadata-artifact-name }}
+      gh-bundle-metadata-artifact-name: ${{ needs.deploy-artifacts.outputs.bundle-metadata-available == 'true' && needs.deploy-artifacts.outputs.bundle-metadata-artifact-name || '' }}

--- a/.github/workflows/reusable_create-release-bundle.yaml
+++ b/.github/workflows/reusable_create-release-bundle.yaml
@@ -46,9 +46,10 @@ on:
         default: ""
       gh-bundle-metadata-artifact-name:
         description: |
-          When set, downloads this GitHub Actions artifact (e.g. deploy job output `bundle-metadata-artifact-name`)
-          and uses the contained `.maven-bundle-metadata.json` for `jf release-bundle-annotate`. Takes precedence
-          over `bundle-metadata-path` when both are set.
+          When set, downloads this GitHub Actions artifact (e.g. deploy job output `bundle-metadata-artifact-name`
+          when `bundle-metadata-available` is true) and uses the contained `.maven-bundle-metadata.json` for
+          `jf release-bundle-annotate`. Takes precedence over `bundle-metadata-path` when both are set.
+          Gate on deploy `bundle-metadata-available` before passing the artifact name.
         required: false
         type: string
         default: ""
@@ -117,11 +118,34 @@ jobs:
           jf rt ping
 
       - name: Download Maven bundle metadata artifact
+        id: download-bundle-metadata
         if: inputs.gh-bundle-metadata-artifact-name != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.gh-bundle-metadata-artifact-name }}
           path: .bundle-metadata-dl
+
+      - name: Verify Maven bundle metadata download
+        if: always() && !cancelled() && inputs.gh-bundle-metadata-artifact-name != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_name="${{ inputs.gh-bundle-metadata-artifact-name }}"
+          if [[ "${{ steps.download-bundle-metadata.outcome }}" != "success" ]]; then
+            echo "Error: failed to download Maven bundle metadata artifact '$artifact_name'." >&2
+            echo "Confirm deploy uploaded it (deploy output bundle-metadata-available must be true)." >&2
+            echo "Pass gh-bundle-metadata-artifact-name only when bundle-metadata-available is true." >&2
+            exit 1
+          fi
+          if [[ ! -d .bundle-metadata-dl ]]; then
+            echo "Error: download succeeded but .bundle-metadata-dl is missing for artifact '$artifact_name'." >&2
+            exit 1
+          fi
+          if [[ -z "$(find .bundle-metadata-dl -name '.maven-bundle-metadata.json' -type f -print -quit)" ]]; then
+            echo "Error: .maven-bundle-metadata.json not found in artifact '$artifact_name'." >&2
+            echo "Check deploy 'Upload Maven bundle metadata' completed without upload-artifact warnings." >&2
+            exit 1
+          fi
 
       - name: Resolve bundle metadata path
         id: bundle-meta
@@ -130,10 +154,6 @@ jobs:
           set -euo pipefail
           meta=""
           if [[ -n "${{ inputs.gh-bundle-metadata-artifact-name }}" ]]; then
-            if [[ ! -d .bundle-metadata-dl ]]; then
-              echo "Error: expected .bundle-metadata-dl after downloading artifact '${{ inputs.gh-bundle-metadata-artifact-name }}'" >&2
-              exit 1
-            fi
             meta="$(find .bundle-metadata-dl -name '.maven-bundle-metadata.json' -type f | head -n1 || true)"
             if [[ -z "$meta" ]]; then
               echo "Error: .maven-bundle-metadata.json not found under .bundle-metadata-dl" >&2

--- a/.github/workflows/reusable_deploy-artifacts.yaml
+++ b/.github/workflows/reusable_deploy-artifacts.yaml
@@ -129,8 +129,8 @@ jobs:
       id-token: write
     outputs:
       jf-build-id: ${{ steps.deploy.outputs.jf-build-id }}
-      bundle-metadata-artifact-name: ${{ steps.bundle-metadata-state.outputs.artifact-name }}
-      bundle-metadata-available: ${{ steps.bundle-metadata-state.outputs.available == 'true' }}
+      bundle-metadata-artifact-name: ${{ steps.upload-bundle-metadata.outcome == 'success' && steps.bundle-metadata-state.outputs.artifact-name || '' }}
+      bundle-metadata-available: ${{ steps.upload-bundle-metadata.outcome == 'success' }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -284,8 +284,11 @@ jobs:
           echo "artifact-name=${{ inputs.gh-bundle-metadata-artifact-name }}" >>"$GITHUB_OUTPUT"
 
       - name: Upload Maven bundle metadata
+        id: upload-bundle-metadata
         if: success() && steps.bundle-metadata-state.outputs.available == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.gh-bundle-metadata-artifact-name }}
           path: structured_build_artifacts/.maven-bundle-metadata.json
+          include-hidden-files: true
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
Fixes silent failure of Maven bundle metadata handoff between `reusable_deploy-artifacts` and `reusable_create-release-bundle`.
In [Example Composable Matrix CI/CD run 31558997913](https://github.com/aerospike/shared-workflows/actions/runs/31558997913), deploy wrote `.maven-bundle-metadata.json` and reported metadata as available, but `upload-artifact` skipped the dotfile (`include-hidden-files: false` by default) and only warned. `create-release-bundle` then failed downloading the missing `bundle-metadata` artifact.
**Root cause:** `.maven-bundle-metadata.json` is a hidden file; the upload step never set `include-hidden-files: true`, and job outputs reflected pre-upload file existence rather than actual upload success.
## Changes
- **`reusable_deploy-artifacts.yaml`**
  - Set `include-hidden-files: true` and `if-no-files-found: error` on **Upload Maven bundle metadata**
  - Tie `bundle-metadata-available` / `bundle-metadata-artifact-name` outputs to upload step success
- **`reusable_create-release-bundle.yaml`**
  - Add **Verify Maven bundle metadata download** step with actionable errors when download or JSON content is missing
- **`example_composable-matrix.yaml`**, **`example_expanded-integration.yaml`**
  - Gate `gh-bundle-metadata-artifact-name` on deploy `bundle-metadata-available == 'true'`
## Test plan
- [ ] Re-run `Example Composable Matrix CI/CD` (`workflow_dispatch`) and confirm deploy uploads `bundle-metadata` and create-release-bundle completes
- [ ] Confirm PR CI workflows (`test_deploy-artifacts-workflow`, integration deploy) still pass
