### PR TITLE
test(deploy): cover the Maven bundle metadata handoff

### DIFF
--- a/.github/workflows/deploy-artifacts/tests/bats/test_bundle_metadata_upload.bats
+++ b/.github/workflows/deploy-artifacts/tests/bats/test_bundle_metadata_upload.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+#
+# Upload settings for .maven-bundle-metadata.json.
+
+WORKFLOW="${BATS_TEST_DIRNAME}/../../../reusable_deploy-artifacts.yaml"
+
+UPLOAD_STEP='.jobs.deploy.steps[] | select(.id == "upload-bundle-metadata")'
+
+@test "the metadata upload includes hidden files" {
+    # .maven-bundle-metadata.json is a dotfile, and upload-artifact excludes
+    # those by default while still reporting success.
+    local value
+    value="$(yq -r "${UPLOAD_STEP} | .with.\"include-hidden-files\"" "$WORKFLOW")"
+    [ "$value" = "true" ]
+}
+
+@test "the metadata upload fails when it matches no file" {
+    local value
+    value="$(yq -r "${UPLOAD_STEP} | .with.\"if-no-files-found\"" "$WORKFLOW")"
+    [ "$value" = "error" ]
+}
+
+@test "availability follows the upload rather than the pre-upload file check" {
+    # A file on disk before the upload does not mean an artifact reached the
+    # run, which is what create-release-bundle goes on to download.
+    local expression
+    expression="$(yq -r '.jobs.deploy.outputs."bundle-metadata-available"' "$WORKFLOW")"
+    [[ "$expression" == *"upload-bundle-metadata.outcome"* ]]
+}

--- a/.github/workflows/test_deploy-artifacts-workflow.yaml
+++ b/.github/workflows/test_deploy-artifacts-workflow.yaml
@@ -45,6 +45,43 @@ jobs:
       gh-artifact-name: test-fixtures
       dry-run: true
 
+  assert-bundle-metadata:
+    needs: test-deploy-workflow
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Assert deploy published the metadata artifact
+        env:
+          AVAILABLE: ${{ needs.test-deploy-workflow.outputs.bundle-metadata-available }}
+          ARTIFACT_NAME: ${{ needs.test-deploy-workflow.outputs.bundle-metadata-artifact-name }}
+        run: |
+          set -euo pipefail
+          if [[ "$AVAILABLE" != "true" || -z "$ARTIFACT_NAME" ]]; then
+            echo "::error::deploy reported bundle-metadata-available=$AVAILABLE name=$ARTIFACT_NAME; the fixtures contain a Maven POM and its sibling JAR, so metadata is expected"
+            exit 1
+          fi
+
+      - name: Download the metadata artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.test-deploy-workflow.outputs.bundle-metadata-artifact-name }}
+          path: bundle-metadata
+
+      - name: Assert the metadata survived the round trip
+        run: |
+          set -euo pipefail
+          meta="bundle-metadata/.maven-bundle-metadata.json"
+          if [[ ! -f "$meta" ]]; then
+            echo "::error::$meta is missing from the artifact that create-release-bundle downloads"
+            ls -aR bundle-metadata
+            exit 1
+          fi
+          jq -e 'has("maven_module_count") and .maven_module_count > 0' "$meta"
+
   run-tests:
     runs-on: ubuntu-22.04
     steps:
@@ -58,6 +95,19 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install dpkg-dev rpm nodejs npm libxml2-utils -y
+
+      # No yq package exists for jammy, and the runner image does not ship one.
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.44.3
+          YQ_SHA256: a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
       - name: Install bats
         run: |
           # Install bats-core from source (recommended method per official documentation)


### PR DESCRIPTION
## Summary

The Maven bundle metadata handoff added in [#251](https://github.com/aerospike/shared-workflows/pull/251) shipped with no test that performs the handoff, so it was broken from [v4.0.0](https://github.com/aerospike/shared-workflows/releases/tag/v4.0.0) until [#299](https://github.com/aerospike/shared-workflows/pull/299) without any check going red. `.maven-bundle-metadata.json` is a dotfile, `upload-artifact` excludes hidden files by default, and `if-no-files-found: warn` kept the step green while nothing was uploaded. [#299](https://github.com/aerospike/shared-workflows/pull/299) added runtime safeguards; this adds the coverage that would have caught it, and would catch its removal.

Follows [INFRA-678](https://aerospike.atlassian.net/browse/INFRA-678).

## Changes

- `test_deploy-artifacts-workflow.yaml`: new `assert-bundle-metadata` job. The deploy test already publishes a `bundle-metadata` artifact on every PR, because the fixtures include `test.pom` and its sibling `test.jar`, but nothing asserted it existed. The job checks the deploy outputs, downloads the artifact, and asserts `.maven-bundle-metadata.json` is inside it and parses.
- `deploy-artifacts/tests/bats/test_bundle_metadata_upload.bats`: static assertions that the upload step sets `include-hidden-files: true` and `if-no-files-found: error`, and that `bundle-metadata-available` derives from the upload outcome rather than the pre-upload file check.
- `yq` install in the bats job, pinned and checksummed, matching `test_docker-build-deploy-validation.yaml`.

No `actions` permission is added; the download is same-run.

## Test plan

- [x] All three bats tests fail with the [#299](https://github.com/aerospike/shared-workflows/pull/299) settings reverted and pass with them in place, run against the pinned yq v4.44.3 rather than the older local flavor
- [x] Full `deploy-artifacts` bats suite passes locally
- [x] `trunk check` clean
- [ ] `assert-bundle-metadata` passes in PR CI


[INFRA-678]: https://aerospike.atlassian.net/browse/INFRA-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ