### PR TITLE
ci(release): preview notes on pull requests and list every change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,11 +76,11 @@ jobs:
             if grep -q "Release note for version" "$log"; then
               # These are the branch's own commits. A squash merge publishes the
               # pull request title instead, so the landed entry may differ.
-              # The logger indents list items by four spaces, which markdown
-              # would otherwise render as a code block.
+              # Other log lines interleave with the notes, and the logger
+              # indents list items by four spaces, which markdown would
+              # otherwise render as a code block.
               sed -n '/Release note for version/,$p' "$log" |
-                tail -n +2 |
-                sed 's/^    //'
+                sed -e '/\[semantic-release\] ›/d' -e 's/^    //'
             else
               echo "No release would be published from these commits."
             fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,13 +38,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.head_ref }}
-          # semantic-release takes the branch from GITHUB_REF, which on a pull
-          # request is refs/pull/N/merge and matches no configured branch.
-          GITHUB_REF: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}
         run: |
           set -euo pipefail
           args=()
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            # semantic-release reads the branch from GITHUB_REF, which the
+            # runner sets to refs/pull/N/merge. Exporting it here rather than in
+            # env: because the runner overrides GITHUB_-prefixed keys there.
+            export GITHUB_REF="refs/heads/$HEAD_REF"
             # --no-ci because semantic-release otherwise declines to analyse a
             # pull request at all, even for a dry run.
             args=(--dry-run --no-ci --branches "$HEAD_REF")

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.head_ref }}
+          # semantic-release takes the branch from GITHUB_REF, which on a pull
+          # request is refs/pull/N/merge and matches no configured branch.
+          GITHUB_REF: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}
         run: |
           set -euo pipefail
           args=()
@@ -59,14 +62,20 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           set -euo pipefail
+          log="$RUNNER_TEMP/release.log"
+          # A branch semantic-release declined to analyse otherwise reports the
+          # same way as one with nothing releasable in it.
+          if grep -q "configured to only publish from" "$log"; then
+            echo "::error::semantic-release did not analyse this branch, so there is no preview"
+            exit 1
+          fi
           {
             echo "## Projected release"
             echo
-            if grep -q "Release note for version" "$RUNNER_TEMP/release.log"; then
+            if grep -q "Release note for version" "$log"; then
               # These are the branch's own commits. A squash merge publishes the
               # pull request title instead, so the landed entry may differ.
-              sed -n '/Release note for version/,$p' "$RUNNER_TEMP/release.log" |
-                tail -n +2
+              sed -n '/Release note for version/,$p' "$log" | tail -n +2
             else
               echo "No release would be published from these commits."
             fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,11 @@ jobs:
             if grep -q "Release note for version" "$log"; then
               # These are the branch's own commits. A squash merge publishes the
               # pull request title instead, so the landed entry may differ.
-              sed -n '/Release note for version/,$p' "$log" | tail -n +2
+              # The logger indents list items by four spaces, which markdown
+              # would otherwise render as a code block.
+              sed -n '/Release note for version/,$p' "$log" |
+                tail -n +2 |
+                sed 's/^    //'
             else
               echo "No release would be published from these commits."
             fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
           node-version: 20
 
       - name: Semantic Release
-        id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
@@ -54,7 +53,6 @@ jobs:
               -p @semantic-release/commit-analyzer@13 \
               -p @semantic-release/release-notes-generator@14 \
               -p @semantic-release/github@11 \
-              -p @semantic-release/exec@7 \
               -p conventional-changelog@7 \
               -p conventional-changelog-conventionalcommits@8 \
               semantic-release "${args[@]}" | tee "$RUNNER_TEMP/release.log"
@@ -85,26 +83,3 @@ jobs:
               echo "No release would be published from these commits."
             fi
           } >>"$GITHUB_STEP_SUMMARY"
-
-      - name: Append the full change list to the release
-        if: github.event_name != 'pull_request' && steps.release.outputs.version != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: v${{ steps.release.outputs.version }}
-        run: |
-          set -euo pipefail
-          # Lookup by tag returns published releases only, so find the draft in
-          # the list instead.
-          id=$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
-            --jq "map(select(.tag_name == \"$TAG\")) | .[0].id")
-          # Generated from merged pull requests, so it also covers commits whose
-          # subject the conventional-commit parser cannot categorise.
-          gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="$TAG" --jq .body >"$RUNNER_TEMP/generated.md"
-          {
-            gh api "repos/${GITHUB_REPOSITORY}/releases/${id}" --jq .body
-            printf '\n\n---\n\n'
-            cat "$RUNNER_TEMP/generated.md"
-          } >"$RUNNER_TEMP/final.md"
-          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${id}" \
-            -F body=@"$RUNNER_TEMP/final.md" --silent

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # A fork's head branch does not exist on this remote, and semantic-release
+    # rejects a --branches value it cannot find there.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -21,19 +24,68 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          # The default merge ref leaves a detached HEAD, and semantic-release
+          # matches --branches against the checked-out branch name.
+          ref: ${{ github.head_ref || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
       - name: Semantic Release
+        id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
+          set -euo pipefail
+          args=()
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            # --no-ci because semantic-release otherwise declines to analyse a
+            # pull request at all, even for a dry run.
+            args=(--dry-run --no-ci --branches "$HEAD_REF")
+          fi
           npx -p semantic-release@24 \
               -p @semantic-release/commit-analyzer@13 \
               -p @semantic-release/release-notes-generator@14 \
               -p @semantic-release/github@11 \
+              -p @semantic-release/exec@7 \
               -p conventional-changelog@7 \
               -p conventional-changelog-conventionalcommits@8 \
-              semantic-release
+              semantic-release "${args[@]}" | tee "$RUNNER_TEMP/release.log"
+
+      - name: Show the projected release on the pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          {
+            echo "## Projected release"
+            echo
+            if grep -q "Release note for version" "$RUNNER_TEMP/release.log"; then
+              # These are the branch's own commits. A squash merge publishes the
+              # pull request title instead, so the landed entry may differ.
+              sed -n '/Release note for version/,$p' "$RUNNER_TEMP/release.log" |
+                tail -n +2
+            else
+              echo "No release would be published from these commits."
+            fi
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Append the full change list to the release
+        if: github.event_name != 'pull_request' && steps.release.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Generated from merged pull requests, so it also covers commits whose
+          # subject the conventional-commit parser cannot categorise.
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body >"$RUNNER_TEMP/generated.md"
+          {
+            gh release view "$TAG" --json body --jq .body
+            printf '\n\n---\n\n'
+            cat "$RUNNER_TEMP/generated.md"
+          } >"$RUNNER_TEMP/final.md"
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/final.md"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,13 +93,18 @@ jobs:
           TAG: v${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
+          # Lookup by tag returns published releases only, so find the draft in
+          # the list instead.
+          id=$(gh api "repos/${GITHUB_REPOSITORY}/releases" \
+            --jq "map(select(.tag_name == \"$TAG\")) | .[0].id")
           # Generated from merged pull requests, so it also covers commits whose
           # subject the conventional-commit parser cannot categorise.
           gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
             -f tag_name="$TAG" --jq .body >"$RUNNER_TEMP/generated.md"
           {
-            gh release view "$TAG" --json body --jq .body
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${id}" --jq .body
             printf '\n\n---\n\n'
             cat "$RUNNER_TEMP/generated.md"
           } >"$RUNNER_TEMP/final.md"
-          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/final.md"
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${id}" \
+            -F body=@"$RUNNER_TEMP/final.md" --silent

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -53,9 +53,29 @@
 		[
 			"@semantic-release/release-notes-generator",
 			{
-				"preset": "conventionalcommits"
+				"preset": "conventionalcommits",
+				"presetConfig": {
+					"types": [
+						{ "type": "feat", "section": "Features" },
+						{ "type": "fix", "section": "Bug Fixes" },
+						{ "type": "perf", "section": "Performance" },
+						{ "type": "revert", "section": "Reverts" },
+						{ "type": "refactor", "section": "Refactoring", "hidden": false },
+						{ "type": "docs", "section": "Documentation", "hidden": false },
+						{ "type": "test", "section": "Tests", "hidden": false },
+						{ "type": "build", "section": "Build System", "hidden": false },
+						{ "type": "ci", "section": "CI", "hidden": false },
+						{ "type": "chore", "section": "Chores", "hidden": false }
+					]
+				}
 			}
 		],
-		"@semantic-release/github"
+		"@semantic-release/github",
+		[
+			"@semantic-release/exec",
+			{
+				"successCmd": "echo \"version=${nextRelease.version}\" >> \"$GITHUB_OUTPUT\""
+			}
+		]
 	]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -70,7 +70,12 @@
 				}
 			}
 		],
-		"@semantic-release/github",
+		[
+			"@semantic-release/github",
+			{
+				"draftRelease": true
+			}
+		],
 		[
 			"@semantic-release/exec",
 			{

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -75,12 +75,6 @@
 			{
 				"draftRelease": true
 			}
-		],
-		[
-			"@semantic-release/exec",
-			{
-				"successCmd": "echo \"version=${nextRelease.version}\" >> \"$GITHUB_OUTPUT\""
-			}
 		]
 	]
 }


### PR DESCRIPTION
## Summary

Release notes are only visible after publishing, they omit part of what shipped, and the release goes out with no chance to review it.

Follows [INFRA-678](https://aerospike.atlassian.net/browse/INFRA-678).

## Changes

- `release.yaml` already triggers on `pull_request` but prints nothing useful. It now runs a dry run and writes the projected version and notes to the job summary.
- `presetConfig.types` unhides the types the conventionalcommits preset drops, so dependency and CI commits are listed. Listing only; the version bump is still `commit-analyzer.releaseRules`.
- `draftRelease: true`, so the release is created as a draft for a human to publish.

## Known gap

A non-conventional commit subject is not categorised and so is not listed. [#292](https://github.com/aerospike/shared-workflows/pull/292) is the only one in v4.1.0, and StepSecurity pull requests bypass title validation in `reusable_pr-hygiene.yml`, so it recurs on theirs. Attribution is out of reach for the same reason: a commit carries a name and email, not a GitHub handle.

## Test plan

- [x] Dry run gives 4.1.0, unchanged, with a new Build System section
- [x] Preview renders on this PR, in the Release job summary


[INFRA-678]: https://aerospike.atlassian.net/browse/INFRA-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ