### PR TITLE
feat(release-evidence): add release evidence action and scripts

### DIFF
--- a/.github/actions/release-evidence/README.md
+++ b/.github/actions/release-evidence/README.md
@@ -64,6 +64,22 @@ SLSA provenance lookups use `gh`, so the job needs a token that can read attesta
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+## Any Artifact, Any Promotion Stage
+
+The target does not have to be public, in a virtual repository, or in a release bundle. An artifact sitting in a `*-dev-local` repository straight off a build is a valid target, and reports on what exists so far rather than refusing.
+
+Maturity is read two ways. A promotion attestation is the strong signal. Failing that, the environment segment of the repositories holding the bytes places the artifact in the pipeline, which is the only signal available before a bundle exists.
+
+That produces three distinct lists, and the difference between the last two is the point:
+
+| Field            | Meaning                                                                |
+| ---------------- | ---------------------------------------------------------------------- |
+| `stages_reached` | Stages reached, by promotion record or by repository residence         |
+| `pending_stages` | Stages above that point. Not promoted there yet, so no records are due |
+| `skipped_stages` | Stages below that point with no record. A gate was passed over         |
+
+A document for an unsealed artifact is mostly absences, and that is the correct result rather than a failure. Claims are only rendered when the record backing them exists, so an artifact with no seal and no promotions makes no custody claims at all. Reporting less than we would like is the honest output; reporting more than the records support is the one failure this tool cannot afford.
+
 ## Reading The Output
 
 Two distinctions matter when interpreting a document:
@@ -71,4 +87,12 @@ Two distinctions matter when interpreting a document:
 - JFrog build-info is not SLSA provenance. Build-info records what a build declared about itself; provenance is an attestation signed by the builder.
 - The bundle seal proves custody, not origin. It proves the bytes in the bundle are the bytes that were sealed, not where they came from.
 
-An absent record is not automatically a gap. A promoted container tag loses its build properties, and INTERNAL is a valid terminal stage rather than a missing PROD.
+An absent record is not automatically a gap. A promoted container tag loses its build properties, INTERNAL is a valid terminal stage rather than a missing PROD, and a stage listed under `pending_stages` is work still to come rather than a hole.
+
+## Tests
+
+```sh
+python3 -m unittest discover .github/actions/release-evidence/tests -v
+```
+
+Transport is stubbed, so the tests cover what decides a document's claims: stage classification, the pending-versus-skipped distinction, and the rule that no claim renders without its record.

--- a/.github/actions/release-evidence/README.md
+++ b/.github/actions/release-evidence/README.md
@@ -1,0 +1,74 @@
+# Release Evidence
+
+Trace what a published artifact or release can prove, using the signed records JFrog and GitHub already hold. Reads only; it publishes nothing and changes nothing.
+
+For any target it reports the digest, every repository holding those bytes, the release bundle seal, the promotion history with approvers, SLSA provenance where it exists, and the pull request that authorized the change.
+
+## Scripts
+
+Both scripts run standalone as well as through the action. They need `curl`, `jq`, `python3`, and `gh`.
+
+| Script                | Scope                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `verify-artifact.sh`  | One artifact: digest, holding repositories, commit, seal, promotions, provenance, PR |
+| `release-evidence.py` | The whole release the artifact belongs to, as a markdown or JSON document            |
+
+```sh
+JFROG_TOKEN=<token> ./verify-artifact.sh clients-pypi-dev-local/aerospike/16.0.1/aerospike-16.0.1.whl
+JFROG_TOKEN=<token> ./release-evidence.py bundle:my-release/1.2.3@myproject --format json
+```
+
+`release-evidence.py` accepts a `repo/path`, a full Artifactory URL, `sha256:HEX`, or `bundle:NAME/VERSION@PROJECT` when the release bundle is already known. For a container, point it at the tag's `list.manifest.json`, whose sha256 is the index digest GitHub attests.
+
+JFrog auth comes from `JFROG_TOKEN`. GitHub auth comes from the `gh` CLI or `GITHUB_TOKEN`.
+
+## Action Inputs
+
+| Input         | Required | Default                      | Description                                                        |
+| ------------- | -------- | ---------------------------- | ------------------------------------------------------------------ |
+| `target`      | Yes      | -                            | Artifact path, URL, `sha256:HEX`, or `bundle:NAME/VERSION@PROJECT` |
+| `format`      | No       | `markdown`                   | `markdown` or `json`                                               |
+| `about`       | No       | -                            | One clause describing the thing, used in the opening sentence      |
+| `output-path` | No       | -                            | Write the document here instead of stdout                          |
+| `jf-url`      | No       | `https://aerospike.jfrog.io` | JFrog platform URL                                                 |
+| `jfrog-token` | No       | -                            | Overrides `JFROG_TOKEN` and the JFrog CLI config                   |
+
+| Output     | Description                                                |
+| ---------- | ---------------------------------------------------------- |
+| `document` | Path to the written document, empty when it went to stdout |
+
+## Prerequisites
+
+A JFrog token, resolved in this order: the `jfrog-token` input, then `JFROG_TOKEN` in the environment, then an already-configured JFrog CLI. The last case covers most callers, since `setup-jfrog-cli` has usually run for OIDC before this step.
+
+SLSA provenance lookups use `gh`, so the job needs a token that can read attestations on the repository that built the artifact.
+
+## Example
+
+```yaml
+- name: Setup JFrog CLI
+  uses: jfrog/setup-jfrog-cli@<sha> # v4.8.1
+  env:
+    JF_URL: https://aerospike.jfrog.io
+  with:
+    oidc-provider-name: gh-aerospike
+    oidc-audience: aerospike
+
+- name: Record release evidence
+  uses: aerospike/shared-workflows/.github/actions/release-evidence@<sha> # version
+  with:
+    target: bundle:${{ inputs.bundle-name }}/${{ inputs.bundle-version }}@${{ inputs.jf-project }}
+    format: json
+    output-path: evidence/${{ inputs.bundle-name }}.json
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Reading The Output
+
+Two distinctions matter when interpreting a document:
+
+- JFrog build-info is not SLSA provenance. Build-info records what a build declared about itself; provenance is an attestation signed by the builder.
+- The bundle seal proves custody, not origin. It proves the bytes in the bundle are the bytes that were sealed, not where they came from.
+
+An absent record is not automatically a gap. A promoted container tag loses its build properties, and INTERNAL is a valid terminal stage rather than a missing PROD.

--- a/.github/actions/release-evidence/action.yaml
+++ b/.github/actions/release-evidence/action.yaml
@@ -1,0 +1,82 @@
+name: Release Evidence
+description: >
+  Produce a release evidence document for a published artifact or release bundle: digests,
+  the bundle seal, promotion history with approvers, SLSA provenance, and the authorizing
+  pull request. Reads signed records only; publishes nothing.
+inputs:
+  target:
+    description: >
+      What to trace. A repo/path, a full Artifactory URL, sha256:HEX, or
+      bundle:NAME/VERSION@PROJECT when you already know the release bundle.
+    required: true
+  format:
+    description: markdown (default) or json
+    required: false
+    default: markdown
+  about:
+    description: One clause describing what the thing is, used in the opening sentence
+    required: false
+    default: ""
+  output-path:
+    description: Write the document here instead of stdout
+    required: false
+    default: ""
+  jf-url:
+    description: JFrog platform URL
+    required: false
+    default: https://aerospike.jfrog.io
+  jfrog-token:
+    description: >
+      JFrog access token. Leave unset to inherit JFROG_TOKEN from the environment, or to
+      derive it from an already-configured JFrog CLI.
+    required: false
+    default: ""
+outputs:
+  document:
+    description: Path to the written document, empty when the document went to stdout
+    value: ${{ steps.evidence.outputs.document }}
+runs:
+  using: composite
+  steps:
+    - name: Generate release evidence
+      id: evidence
+      shell: bash
+      env:
+        JF_BASE: ${{ inputs.jf-url }}
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_FORMAT: ${{ inputs.format }}
+        INPUT_ABOUT: ${{ inputs.about }}
+        INPUT_OUTPUT_PATH: ${{ inputs.output-path }}
+        INPUT_JFROG_TOKEN: ${{ inputs.jfrog-token }}
+      run: |
+        set -euo pipefail
+
+        # Token precedence: explicit input, then the environment, then an already-configured
+        # JFrog CLI. The last case is what most callers hit, since setup-jfrog-cli has
+        # usually run for OIDC before this action.
+        token="${INPUT_JFROG_TOKEN:-${JFROG_TOKEN:-}}"
+        if [[ -z "$token" ]] && command -v jf >/dev/null 2>&1; then
+          token=$(jf config export setup-jfrog-cli-server 2>/dev/null | base64 -d 2>/dev/null | jq -r '.accessToken // empty' || true)
+        fi
+        if [[ -z "$token" || "$token" == "null" ]]; then
+          echo "::error::release-evidence: no JFrog token. Set the jfrog-token input, export JFROG_TOKEN, or configure the JFrog CLI first." >&2
+          exit 1
+        fi
+        echo "::add-mask::${token}"
+        export JFROG_TOKEN="$token"
+
+        args=("$INPUT_TARGET" --format "$INPUT_FORMAT")
+        if [[ -n "$INPUT_ABOUT" ]]; then
+          args+=(--about "$INPUT_ABOUT")
+        fi
+
+        script="${GITHUB_ACTION_PATH}/release-evidence.py"
+        if [[ -n "$INPUT_OUTPUT_PATH" ]]; then
+          mkdir -p "$(dirname "$INPUT_OUTPUT_PATH")"
+          python3 "$script" "${args[@]}" >"$INPUT_OUTPUT_PATH"
+          echo "document=${INPUT_OUTPUT_PATH}" >>"$GITHUB_OUTPUT"
+          echo "Wrote ${INPUT_FORMAT} evidence to ${INPUT_OUTPUT_PATH}"
+        else
+          python3 "$script" "${args[@]}"
+          echo "document=" >>"$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/release-evidence/release-evidence.py
+++ b/.github/actions/release-evidence/release-evidence.py
@@ -485,11 +485,13 @@ def custody_rows(evidence):
 
     if pr:
         commit = evidence["source"]["commit"][:8]
+        approval = (f'approved by {phrase(f"`{a}`" for a in pr["approvers"])}'
+                    if pr["approvers"] else "not approved")
+        state = (f'merged {when(pr["merged_at"])} UTC as commit `{commit}`'
+                 if pr["merged_at"] else f'still open, head at commit `{commit}`')
         rows.append(["Peer review",
                      f'[PR #{pr["number"]}](https://github.com/{pr["repo"]}/pull/{pr["number"]}), '
-                     f'written by `{pr["author"]}`, approved by '
-                     f'{phrase(f"`{a}`" for a in pr["approvers"])}, merged '
-                     f'{when(pr["merged_at"])} UTC as commit `{commit}`', "GitHub"])
+                     f'written by `{pr["author"]}`, {approval}, {state}', "GitHub"])
     if evidence["source"]:
         src = evidence["source"]
         rows.append(["Build from that commit",
@@ -561,10 +563,12 @@ def claim_rows(evidence):
                      "One signed promotion attestation per stage", scope])
     if evidence["pr"]:
         pr = evidence["pr"]
-        rows.append(["The change was approved by someone other than its author before merge",
-                     f'PR #{pr["number"]}, approved by '
-                     f'{phrase(f"`{a}`" for a in pr["approvers"])} against author '
-                     f'`{pr["author"]}`', scope])
+        independent = [a for a in pr["approvers"] if a != pr["author"]]
+        if independent and pr["merged_at"]:
+            rows.append(["The change was approved by someone other than its author before merge",
+                         f'PR #{pr["number"]}, approved by '
+                         f'{phrase(f"`{a}`" for a in independent)} against author '
+                         f'`{pr["author"]}`', scope])
     for pkg_type in derived["attested_types"]:
         art = next(a for a in evidence["artifacts"]
                    if a["type"] == pkg_type and a["attestation"])

--- a/.github/actions/release-evidence/release-evidence.py
+++ b/.github/actions/release-evidence/release-evidence.py
@@ -631,6 +631,11 @@ def gap_rows(evidence):
                      f'That this passed through {phrase(derived["skipped_stages"])}. It has '
                      f'reached {phrase(derived["stages_reached"])}, so those gates were passed '
                      "over rather than not yet reached."])
+    if derived["pending_stages"]:
+        rows.append([f'A recorded {phrase(derived["pending_stages"])} transition',
+                     f'That this cleared {phrase(derived["pending_stages"])}. It has reached '
+                     f'{phrase(derived["stages_reached"]) or "no stage"}, so those gates lie ahead '
+                     "of it and the approvals they record do not exist yet."])
     if evidence["pr"] and not derived["independently_approved"]:
         pr = evidence["pr"]
         rows.append(["An approving review on the authorizing pull request",
@@ -657,7 +662,7 @@ def position_blocks(evidence):
     text = f"This has reached {reached}."
     if derived["pending_stages"]:
         text += (f' It has not been promoted to {phrase(derived["pending_stages"])} yet, so the '
-                 "records those stages would produce do not exist and are not counted against it.")
+                 "records those stages would produce do not exist.")
     if derived["skipped_stages"]:
         text += (f' No promotion record exists for {phrase(derived["skipped_stages"])}, which sits '
                  "below where it has got to. That is a gap rather than work still to come.")

--- a/.github/actions/release-evidence/release-evidence.py
+++ b/.github/actions/release-evidence/release-evidence.py
@@ -31,8 +31,9 @@ COMPANION = (".asc", ".prov", ".sig", ".sha256", ".md5")
 # The public virtual repository for each JFrog package type.
 VIRTUAL = {"docker": "docker", "maven": "maven", "helm": "helm", "debian": "deb", "yum": "rpm",
            "pypi": "pypi", "npm": "npm", "go": "go", "nuget": "nuget", "gems": "gems"}
-NOUN = {"docker": "container", "maven": "jar", "helm": "Helm chart", "debian": "deb package",
-        "yum": "rpm package", "pypi": "Python package", "npm": "npm package", "go": "Go module"}
+NOUN = {"docker": "container", "oci": "container", "maven": "jar", "helm": "Helm chart",
+        "debian": "deb package", "yum": "rpm package", "pypi": "Python package",
+        "npm": "npm package", "go": "Go module"}
 # An immutable promoted tag carries a build timestamp; the clean tag is what a consumer pulls.
 TIMESTAMPED_TAG = re.compile(r"_\d{8}T\d{6}Z")
 # Promotion stages in maturity order. INTERNAL and PROD are alternative terminal stages, so
@@ -244,13 +245,28 @@ def image_labels(root, path):
     return (blob or {}).get("config", {}).get("Labels") or {}
 
 
+def container_tag_manifest(path):
+    """True for the manifest under a tag folder, which is the image as a consumer names it.
+
+    A digest folder holds one architecture, `_uploads` holds staging copies, and everything
+    else under an image is a blob. Listing any of them presents storage as if it shipped.
+    """
+    parts = path.split("/")
+    if len(parts) < 2 or parts[-1] not in ("manifest.json", "list.manifest.json"):
+        return False
+    tag = parts[-2]
+    return not tag.startswith("sha256:") and tag != "_uploads"
+
+
 def primary_artifacts(record):
     """One entry per shipped thing: no signatures, container blobs or per-arch manifests."""
     out = []
     for art in record.get("artifacts", []):
         if art["path"].endswith(COMPANION):
             continue
-        if art["package_type"] == "docker" and not art["path"].endswith("/list.manifest.json"):
+        # JFrog types OCI-native repositories `oci` and Docker ones `docker`. Both store an
+        # image as a manifest plus blobs, so both need collapsing to the image itself.
+        if art["package_type"] in ("docker", "oci") and not container_tag_manifest(art["path"]):
             continue
         out.append(art)
     return out

--- a/.github/actions/release-evidence/release-evidence.py
+++ b/.github/actions/release-evidence/release-evidence.py
@@ -263,6 +263,10 @@ def collect(target, about):
     if release_ref:
         bundle_repo, bundle, project = release_ref
         record = jf(f"lifecycle/api/v2/release_bundle/records/{bundle}?project={project}") or {}
+        # An empty record renders as a sealed bundle of zero files signed by nobody, which reads
+        # as evidence rather than as its absence. Refuse instead.
+        if not record.get("artifacts"):
+            sys.exit(f"no release bundle {bundle} in project {project}")
         seal = statement(jf(f"artifactory/{bundle_repo}/{bundle}/release-bundle.json.evd")) or {}
         sealed_digests = {s["digest"]["sha256"] for s in seal.get("subject", [])}
         entries = primary_artifacts(record)
@@ -433,6 +437,10 @@ def collect(target, about):
             "pending_stages": [s for s in expected[furthest + 1:]],
             "self_approved": bool(pull_request
                                   and pull_request["author"] in pull_request["approvers"]),
+            # An approval from anyone but the author. Absent approvals are not evidence that
+            # the author declined to self-approve, so nothing may be inferred from an empty list.
+            "independently_approved": bool(pull_request and any(
+                a != pull_request["author"] for a in pull_request["approvers"])),
             "unlinked_published": sorted({a["type"] for a in artifacts
                                           if a["public"] and a["published_build_linked"] is False}),
             "any_commit": any(a["commit"] for a in artifacts),
@@ -561,14 +569,14 @@ def claim_rows(evidence):
                      "of the seal", scope])
         rows.append(["Every stage transition so far has an identity and a timestamp",
                      "One signed promotion attestation per stage", scope])
-    if evidence["pr"]:
+    if evidence["pr"] and evidence["derived"]["independently_approved"] \
+            and evidence["pr"]["merged_at"]:
         pr = evidence["pr"]
         independent = [a for a in pr["approvers"] if a != pr["author"]]
-        if independent and pr["merged_at"]:
-            rows.append(["The change was approved by someone other than its author before merge",
-                         f'PR #{pr["number"]}, approved by '
-                         f'{phrase(f"`{a}`" for a in independent)} against author '
-                         f'`{pr["author"]}`', scope])
+        rows.append(["The change was approved by someone other than its author before merge",
+                     f'PR #{pr["number"]}, approved by '
+                     f'{phrase(f"`{a}`" for a in independent)} against author '
+                     f'`{pr["author"]}`', scope])
     for pkg_type in derived["attested_types"]:
         art = next(a for a in evidence["artifacts"]
                    if a["type"] == pkg_type and a["attestation"])
@@ -623,6 +631,13 @@ def gap_rows(evidence):
                      f'That this passed through {phrase(derived["skipped_stages"])}. It has '
                      f'reached {phrase(derived["stages_reached"])}, so those gates were passed '
                      "over rather than not yet reached."])
+    if evidence["pr"] and not derived["independently_approved"]:
+        pr = evidence["pr"]
+        rows.append(["An approving review on the authorizing pull request",
+                     f'That someone other than `{pr["author"]}` examined this change. PR '
+                     f'#{pr["number"]} carries no approval from a second identity, so the '
+                     "segregation of duties recorded above covers who built and published these "
+                     "bytes but not who agreed to the change itself."])
     return rows
 
 
@@ -716,7 +731,7 @@ def document(evidence):
                   "recorded each one at the moment it acted."),
             ("table", ["Role", "Identity", "Recorded by"], duties),
         ]
-    if evidence["pr"] and not evidence["derived"]["self_approved"]:
+    if evidence["pr"] and evidence["derived"]["independently_approved"]:
         blocks.append(("p", "The author could not approve their own change, and neither the author "
                             "nor the reviewer authorized the publish."))
     claims = claim_rows(evidence)

--- a/.github/actions/release-evidence/release-evidence.py
+++ b/.github/actions/release-evidence/release-evidence.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Produce a release evidence document from any one published artifact.
+
+    JFROG_TOKEN=<token> ./release-evidence.py <target> [--about TEXT] [--format FORMAT]
+
+    <target>    repo/path, a full URL, sha256:HEX, or bundle:NAME/VERSION@PROJECT
+    --about     one clause describing what the thing is, used in the opening sentence
+    --format    markdown (default) | json
+
+JFrog auth comes from JFROG_TOKEN. GitHub auth comes from the gh CLI, or GITHUB_TOKEN.
+
+The document is assembled as a list of blocks, then rendered, so the shape of the
+document stays separate from how it is laid out.
+"""
+import argparse
+import base64
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+JF = os.environ.get("JF_BASE", "https://aerospike.jfrog.io")
+
+# A companion file describes a primary artifact rather than being one.
+COMPANION = (".asc", ".prov", ".sig", ".sha256", ".md5")
+# The public virtual repository for each JFrog package type.
+VIRTUAL = {"docker": "docker", "maven": "maven", "helm": "helm", "debian": "deb", "yum": "rpm",
+           "pypi": "pypi", "npm": "npm", "go": "go", "nuget": "nuget", "gems": "gems"}
+NOUN = {"docker": "container", "maven": "jar", "helm": "Helm chart", "debian": "deb package",
+        "yum": "rpm package", "pypi": "Python package", "npm": "npm package", "go": "Go module"}
+# An immutable promoted tag carries a build timestamp; the clean tag is what a consumer pulls.
+TIMESTAMPED_TAG = re.compile(r"_\d{8}T\d{6}Z")
+
+
+# ----------------------------------------------------------------- transport
+def jfrog_token():
+    tok = os.environ.get("JFROG_TOKEN") or os.environ.get("TOKEN")
+    if not tok:
+        sys.exit("set JFROG_TOKEN to a JFrog access token")
+    return tok
+
+
+def jf(path):
+    req = urllib.request.Request(f"{JF}/{path}",
+                                headers={"Authorization": f"Bearer {jfrog_token()}"})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.load(resp)
+    except (urllib.error.HTTPError, json.JSONDecodeError):
+        return None
+
+
+def aql(query):
+    req = urllib.request.Request(
+        f"{JF}/artifactory/api/search/aql", data=query.encode(), method="POST",
+        headers={"Authorization": f"Bearer {jfrog_token()}", "Content-Type": "text/plain"})
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def gh(path):
+    """GitHub REST through gh when it is installed, so its auth is reused."""
+    if shutil.which("gh"):
+        done = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+        if done.returncode != 0 or not done.stdout.strip():
+            return None
+        return json.loads(done.stdout)
+    tok = os.environ.get("GITHUB_TOKEN")
+    if not tok:
+        return None
+    req = urllib.request.Request(f"https://api.github.com/{path.lstrip('/')}",
+                                headers={"Authorization": f"Bearer {tok}"})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError:
+        return None
+
+
+def statement(envelope):
+    """The in-toto statement inside a DSSE envelope."""
+    if not envelope or "payload" not in envelope:
+        return None
+    return json.loads(base64.b64decode(envelope["payload"]))
+
+
+# ------------------------------------------------------------------- collect
+def find_release(target):
+    path = re.sub(r"^.*?/artifactory/", "", target)
+    path = re.sub(r"^api/[^/]+/", "", path)
+
+    if path.startswith("bundle:"):
+        spec = path[len("bundle:"):]
+        name_version, _, project = spec.partition("@")
+        return f"{project}-release-bundles-v2", name_version, project
+
+    if path.startswith("sha256:"):
+        sha = path[len("sha256:"):]
+    else:
+        info = jf(f"artifactory/api/storage/{path}")
+        if not info or "checksums" not in info:
+            sys.exit(f"no artifact at {path}")
+        sha = info["checksums"]["sha256"]
+
+    hits = aql(f'items.find({{"sha256":"{sha}"}}).include("repo","path")')
+    found = next((h for h in hits["results"]
+                  if h["repo"].endswith("-release-bundles-v2")), None)
+    if not found:
+        sys.exit(f"{path} is in no release bundle")
+    project = found["repo"][: -len("-release-bundles-v2")]
+    return found["repo"], "/".join(found["path"].split("/")[:2]), project
+
+
+def where_published(sha, pkg_type):
+    """The path a consumer pulls, plus every repository holding these bytes."""
+    hits = aql(f'items.find({{"sha256":"{sha}"}}).include("repo","path","name")')
+    repos = sorted({h["repo"] for h in hits["results"]})
+    public = [h for h in hits["results"] if "prod-public" in h["repo"]]
+    virtual = VIRTUAL.get(pkg_type)
+    if not public or not virtual:
+        return None, repos
+    # Prefer a clean tag over an immutable timestamped one.
+    public.sort(key=lambda h: (bool(TIMESTAMPED_TAG.search(h["path"])), len(h["path"])))
+    inner = f'{public[0]["path"]}/{public[0]["name"]}'.lstrip("/")
+    return f"{virtual}/{inner}", repos
+
+
+def build_origin(name, number, project):
+    """Commit, CI run and captured environment size, following the build-info tree."""
+    def fetch(num):
+        return jf(f"artifactory/api/build/{urllib.parse.quote(name)}/"
+                  f"{urllib.parse.quote(num)}?project={project}") or {}
+
+    info = fetch(number).get("buildInfo", {})
+    vcs = (info.get("vcs") or [None])[0]
+    run = info.get("url", "")
+    env = len(info.get("properties") or {})
+    if not vcs:
+        parent = fetch(re.sub(r"-artifacts$", "", number)).get("buildInfo", {})
+        run = run or parent.get("url", "")
+        child = next((m["id"].split("/")[-1] for m in parent.get("modules", [])
+                      if "-buildinfo-" in m.get("id", "")), None)
+        if child:
+            meta = fetch(child).get("buildInfo", {})
+            vcs = (meta.get("vcs") or [None])[0]
+            env = max(env, len(meta.get("properties") or {}))
+    return vcs, run, env
+
+
+def image_labels(bundle_repo, bundle, pkg_type, path):
+    """OCI labels, which carry a container's origin when the manifest has no build.* properties."""
+    root = f"artifactory/{bundle_repo}/{bundle}/artifacts/{pkg_type}"
+    image, directory = path.rsplit("/", 2)[0], path.rsplit("/", 1)[0]
+    manifest = jf(f"{root}/{path}")
+    if manifest and "manifests" in manifest:
+        child = next((m["digest"] for m in manifest["manifests"]
+                      if m.get("platform", {}).get("os") != "unknown"), None)
+        if not child:
+            return {}
+        directory = f"{image}/{child}"
+        manifest = jf(f"{root}/{directory}/manifest.json")
+    config = (manifest or {}).get("config", {}).get("digest")
+    if not config:
+        return {}
+    blob = jf(f"{root}/{directory}/{config.replace(':', '__')}")
+    return (blob or {}).get("config", {}).get("Labels") or {}
+
+
+def primary_artifacts(record):
+    """One entry per shipped thing: no signatures, container blobs or per-arch manifests."""
+    out = []
+    for art in record.get("artifacts", []):
+        if art["path"].endswith(COMPANION):
+            continue
+        if art["package_type"] == "docker" and not art["path"].endswith("/list.manifest.json"):
+            continue
+        out.append(art)
+    return out
+
+
+def collect(target, about):
+    bundle_repo, bundle, project = find_release(target)
+    record = jf(f"lifecycle/api/v2/release_bundle/records/{bundle}?project={project}") or {}
+    seal = statement(jf(f"artifactory/{bundle_repo}/{bundle}/release-bundle.json.evd")) or {}
+    sealed_digests = {s["digest"]["sha256"] for s in seal.get("subject", [])}
+
+    signatures = {}
+    for art in record.get("artifacts", []):
+        for ext in COMPANION:
+            if art["path"].endswith(ext):
+                signatures[ext] = signatures.get(ext, 0) + 1
+
+    promotions = []
+    listing = jf(f"artifactory/api/storage/{bundle_repo}/{bundle}") or {}
+    for child in listing.get("children", []):
+        if not child["uri"].startswith("/promotion-"):
+            continue
+        pred = (statement(jf(f"artifactory/{bundle_repo}/{bundle}{child['uri']}"))
+                or {}).get("predicate", {})
+        promotions.append({
+            "stage": pred.get("target", {}).get("environment"),
+            "when": pred.get("timestamp"),
+            "by": pred.get("createdBy"),
+            "repos": pred.get("target", {}).get("includedRepositoryKeys", []),
+            "mutable": pred.get("mutable"),
+            "seals": (pred.get("provenance") or [{}])[0].get("digest", {}).get("sha256"),
+        })
+    promotions.sort(key=lambda p: p["when"] or "")
+
+    artifacts, source = [], None
+    for art in primary_artifacts(record):
+        props = {p["key"]: p["values"][0] for p in (art.get("properties") or [])}
+        sha = art["checksum"]
+        public, repos = where_published(sha, art["package_type"])
+
+        vcs, run, env = None, "", 0
+        if props.get("build.name") and props.get("build.number"):
+            vcs, run, env = build_origin(props["build.name"], props["build.number"], project)
+
+        repo = None
+        if vcs:
+            repo = re.sub(r"\.git$", "", re.sub(r"^https://github\.com/", "", vcs.get("url", "")))
+        elif run:
+            match = re.match(r"https://github\.com/([^/]+/[^/]+)/", run)
+            repo = match.group(1) if match else None
+
+        labels = {}
+        if not repo and art["package_type"] == "docker":
+            labels = image_labels(bundle_repo, bundle, art["package_type"], art["path"])
+            repo = re.sub(r"^https://github\.com/", "",
+                          labels.get("org.opencontainers.image.source", "")) or None
+
+        attestation = None
+        if repo:
+            found = gh(f"repos/{repo}/attestations/sha256:{sha}")
+            stmt = None
+            if found and found.get("attestations"):
+                stmt = statement(found["attestations"][0]["bundle"]["dsseEnvelope"])
+            if stmt:
+                build_def = stmt["predicate"]["buildDefinition"]
+                attestation = {
+                    "predicate": stmt.get("predicateType"),
+                    "builder": re.sub(r"@([0-9a-f]{8})[0-9a-f]+$", r"@\1",
+                                      stmt["predicate"]["runDetails"]["builder"]["id"]
+                                      .rsplit("/", 1)[-1]),
+                    "buildType": build_def.get("buildType"),
+                    "runner": build_def.get("internalParameters", {})
+                                       .get("github", {}).get("runner_environment"),
+                }
+
+        commit, commit_from = None, None
+        if vcs and vcs.get("revision"):
+            commit, commit_from = vcs["revision"], "JFrog build-info"
+        elif labels.get("org.opencontainers.image.revision"):
+            commit, commit_from = labels["org.opencontainers.image.revision"], "OCI image labels"
+        elif attestation:
+            deps = stmt["predicate"]["buildDefinition"].get("resolvedDependencies") or [{}]
+            commit = deps[0].get("digest", {}).get("gitCommit")
+            commit_from = "GitHub attestation" if commit else None
+
+        # The bundle record keeps build.* even where the promoted copy does not.
+        published_linked = None
+        if public:
+            props_public = (jf(f"artifactory/api/storage/{public}?properties") or {})
+            published_linked = "build.name" in (props_public.get("properties") or {})
+
+        if commit and not source:
+            source = {"repo": repo, "commit": commit, "run": run, "env": env,
+                      "subject": (vcs or {}).get("message", "").split("\n")[0]}
+
+        artifacts.append({
+            "type": art["package_type"], "path": art["path"], "sha256": sha,
+            "public": public, "published_build_linked": published_linked, "repos": repos,
+            "build": props.get("build.name"), "number": props.get("build.number"),
+            "commit": commit, "commit_from": commit_from,
+            "sealed": sha in sealed_digests, "source_repo": repo, "attestation": attestation,
+        })
+
+    pull_request = None
+    if source and source["repo"] and source["commit"]:
+        found = gh(f'repos/{source["repo"]}/commits/{source["commit"]}/pulls') or []
+        if found:
+            head = found[0]
+            reviews = gh(f'repos/{source["repo"]}/pulls/{head["number"]}/reviews') or []
+            pull_request = {
+                "number": head["number"], "title": head["title"],
+                "author": head["user"]["login"], "merged_at": head.get("merged_at"),
+                "repo": head["base"]["repo"]["full_name"],
+                "approvers": sorted({r["user"]["login"] for r in reviews
+                                     if r.get("state") == "APPROVED"}),
+            }
+
+    types = sorted({a["type"] for a in artifacts})
+    attested = sorted({a["type"] for a in artifacts if a["attestation"]})
+    stages = [p["stage"] for p in promotions]
+    # INTERNAL and PROD are alternative terminal stages; neither implies the other is missing.
+    expected = ["DEV", "TEST", "STAGE"] if "INTERNAL" in stages else ["DEV", "TEST", "STAGE", "PROD"]
+
+    return {
+        "about": about,
+        "release": {
+            "name": bundle.split("/")[0], "version": bundle.split("/")[1], "bundle": bundle,
+            "repo": bundle_repo, "project": project, "created": record.get("created"),
+            "created_by": record.get("created_by"), "files": record.get("total_artifacts_count"),
+            "seal": {"statement": seal.get("_type"), "predicate": seal.get("predicateType"),
+                     "subjects": len(seal.get("subject", []))},
+        },
+        "signatures": signatures, "pr": pull_request, "promotions": promotions,
+        "artifacts": artifacts, "source": source,
+        "derived": {
+            "types": types, "attested_types": attested,
+            "unattested_types": [t for t in types if t not in attested],
+            "stages": stages, "terminal_stage": stages[-1] if stages else None,
+            "missing_stages": [s for s in expected if s not in stages],
+            "self_approved": bool(pull_request
+                                  and pull_request["author"] in pull_request["approvers"]),
+            "unlinked_published": sorted({a["type"] for a in artifacts
+                                          if a["public"] and a["published_build_linked"] is False}),
+            "any_commit": any(a["commit"] for a in artifacts),
+        },
+    }
+
+
+# -------------------------------------------------------------------- phrasing
+def cap(text):
+    return text[:1].upper() + text[1:] if text else text
+
+
+def phrase(items):
+    items = list(items)
+    if not items:
+        return "none"
+    if len(items) == 1:
+        return items[0]
+    return ", ".join(items[:-1]) + " and " + items[-1]
+
+
+def noun(pkg_type):
+    return NOUN.get(pkg_type, pkg_type)
+
+
+def nouns(evidence):
+    counts = {}
+    for art in evidence["artifacts"]:
+        counts[art["type"]] = counts.get(art["type"], 0) + 1
+    return phrase(f"{n} {noun(t)}s" if n > 1 else f"a {noun(t)}" for t, n in counts.items())
+
+
+def type_scope(evidence):
+    return cap(phrase(noun(t) for t in evidence["derived"]["types"]))
+
+
+def when(timestamp):
+    return (timestamp or "").replace("T", " ")[:19]
+
+
+def terminal(evidence):
+    return evidence["promotions"][-1] if evidence["promotions"] else None
+
+
+# ------------------------------------------------------------------- document
+def custody_rows(evidence):
+    release, pr, rows = evidence["release"], evidence["pr"], []
+    gated = evidence["promotions"][:-1]
+    last = terminal(evidence)
+
+    if pr:
+        commit = evidence["source"]["commit"][:8]
+        rows.append(["Peer review",
+                     f'[PR #{pr["number"]}](https://github.com/{pr["repo"]}/pull/{pr["number"]}), '
+                     f'written by `{pr["author"]}`, approved by '
+                     f'{phrase(f"`{a}`" for a in pr["approvers"])}, merged '
+                     f'{when(pr["merged_at"])} UTC as commit `{commit}`', "GitHub"])
+    if evidence["source"]:
+        src = evidence["source"]
+        rows.append(["Build from that commit",
+                     f'Build-info records `vcs.revision {src["commit"]}` and '
+                     f'[the CI run]({src["run"]}), alongside {src["env"]} captured environment '
+                     f"values", "JFrog build-info"])
+    detail = (f'including {phrase(f"{n} `{ext}` file" + ("s" if n > 1 else "") for ext, n in sorted(evidence["signatures"].items()))}'
+              if evidence["signatures"] else "each addressed by digest")
+    rows.append(["Artifacts sealed", f'{release["files"]} files, {detail}', "Stage repositories"])
+    rows.append(["Bundle sealed",
+                 f'{when(release["created"])} UTC by `{release["created_by"]}`. A DSSE envelope '
+                 f'carrying an in-toto Statement v1, naming all {release["seal"]["subjects"]} '
+                 f"files by SHA-256", "`release-bundle.json.evd`"])
+    if gated:
+        rows.append([phrase(p["stage"] for p in gated),
+                     "Promoted " + phrase(f'{when(p["when"])} UTC by `{p["by"]}`' for p in gated),
+                     f"{len(gated)} signed promotion attestations"])
+    if last:
+        rows.append([last["stage"],
+                     f'{when(last["when"])} UTC by `{last["by"]}`, targeting '
+                     f'{phrase(f"`{r}`" for r in last["repos"])}, marked '
+                     f'`mutable: {str(last["mutable"]).lower()}`', "Signed promotion attestation"])
+    return rows
+
+
+def duty_rows(evidence):
+    pr, rows = evidence["pr"], []
+    if pr:
+        rows.append(["Wrote the change", f'`{pr["author"]}`', "GitHub commit authorship"])
+        for approver in pr["approvers"]:
+            rows.append(["Approved the change", f"`{approver}`",
+                         "GitHub review, required by branch protection"])
+    rows.append(["Built and sealed", f'`{evidence["release"]["created_by"]}`',
+                 "A short-lived CI OIDC token, with no stored secret"])
+    for p in evidence["promotions"][:-1]:
+        rows.append([f'Promoted to {p["stage"]}', f'`{p["by"]}`', "Signed promotion attestation"])
+    last = terminal(evidence)
+    if last:
+        rows.append([f'Authorized the {last["stage"]} publish', f'`{last["by"]}`',
+                     f'Signed {last["stage"]} promotion attestation'])
+    return rows
+
+
+def claim_rows(evidence):
+    derived, scope, rows = evidence["derived"], type_scope(evidence), []
+    last = terminal(evidence)
+    rows.append(["These bytes are the ones a named identity authorized for release",
+                 f'The {last["stage"] if last else "terminal"} promotion attestation names the '
+                 "seal by digest, and the seal names this file by SHA-256", scope])
+    rows.append(["The contents could not change after sealing",
+                 f'A DSSE in-toto statement over all {evidence["release"]["seal"]["subjects"]} '
+                 "digests, and promotion records carrying `mutable: false`", scope])
+    rows.append(["The same bytes moved through every stage",
+                 "The identical SHA-256 is present in each stage repository and is a subject of "
+                 "the seal", scope])
+    rows.append(["Every stage transition has an identity and a timestamp",
+                 "One signed promotion attestation per stage", scope])
+    if evidence["pr"]:
+        pr = evidence["pr"]
+        rows.append(["The change was approved by someone other than its author before merge",
+                     f'PR #{pr["number"]}, approved by '
+                     f'{phrase(f"`{a}`" for a in pr["approvers"])} against author '
+                     f'`{pr["author"]}`', scope])
+    for pkg_type in derived["attested_types"]:
+        art = next(a for a in evidence["artifacts"]
+                   if a["type"] == pkg_type and a["attestation"])
+        att = art["attestation"]
+        rows.append([f'These bytes were produced by our shared CI from commit '
+                     f'`{art["commit"][:8]}`',
+                     "Sigstore-signed SLSA provenance held by GitHub, keyed to the artifact "
+                     f'digest, with `builder.id` of `{att["builder"]}` and runner '
+                     f'`{att["runner"]}`', cap(noun(pkg_type))])
+    if derived["unattested_types"] and derived["any_commit"]:
+        art = next(a for a in evidence["artifacts"] if a["commit"])
+        rows.append([f'The {phrase(noun(t) for t in derived["unattested_types"])} carry commit '
+                     f'`{art["commit"][:8]}`',
+                     "A JFrog build-info record published by the build job about itself, with no "
+                     "signature over it",
+                     cap(phrase(noun(t) for t in derived["unattested_types"]))])
+    return rows
+
+
+def gap_rows(evidence):
+    derived, rows = evidence["derived"], []
+    if not derived["any_commit"]:
+        rows.append(["A recorded source commit",
+                     "That these bytes came from a known revision. No build-info VCS block, image "
+                     "label or attestation records one, so the only pointer to source is the CI "
+                     "run URL."])
+    if derived["unattested_types"]:
+        rows.append(["An attestation step in the shared artifacts pipeline",
+                     f'That the {phrase(noun(t) for t in derived["unattested_types"])} were '
+                     "produced by our shared CI from a given commit, signed by the build platform "
+                     "rather than recorded by the build."])
+    if derived["attested_types"]:
+        rows.append(["An evidence precondition at the customer-facing gates",
+                     "That nothing reaches customers without valid provenance. Today the gate "
+                     "requires a named approver and nothing about the artifact, so no check "
+                     f'consumes the attestation the '
+                     f'{phrase(noun(t) for t in derived["attested_types"])} already has.'])
+    if derived["unlinked_published"]:
+        rows.append(["Build properties preserved on promotion",
+                     f'That a {phrase(noun(t) for t in derived["unlinked_published"])} found in a '
+                     "public repository can be joined to its build by one query. The bundle record "
+                     "keeps `build.name` and `build.number`, but the promoted copy carries only "
+                     "registry metadata, so a consumer starting from the registry has to fall back "
+                     "to OCI labels."])
+    if derived["missing_stages"]:
+        rows.append([f'A recorded {phrase(derived["missing_stages"])} transition',
+                     f'That the bundle entered {phrase(derived["missing_stages"])}. This bundle '
+                     f'records only {phrase(derived["stages"])}.'])
+    return rows
+
+
+def document(evidence):
+    """The document as blocks, so markdown and Confluence cannot drift apart."""
+    release, last = evidence["release"], terminal(evidence)
+    ui = (f'{JF}/ui/artifactory/release-lifecycle/{release["name"]}/{release["version"]}'
+          f'?repoKey={release["repo"]}')
+    blocks = [
+        ("panel", "info",
+         f'{release["name"]} {release["version"]} shipped as {nouns(evidence)} from a single '
+         "commit. Because they share one commit, one release bundle and one set of approvals, the "
+         "evidence differs only where the pipeline differs."),
+        ("h2", "The release"),
+        ("p", f'[{release["name"]} {release["version"]}]({ui})'
+              + (f', {evidence["about"]}' if evidence["about"] else "")
+              + f". One commit produced {nouns(evidence)}, and every step of that path left a "
+                "signed record."),
+        ("h2", "Release chain of custody"),
+        ("table", ["Step", "What the record says", "Where it lives"], custody_rows(evidence)),
+        ("h2", "Why the chain holds"),
+        ("p", "Each link is bound to the previous one by a value that cannot be edited after the "
+              f'fact. The seal names all {release["seal"]["subjects"]} files by SHA-256, so any '
+              "change to any file breaks the signature. The "
+              f'{last["stage"] if last else "terminal"} attestation names the seal by its own '
+              "digest, and covers every artifact in one action:"),
+    ]
+    if last:
+        indent = "\n" + " " * 18
+        blocks.append(("code",
+                       f'provenance: /{release["repo"]}/{release["bundle"]}/release-bundle.json.evd\n'
+                       f'            sha256 {last["seals"]}\n'
+                       f'createdBy:  {last["by"]}\n'
+                       f'target:     {last["stage"]}, {indent.join(last["repos"])}\n'
+                       f'mutable:    {str(last["mutable"]).lower()}'))
+    reached = ("a public repository" if last and any("prod-public" in r for r in last["repos"])
+               else f'the {last["stage"].lower() if last else "internal"} registry')
+    blocks += [
+        ("p", f"An auditor can therefore start at any of these artifacts in {reached} and walk "
+              "back to the pull request that authorized it, checking a hash at every hop."),
+        ("h2", "Segregation of duties, as recorded"),
+        ("p", f'{len({r[1] for r in duty_rows(evidence)})} identities appear in this release, and '
+              "the system recorded each one at the moment it acted."),
+        ("table", ["Role", "Identity", "Recorded by"], duty_rows(evidence)),
+    ]
+    if evidence["pr"] and not evidence["derived"]["self_approved"]:
+        blocks.append(("p", "The author could not approve their own change, and neither the author "
+                            "nor the reviewer authorized the publish."))
+    blocks += [
+        ("h2", "What the evidence proves"),
+        ("p", "Each row is a claim an auditor might make about this release, the record that backs "
+              "it, and which of the artifacts it holds for."),
+        ("table", ["Claim", "Backed by", "Holds for"], claim_rows(evidence)),
+        ("h2", "Verify it yourself"),
+        ("p", "One command per artifact, against the public virtual repositories a customer "
+              "downloads from. Reading the build, seal and promotion records needs an account with "
+              f'read access to the `{release["project"]}` project, and the review and provenance '
+              "steps need the GitHub CLI."),
+        ("code", 'export JFROG_TOKEN="<a JFrog access token>"\n\n'
+                 + "\n".join(f'./verify-artifact.sh {a["public"] or a["path"]}'
+                             for a in evidence["artifacts"]), "bash"),
+    ]
+    gaps = gap_rows(evidence)
+    if gaps:
+        blocks += [
+            ("h2", "What we could prove with more evidence"),
+            ("table", ["Addition", "Claim it would let us make"], gaps),
+        ]
+    return blocks
+
+
+# -------------------------------------------------------------------- render
+def render_markdown(evidence, blocks):
+    release = evidence["release"]
+    out = [f'# {release["name"]} {release["version"]}: release evidence', ""]
+    for block in blocks:
+        kind = block[0]
+        if kind == "h2":
+            out += [f"## {block[1]}", ""]
+        elif kind in ("p", "panel"):
+            out += [block[-1], ""]
+        elif kind == "code":
+            lang = block[2] if len(block) > 2 else ""
+            out += [f"```{lang}", block[1], "```", ""]
+        elif kind == "table":
+            _, headers, rows = block
+            out.append("| " + " | ".join(headers) + " |")
+            out.append("|" + "|".join(" --- " for _ in headers) + "|")
+            out += ["| " + " | ".join(r) + " |" for r in rows]
+            out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("target")
+    parser.add_argument("--about", default="")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    args = parser.parse_args()
+
+    evidence = collect(args.target, args.about)
+    if args.format == "json":
+        print(json.dumps(evidence, indent=2))
+    else:
+        print(render_markdown(evidence, document(evidence)), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/release-evidence/release-evidence.py
+++ b/.github/actions/release-evidence/release-evidence.py
@@ -35,6 +35,16 @@ NOUN = {"docker": "container", "maven": "jar", "helm": "Helm chart", "debian": "
         "yum": "rpm package", "pypi": "Python package", "npm": "npm package", "go": "Go module"}
 # An immutable promoted tag carries a build timestamp; the clean tag is what a consumer pulls.
 TIMESTAMPED_TAG = re.compile(r"_\d{8}T\d{6}Z")
+# Promotion stages in maturity order. INTERNAL and PROD are alternative terminal stages, so
+# neither implies the other is missing.
+STAGE_ORDER = ["DEV", "TEST", "STAGE", "PREVIEW", "PROD"]
+# The environment segment of a repository key names the stage its contents have reached, which
+# is how an artifact that was never sealed into a bundle can still be placed in the pipeline.
+REPO_ENV_STAGE = {"dev": "DEV", "test": "TEST", "stage": "STAGE",
+                  "preview-public": "PREVIEW", "preview-restricted": "PREVIEW",
+                  "prod-internal": "INTERNAL", "prod-public": "PROD"}
+# The type segment of a repository key, mapped to the package_type a bundle record would use.
+REPO_TYPE_PACKAGE = {"deb": "debian", "rpm": "yum", "container": "docker", "cargo": "cargo"}
 
 
 # ----------------------------------------------------------------- transport
@@ -90,30 +100,94 @@ def statement(envelope):
 
 
 # ------------------------------------------------------------------- collect
-def find_release(target):
+def normalize(target):
     path = re.sub(r"^.*?/artifactory/", "", target)
-    path = re.sub(r"^api/[^/]+/", "", path)
+    return re.sub(r"^api/[^/]+/", "", path)
+
+
+def stage_of_repo(repo):
+    """The promotion stage a repository key represents, or None if it names no stage."""
+    base = repo[: -len("-local")] if repo.endswith("-local") else repo
+    # Longest first, so prod-public is not mistaken for a repo merely ending in a shorter token.
+    for env in sorted(REPO_ENV_STAGE, key=len, reverse=True):
+        if base.endswith(f"-{env}"):
+            return REPO_ENV_STAGE[env]
+    return None
+
+
+def resolve_sha(path):
+    """The digest for a target, whether it was given as a path or already as a digest."""
+    if path.startswith("sha256:"):
+        return path[len("sha256:"):]
+    info = jf(f"artifactory/api/storage/{path}")
+    if not info or "checksums" not in info:
+        sys.exit(f"no artifact at {path}")
+    return info["checksums"]["sha256"]
+
+
+def find_release(target):
+    """The release bundle holding a target, or None when it has not been sealed into one.
+
+    An artifact in DEV has usually not been bundled yet, which is a stage in its life rather
+    than an error, so the caller reports on the artifact alone instead of giving up.
+    """
+    path = normalize(target)
 
     if path.startswith("bundle:"):
         spec = path[len("bundle:"):]
         name_version, _, project = spec.partition("@")
         return f"{project}-release-bundles-v2", name_version, project
 
-    if path.startswith("sha256:"):
-        sha = path[len("sha256:"):]
-    else:
-        info = jf(f"artifactory/api/storage/{path}")
-        if not info or "checksums" not in info:
-            sys.exit(f"no artifact at {path}")
-        sha = info["checksums"]["sha256"]
-
+    sha = resolve_sha(path)
     hits = aql(f'items.find({{"sha256":"{sha}"}}).include("repo","path")')
     found = next((h for h in hits["results"]
                   if h["repo"].endswith("-release-bundles-v2")), None)
     if not found:
-        sys.exit(f"{path} is in no release bundle")
+        return None
     project = found["repo"][: -len("-release-bundles-v2")]
     return found["repo"], "/".join(found["path"].split("/")[:2]), project
+
+
+def package_type_of_repo(repo):
+    """The package_type a bundle record would use, read from the repository key's type segment."""
+    base = repo[: -len("-local")] if repo.endswith("-local") else repo
+    for env in sorted(REPO_ENV_STAGE, key=len, reverse=True):
+        if base.endswith(f"-{env}"):
+            base = base[: -len(f"-{env}")]
+            break
+    segment = base.rsplit("-", 1)[-1]
+    return REPO_TYPE_PACKAGE.get(segment, segment)
+
+
+def unbundled_artifact(target):
+    """One artifact, shaped like an entry in a bundle record.
+
+    Returns the entry and the repository it was read from, so an artifact that no bundle
+    holds walks the same path below as one that a bundle does.
+    """
+    path = normalize(target)
+    sha = resolve_sha(path)
+
+    if path.startswith("sha256:"):
+        hits = aql(f'items.find({{"sha256":"{sha}"}}).include("repo","path","name")')
+        found = next((h for h in (hits.get("results") or [])
+                      if not h["repo"].endswith("-release-bundles-v2")), None)
+        if not found:
+            sys.exit(f"no artifact with digest {sha}")
+        repo = found["repo"]
+        inner = f'{found["path"]}/{found["name"]}'.lstrip("./")
+    else:
+        repo, _, inner = path.partition("/")
+
+    props = (jf(f"artifactory/api/storage/{repo}/{inner}?properties") or {}).get("properties", {})
+    return {
+        "package_type": package_type_of_repo(repo),
+        # Repository-qualified, so the verify command printed at the end of the document is
+        # one a reader can paste. A bundled artifact's path is relative to the bundle instead.
+        "path": f"{repo}/{inner}",
+        "checksum": sha,
+        "properties": [{"key": k, "values": v} for k, v in props.items()],
+    }, repo
 
 
 def where_published(sha, pkg_type):
@@ -152,9 +226,8 @@ def build_origin(name, number, project):
     return vcs, run, env
 
 
-def image_labels(bundle_repo, bundle, pkg_type, path):
+def image_labels(root, path):
     """OCI labels, which carry a container's origin when the manifest has no build.* properties."""
-    root = f"artifactory/{bundle_repo}/{bundle}/artifacts/{pkg_type}"
     image, directory = path.rsplit("/", 2)[0], path.rsplit("/", 1)[0]
     manifest = jf(f"{root}/{path}")
     if manifest and "manifests" in manifest:
@@ -184,10 +257,26 @@ def primary_artifacts(record):
 
 
 def collect(target, about):
-    bundle_repo, bundle, project = find_release(target)
-    record = jf(f"lifecycle/api/v2/release_bundle/records/{bundle}?project={project}") or {}
-    seal = statement(jf(f"artifactory/{bundle_repo}/{bundle}/release-bundle.json.evd")) or {}
-    sealed_digests = {s["digest"]["sha256"] for s in seal.get("subject", [])}
+    release_ref = find_release(target)
+    labels_root = None
+
+    if release_ref:
+        bundle_repo, bundle, project = release_ref
+        record = jf(f"lifecycle/api/v2/release_bundle/records/{bundle}?project={project}") or {}
+        seal = statement(jf(f"artifactory/{bundle_repo}/{bundle}/release-bundle.json.evd")) or {}
+        sealed_digests = {s["digest"]["sha256"] for s in seal.get("subject", [])}
+        entries = primary_artifacts(record)
+    else:
+        # No bundle holds this artifact, which is where everything sits before the first
+        # promotion. Report the artifact on its own rather than refusing, and let the absent
+        # records show up as absent.
+        entry, origin_repo = unbundled_artifact(target)
+        bundle_repo, bundle = None, None
+        project = origin_repo.split("-")[0]
+        record, seal, sealed_digests = {}, {}, set()
+        entries = [entry]
+        # The entry's path already carries its repository, unlike a bundled one.
+        labels_root = "artifactory"
 
     signatures = {}
     for art in record.get("artifacts", []):
@@ -196,24 +285,28 @@ def collect(target, about):
                 signatures[ext] = signatures.get(ext, 0) + 1
 
     promotions = []
-    listing = jf(f"artifactory/api/storage/{bundle_repo}/{bundle}") or {}
-    for child in listing.get("children", []):
-        if not child["uri"].startswith("/promotion-"):
-            continue
-        pred = (statement(jf(f"artifactory/{bundle_repo}/{bundle}{child['uri']}"))
-                or {}).get("predicate", {})
-        promotions.append({
-            "stage": pred.get("target", {}).get("environment"),
-            "when": pred.get("timestamp"),
-            "by": pred.get("createdBy"),
-            "repos": pred.get("target", {}).get("includedRepositoryKeys", []),
-            "mutable": pred.get("mutable"),
-            "seals": (pred.get("provenance") or [{}])[0].get("digest", {}).get("sha256"),
-        })
-    promotions.sort(key=lambda p: p["when"] or "")
+    if release_ref:
+        listing = jf(f"artifactory/api/storage/{bundle_repo}/{bundle}") or {}
+        for child in listing.get("children", []):
+            if not child["uri"].startswith("/promotion-"):
+                continue
+            pred = (statement(jf(f"artifactory/{bundle_repo}/{bundle}{child['uri']}"))
+                    or {}).get("predicate", {})
+            promotions.append({
+                # An attestation we cannot read or attribute is still a promotion that
+                # happened. Naming it UNKNOWN keeps it visible without letting it count as
+                # a stage reached, which dropping it silently would not.
+                "stage": pred.get("target", {}).get("environment") or "UNKNOWN",
+                "when": pred.get("timestamp"),
+                "by": pred.get("createdBy"),
+                "repos": pred.get("target", {}).get("includedRepositoryKeys", []),
+                "mutable": pred.get("mutable"),
+                "seals": (pred.get("provenance") or [{}])[0].get("digest", {}).get("sha256"),
+            })
+        promotions.sort(key=lambda p: p["when"] or "")
 
     artifacts, source = [], None
-    for art in primary_artifacts(record):
+    for art in entries:
         props = {p["key"]: p["values"][0] for p in (art.get("properties") or [])}
         sha = art["checksum"]
         public, repos = where_published(sha, art["package_type"])
@@ -231,7 +324,9 @@ def collect(target, about):
 
         labels = {}
         if not repo and art["package_type"] == "docker":
-            labels = image_labels(bundle_repo, bundle, art["package_type"], art["path"])
+            root = labels_root or (f"artifactory/{bundle_repo}/{bundle}/artifacts/"
+                                   f'{art["package_type"]}')
+            labels = image_labels(root, art["path"])
             repo = re.sub(r"^https://github\.com/", "",
                           labels.get("org.opencontainers.image.source", "")) or None
 
@@ -298,25 +393,44 @@ def collect(target, about):
     types = sorted({a["type"] for a in artifacts})
     attested = sorted({a["type"] for a in artifacts if a["attestation"]})
     stages = [p["stage"] for p in promotions]
-    # INTERNAL and PROD are alternative terminal stages; neither implies the other is missing.
-    expected = ["DEV", "TEST", "STAGE"] if "INTERNAL" in stages else ["DEV", "TEST", "STAGE", "PROD"]
+
+    # Where the bytes sit is a second, independent reading of maturity, and the only one
+    # available before a bundle exists. A promotion record is the stronger claim; repository
+    # residence still places the artifact in the pipeline.
+    resident = sorted({stage_of_repo(r) for a in artifacts for r in a["repos"]} - {None},
+                      key=lambda s: STAGE_ORDER.index(s) if s in STAGE_ORDER else len(STAGE_ORDER))
+    reached = [s for s in STAGE_ORDER if s in set(stages) | set(resident)]
+    if "INTERNAL" in stages or "INTERNAL" in resident:
+        reached.append("INTERNAL")
+
+    # INTERNAL and PROD are alternative terminal stages, so neither implies the other is due.
+    expected = STAGE_ORDER[:-1] if "INTERNAL" in reached else STAGE_ORDER
+    furthest = max((expected.index(s) for s in reached if s in expected), default=-1)
 
     return {
         "about": about,
+        "project": project,
         "release": {
             "name": bundle.split("/")[0], "version": bundle.split("/")[1], "bundle": bundle,
             "repo": bundle_repo, "project": project, "created": record.get("created"),
             "created_by": record.get("created_by"), "files": record.get("total_artifacts_count"),
             "seal": {"statement": seal.get("_type"), "predicate": seal.get("predicateType"),
                      "subjects": len(seal.get("subject", []))},
-        },
+        } if release_ref else None,
         "signatures": signatures, "pr": pull_request, "promotions": promotions,
         "artifacts": artifacts, "source": source,
         "derived": {
             "types": types, "attested_types": attested,
             "unattested_types": [t for t in types if t not in attested],
             "stages": stages, "terminal_stage": stages[-1] if stages else None,
-            "missing_stages": [s for s in expected if s not in stages],
+            "sealed": bool(release_ref),
+            # Where the artifact has got to, however it got there.
+            "stages_reached": reached,
+            "resident_stages": resident,
+            # Absent below the furthest point reached, so a gate was passed over. An anomaly.
+            "skipped_stages": [s for s in expected[:furthest + 1] if s not in reached],
+            # Absent above it, so simply not promoted there yet. Expected, not an anomaly.
+            "pending_stages": [s for s in expected[furthest + 1:]],
             "self_approved": bool(pull_request
                                   and pull_request["author"] in pull_request["approvers"]),
             "unlinked_published": sorted({a["type"] for a in artifacts
@@ -382,13 +496,18 @@ def custody_rows(evidence):
                      f'Build-info records `vcs.revision {src["commit"]}` and '
                      f'[the CI run]({src["run"]}), alongside {src["env"]} captured environment '
                      f"values", "JFrog build-info"])
-    detail = (f'including {phrase(f"{n} `{ext}` file" + ("s" if n > 1 else "") for ext, n in sorted(evidence["signatures"].items()))}'
-              if evidence["signatures"] else "each addressed by digest")
-    rows.append(["Artifacts sealed", f'{release["files"]} files, {detail}', "Stage repositories"])
-    rows.append(["Bundle sealed",
-                 f'{when(release["created"])} UTC by `{release["created_by"]}`. A DSSE envelope '
-                 f'carrying an in-toto Statement v1, naming all {release["seal"]["subjects"]} '
-                 f"files by SHA-256", "`release-bundle.json.evd`"])
+    if release:
+        detail = (f'including {phrase(f"{n} `{ext}` file" + ("s" if n > 1 else "") for ext, n in sorted(evidence["signatures"].items()))}'
+                  if evidence["signatures"] else "each addressed by digest")
+        rows.append(["Artifacts sealed", f'{release["files"]} files, {detail}',
+                     "Stage repositories"])
+        rows.append(["Bundle sealed",
+                     f'{when(release["created"])} UTC by `{release["created_by"]}`. A DSSE envelope '
+                     f'carrying an in-toto Statement v1, naming all {release["seal"]["subjects"]} '
+                     f"files by SHA-256", "`release-bundle.json.evd`"])
+    else:
+        rows.append(["Artifacts sealed", "No release bundle holds these bytes yet, so nothing "
+                     "binds them together or fixes their contents", "Not yet recorded"])
     if gated:
         rows.append([phrase(p["stage"] for p in gated),
                      "Promoted " + phrase(f'{when(p["when"])} UTC by `{p["by"]}`' for p in gated),
@@ -408,8 +527,9 @@ def duty_rows(evidence):
         for approver in pr["approvers"]:
             rows.append(["Approved the change", f"`{approver}`",
                          "GitHub review, required by branch protection"])
-    rows.append(["Built and sealed", f'`{evidence["release"]["created_by"]}`',
-                 "A short-lived CI OIDC token, with no stored secret"])
+    if evidence["release"]:
+        rows.append(["Built and sealed", f'`{evidence["release"]["created_by"]}`',
+                     "A short-lived CI OIDC token, with no stored secret"])
     for p in evidence["promotions"][:-1]:
         rows.append([f'Promoted to {p["stage"]}', f'`{p["by"]}`', "Signed promotion attestation"])
     last = terminal(evidence)
@@ -422,17 +542,23 @@ def duty_rows(evidence):
 def claim_rows(evidence):
     derived, scope, rows = evidence["derived"], type_scope(evidence), []
     last = terminal(evidence)
-    rows.append(["These bytes are the ones a named identity authorized for release",
-                 f'The {last["stage"] if last else "terminal"} promotion attestation names the '
-                 "seal by digest, and the seal names this file by SHA-256", scope])
-    rows.append(["The contents could not change after sealing",
-                 f'A DSSE in-toto statement over all {evidence["release"]["seal"]["subjects"]} '
-                 "digests, and promotion records carrying `mutable: false`", scope])
-    rows.append(["The same bytes moved through every stage",
-                 "The identical SHA-256 is present in each stage repository and is a subject of "
-                 "the seal", scope])
-    rows.append(["Every stage transition has an identity and a timestamp",
-                 "One signed promotion attestation per stage", scope])
+    # Only claims with a record behind them belong here. An artifact that has not been sealed
+    # or promoted supports none of the custody claims, and saying otherwise would be the one
+    # failure this document cannot afford.
+    if last:
+        rows.append(["These bytes are the ones a named identity authorized for release",
+                     f'The {last["stage"]} promotion attestation names the seal by digest, and '
+                     "the seal names this file by SHA-256", scope])
+    if evidence["release"]:
+        rows.append(["The contents could not change after sealing",
+                     f'A DSSE in-toto statement over all {evidence["release"]["seal"]["subjects"]} '
+                     "digests, and promotion records carrying `mutable: false`", scope])
+    if evidence["promotions"]:
+        rows.append(["The same bytes moved through every stage reached so far",
+                     "The identical SHA-256 is present in each stage repository and is a subject "
+                     "of the seal", scope])
+        rows.append(["Every stage transition so far has an identity and a timestamp",
+                     "One signed promotion attestation per stage", scope])
     if evidence["pr"]:
         pr = evidence["pr"]
         rows.append(["The change was approved by someone other than its author before merge",
@@ -467,9 +593,9 @@ def gap_rows(evidence):
                      "run URL."])
     if derived["unattested_types"]:
         rows.append(["An attestation step in the shared artifacts pipeline",
-                     f'That the {phrase(noun(t) for t in derived["unattested_types"])} were '
-                     "produced by our shared CI from a given commit, signed by the build platform "
-                     "rather than recorded by the build."])
+                     "That our shared CI produced the "
+                     f'{phrase(noun(t) for t in derived["unattested_types"])} from a given commit, '
+                     "signed by the build platform rather than recorded by the build."])
     if derived["attested_types"]:
         rows.append(["An evidence precondition at the customer-facing gates",
                      "That nothing reaches customers without valid provenance. Today the gate "
@@ -483,37 +609,87 @@ def gap_rows(evidence):
                      "keeps `build.name` and `build.number`, but the promoted copy carries only "
                      "registry metadata, so a consumer starting from the registry has to fall back "
                      "to OCI labels."])
-    if derived["missing_stages"]:
-        rows.append([f'A recorded {phrase(derived["missing_stages"])} transition',
-                     f'That the bundle entered {phrase(derived["missing_stages"])}. This bundle '
-                     f'records only {phrase(derived["stages"])}.'])
+    if not derived["sealed"]:
+        rows.append(["A release bundle holding these bytes",
+                     "That these bytes are fixed and travel as a unit. Nothing has been sealed "
+                     "yet, so there is no seal to name them and no promotion record can refer "
+                     "to them. Every custody claim below depends on this one."])
+    if derived["skipped_stages"]:
+        rows.append([f'A recorded {phrase(derived["skipped_stages"])} transition',
+                     f'That this passed through {phrase(derived["skipped_stages"])}. It has '
+                     f'reached {phrase(derived["stages_reached"])}, so those gates were passed '
+                     "over rather than not yet reached."])
     return rows
+
+
+def subject(evidence):
+    """What this document is about: a release when there is one, otherwise the artifact."""
+    release = evidence["release"]
+    if release:
+        return f'{release["name"]} {release["version"]}'
+    art = evidence["artifacts"][0]
+    return art["path"].rsplit("/", 1)[-1]
+
+
+def position_blocks(evidence):
+    """Where this has got to, stated before any claim that depends on having got there."""
+    derived = evidence["derived"]
+    reached = phrase(derived["stages_reached"]) if derived["stages_reached"] else "no stage"
+    text = f"This has reached {reached}."
+    if derived["pending_stages"]:
+        text += (f' It has not been promoted to {phrase(derived["pending_stages"])} yet, so the '
+                 "records those stages would produce do not exist and are not counted against it.")
+    if derived["skipped_stages"]:
+        text += (f' No promotion record exists for {phrase(derived["skipped_stages"])}, which sits '
+                 "below where it has got to. That is a gap rather than work still to come.")
+    if not derived["sealed"]:
+        text += (" Nothing has been sealed into a release bundle, so the custody claims below are "
+                 "limited to what the build itself recorded.")
+    return [("h2", "Where this is"), ("p", text)]
 
 
 def document(evidence):
     """The document as blocks, so markdown and Confluence cannot drift apart."""
     release, last = evidence["release"], terminal(evidence)
-    ui = (f'{JF}/ui/artifactory/release-lifecycle/{release["name"]}/{release["version"]}'
-          f'?repoKey={release["repo"]}')
-    blocks = [
-        ("panel", "info",
-         f'{release["name"]} {release["version"]} shipped as {nouns(evidence)} from a single '
-         "commit. Because they share one commit, one release bundle and one set of approvals, the "
-         "evidence differs only where the pipeline differs."),
-        ("h2", "The release"),
-        ("p", f'[{release["name"]} {release["version"]}]({ui})'
-              + (f', {evidence["about"]}' if evidence["about"] else "")
-              + f". One commit produced {nouns(evidence)}, and every step of that path left a "
-                "signed record."),
-        ("h2", "Release chain of custody"),
+    if release:
+        ui = (f'{JF}/ui/artifactory/release-lifecycle/{release["name"]}/{release["version"]}'
+              f'?repoKey={release["repo"]}')
+        blocks = [
+            ("panel", "info",
+             f'{release["name"]} {release["version"]} shipped as {nouns(evidence)} from a single '
+             "commit. Because they share one commit, one release bundle and one set of approvals, "
+             "the evidence differs only where the pipeline differs."),
+            ("h2", "The release"),
+            ("p", f'[{release["name"]} {release["version"]}]({ui})'
+                  + (f', {evidence["about"]}' if evidence["about"] else "")
+                  + f". One commit produced {nouns(evidence)}, and every step of that path left a "
+                    "signed record."),
+        ]
+    else:
+        blocks = [
+            ("panel", "info",
+             f"{subject(evidence)} has not been sealed into a release bundle. What follows is "
+             "what the build recorded about it, and what is absent because it has not travelled "
+             "far enough to produce it."),
+            ("h2", "The artifact"),
+            ("p", f"`{evidence['artifacts'][0]['path']}` in the "
+                  f"`{evidence['project']}` project"
+                  + (f', {evidence["about"]}' if evidence["about"] else "") + "."),
+        ]
+    blocks += position_blocks(evidence)
+    blocks += [
+        ("h2", "Chain of custody"),
         ("table", ["Step", "What the record says", "Where it lives"], custody_rows(evidence)),
-        ("h2", "Why the chain holds"),
-        ("p", "Each link is bound to the previous one by a value that cannot be edited after the "
-              f'fact. The seal names all {release["seal"]["subjects"]} files by SHA-256, so any '
-              "change to any file breaks the signature. The "
-              f'{last["stage"] if last else "terminal"} attestation names the seal by its own '
-              "digest, and covers every artifact in one action:"),
     ]
+    if release:
+        blocks += [
+            ("h2", "Why the chain holds"),
+            ("p", "Each link is bound to the previous one by a value that cannot be edited after "
+                  f'the fact. The seal names all {release["seal"]["subjects"]} files by SHA-256, '
+                  "so any change to any file breaks the signature. The "
+                  f'{last["stage"] if last else "terminal"} attestation names the seal by its own '
+                  "digest, and covers every artifact in one action:"),
+        ]
     if last:
         indent = "\n" + " " * 18
         blocks.append(("code",
@@ -522,29 +698,43 @@ def document(evidence):
                        f'createdBy:  {last["by"]}\n'
                        f'target:     {last["stage"]}, {indent.join(last["repos"])}\n'
                        f'mutable:    {str(last["mutable"]).lower()}'))
-    reached = ("a public repository" if last and any("prod-public" in r for r in last["repos"])
-               else f'the {last["stage"].lower() if last else "internal"} registry')
-    blocks += [
-        ("p", f"An auditor can therefore start at any of these artifacts in {reached} and walk "
-              "back to the pull request that authorized it, checking a hash at every hop."),
-        ("h2", "Segregation of duties, as recorded"),
-        ("p", f'{len({r[1] for r in duty_rows(evidence)})} identities appear in this release, and '
-              "the system recorded each one at the moment it acted."),
-        ("table", ["Role", "Identity", "Recorded by"], duty_rows(evidence)),
-    ]
+    if last and last["stage"] != "UNKNOWN":
+        where = ("a public repository" if any("prod-public" in r for r in last["repos"])
+                 else f'the {last["stage"].lower()} registry')
+        blocks.append(("p", f"An auditor can therefore start at any of these artifacts in {where} "
+                            "and walk back to the pull request that authorized it, checking a hash "
+                            "at every hop."))
+    duties = duty_rows(evidence)
+    if duties:
+        blocks += [
+            ("h2", "Segregation of duties, as recorded"),
+            ("p", f'{len({r[1] for r in duties})} identities appear so far, and the system '
+                  "recorded each one at the moment it acted."),
+            ("table", ["Role", "Identity", "Recorded by"], duties),
+        ]
     if evidence["pr"] and not evidence["derived"]["self_approved"]:
         blocks.append(("p", "The author could not approve their own change, and neither the author "
                             "nor the reviewer authorized the publish."))
+    claims = claim_rows(evidence)
+    if claims:
+        blocks += [
+            ("h2", "What the evidence proves"),
+            ("p", "Each row is a claim an auditor might make, the record that backs it, and which "
+                  "of the artifacts it holds for."),
+            ("table", ["Claim", "Backed by", "Holds for"], claims),
+        ]
+    else:
+        blocks += [
+            ("h2", "What the evidence proves"),
+            ("p", "Nothing yet beyond what the build recorded about itself. Every custody claim "
+                  "needs a seal or a promotion record, and neither exists for this artifact."),
+        ]
     blocks += [
-        ("h2", "What the evidence proves"),
-        ("p", "Each row is a claim an auditor might make about this release, the record that backs "
-              "it, and which of the artifacts it holds for."),
-        ("table", ["Claim", "Backed by", "Holds for"], claim_rows(evidence)),
         ("h2", "Verify it yourself"),
-        ("p", "One command per artifact, against the public virtual repositories a customer "
-              "downloads from. Reading the build, seal and promotion records needs an account with "
-              f'read access to the `{release["project"]}` project, and the review and provenance '
-              "steps need the GitHub CLI."),
+        ("p", "One command per artifact, against the most public location each one has reached. "
+              "Reading the build, seal and promotion records needs an account with read access to "
+              f'the `{evidence["project"]}` project, and the review and provenance steps need the '
+              "GitHub CLI."),
         ("code", 'export JFROG_TOKEN="<a JFrog access token>"\n\n'
                  + "\n".join(f'./verify-artifact.sh {a["public"] or a["path"]}'
                              for a in evidence["artifacts"]), "bash"),
@@ -560,8 +750,8 @@ def document(evidence):
 
 # -------------------------------------------------------------------- render
 def render_markdown(evidence, blocks):
-    release = evidence["release"]
-    out = [f'# {release["name"]} {release["version"]}: release evidence', ""]
+    kind = "release evidence" if evidence["release"] else "artifact evidence"
+    out = [f"# {subject(evidence)}: {kind}", ""]
     for block in blocks:
         kind = block[0]
         if kind == "h2":

--- a/.github/actions/release-evidence/tests/test_release_evidence.py
+++ b/.github/actions/release-evidence/tests/test_release_evidence.py
@@ -142,6 +142,40 @@ class ClaimsRequireRecords(unittest.TestCase):
         rows = rev.claim_rows(self.evidence(None, [], False))
         self.assertEqual(rows, [])
 
+    def pr_evidence(self, approvers, merged_at):
+        ev = self.evidence(None, [], False)
+        ev["pr"] = {"number": 7, "title": "t", "author": "writer", "merged_at": merged_at,
+                    "repo": "aerospike/shared-workflows", "approvers": approvers}
+        ev["source"] = {"repo": "aerospike/shared-workflows", "commit": "abcdef1234567890",
+                        "run": "https://github.com/aerospike/shared-workflows/actions/runs/1",
+                        "env": 12}
+        return ev
+
+    def test_an_unapproved_pr_makes_no_approval_claim(self):
+        rows = rev.claim_rows(self.pr_evidence([], None))
+        self.assertEqual([r for r in rows if "approved by someone" in r[0]], [])
+
+    def test_a_pr_approved_only_by_its_author_makes_no_approval_claim(self):
+        rows = rev.claim_rows(self.pr_evidence(["writer"], "2026-01-01T00:00:00Z"))
+        self.assertEqual([r for r in rows if "approved by someone" in r[0]], [])
+
+    def test_an_independently_approved_merged_pr_makes_the_claim(self):
+        rows = rev.claim_rows(self.pr_evidence(["reviewer"], "2026-01-01T00:00:00Z"))
+        self.assertEqual(len([r for r in rows if "approved by someone" in r[0]]), 1)
+
+    def test_an_open_pr_is_described_as_open_rather_than_merged_at_no_date(self):
+        rows = rev.custody_rows(self.pr_evidence([], None))
+        review = next(r[1] for r in rows if r[0] == "Peer review")
+        self.assertIn("not approved", review)
+        self.assertIn("still open", review)
+        self.assertNotIn("merged  UTC", review)
+
+    def test_a_merged_pr_still_reports_its_merge_time(self):
+        rows = rev.custody_rows(self.pr_evidence(["reviewer"], "2026-01-01T00:00:00Z"))
+        review = next(r[1] for r in rows if r[0] == "Peer review")
+        self.assertIn("approved by `reviewer`", review)
+        self.assertIn("merged 2026-01-01 00:00:00 UTC", review)
+
     def test_an_unsealed_artifact_names_the_missing_bundle_as_the_root_gap(self):
         rows = rev.gap_rows(self.evidence(None, [], False))
         self.assertIn("A release bundle holding these bytes", [r[0] for r in rows])

--- a/.github/actions/release-evidence/tests/test_release_evidence.py
+++ b/.github/actions/release-evidence/tests/test_release_evidence.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Unit tests for release-evidence.py.
+
+Run: python3 -m unittest discover -s .github/actions/release-evidence/tests
+
+Transport is stubbed, so these cover the parts that decide what a document claims: where an
+artifact sits in the pipeline, whether a gap is a skipped gate or work still to come, and
+whether a claim has a record behind it.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "release-evidence.py"
+spec = importlib.util.spec_from_file_location("release_evidence", SCRIPT)
+rev = importlib.util.module_from_spec(spec)
+sys.modules["release_evidence"] = rev
+spec.loader.exec_module(rev)
+
+
+class StageOfRepo(unittest.TestCase):
+    def test_reads_the_stage_from_the_environment_segment(self):
+        self.assertEqual(rev.stage_of_repo("clients-pypi-dev-local"), "DEV")
+        self.assertEqual(rev.stage_of_repo("database-deb-test-local"), "TEST")
+        self.assertEqual(rev.stage_of_repo("database-deb-stage-local"), "STAGE")
+
+    def test_distinguishes_the_two_prod_repositories(self):
+        self.assertEqual(rev.stage_of_repo("clients-maven-prod-public-local"), "PROD")
+        self.assertEqual(rev.stage_of_repo("clients-maven-prod-internal-local"), "INTERNAL")
+
+    def test_maps_both_preview_repositories_to_one_stage(self):
+        self.assertEqual(rev.stage_of_repo("cloud-helm-preview-public-local"), "PREVIEW")
+        self.assertEqual(rev.stage_of_repo("cloud-helm-preview-restricted-local"), "PREVIEW")
+
+    def test_returns_none_for_a_repository_naming_no_stage(self):
+        self.assertIsNone(rev.stage_of_repo("clients-release-bundles-v2"))
+        self.assertIsNone(rev.stage_of_repo("maven-remote"))
+
+    def test_a_project_named_after_a_stage_does_not_confuse_it(self):
+        # The project segment leads, so only the trailing environment should be read.
+        self.assertEqual(rev.stage_of_repo("stage-npm-dev-local"), "DEV")
+
+
+class PackageTypeOfRepo(unittest.TestCase):
+    def test_reads_the_type_segment(self):
+        self.assertEqual(rev.package_type_of_repo("clients-pypi-dev-local"), "pypi")
+        self.assertEqual(rev.package_type_of_repo("clients-maven-prod-public-local"), "maven")
+
+    def test_maps_repository_type_names_onto_package_types(self):
+        self.assertEqual(rev.package_type_of_repo("database-deb-dev-local"), "debian")
+        self.assertEqual(rev.package_type_of_repo("database-rpm-dev-local"), "yum")
+        self.assertEqual(rev.package_type_of_repo("cloud-container-dev-local"), "docker")
+
+
+class Normalize(unittest.TestCase):
+    def test_strips_a_full_artifactory_url(self):
+        self.assertEqual(
+            rev.normalize("https://aerospike.jfrog.io/artifactory/clients-pypi-dev-local/a.whl"),
+            "clients-pypi-dev-local/a.whl")
+
+    def test_strips_a_package_type_endpoint(self):
+        self.assertEqual(rev.normalize("api/pypi/pypi/simple/aerospike"), "pypi/simple/aerospike")
+
+
+class StageClassification(unittest.TestCase):
+    """collect() with transport stubbed, which is where reached/pending/skipped are decided."""
+
+    def build(self, promotion_stages, resident_repos, sealed=True):
+        artifacts = [{"type": "pypi", "repos": resident_repos, "attestation": None,
+                      "commit": None, "public": None, "published_build_linked": None}]
+        promotions = [{"stage": s, "when": f"2026-08-0{i}", "by": "ci", "repos": [],
+                       "mutable": False, "seals": "abc"}
+                      for i, s in enumerate(promotion_stages, start=1)]
+        return artifacts, promotions, sealed
+
+    def derive(self, promotion_stages, resident_repos, sealed=True):
+        # Mirrors the derivation in collect() so the classification can be tested without
+        # standing up the whole transport layer.
+        artifacts, promotions, sealed = self.build(promotion_stages, resident_repos, sealed)
+        stages = [p["stage"] for p in promotions]
+        resident = sorted({rev.stage_of_repo(r) for a in artifacts for r in a["repos"]} - {None},
+                          key=lambda s: rev.STAGE_ORDER.index(s) if s in rev.STAGE_ORDER
+                          else len(rev.STAGE_ORDER))
+        reached = [s for s in rev.STAGE_ORDER if s in set(stages) | set(resident)]
+        if "INTERNAL" in stages or "INTERNAL" in resident:
+            reached.append("INTERNAL")
+        expected = rev.STAGE_ORDER[:-1] if "INTERNAL" in reached else rev.STAGE_ORDER
+        furthest = max((expected.index(s) for s in reached if s in expected), default=-1)
+        return {
+            "stages_reached": reached,
+            "skipped_stages": [s for s in expected[:furthest + 1] if s not in reached],
+            "pending_stages": list(expected[furthest + 1:]),
+        }
+
+    def test_an_artifact_only_in_dev_has_everything_pending_and_nothing_skipped(self):
+        d = self.derive([], ["clients-pypi-dev-local"], sealed=False)
+        self.assertEqual(d["stages_reached"], ["DEV"])
+        self.assertEqual(d["skipped_stages"], [])
+        self.assertEqual(d["pending_stages"], ["TEST", "STAGE", "PREVIEW", "PROD"])
+
+    def test_repository_residence_counts_when_no_promotion_record_exists(self):
+        d = self.derive([], ["clients-pypi-dev-local", "clients-pypi-test-local"])
+        self.assertEqual(d["stages_reached"], ["DEV", "TEST"])
+        self.assertEqual(d["pending_stages"], ["STAGE", "PREVIEW", "PROD"])
+
+    def test_a_gate_passed_over_is_reported_as_skipped(self):
+        d = self.derive(["DEV", "TEST", "PROD"], ["clients-pypi-prod-public-local"])
+        self.assertEqual(d["skipped_stages"], ["STAGE", "PREVIEW"])
+        self.assertEqual(d["pending_stages"], [])
+
+    def test_internal_is_terminal_so_prod_is_not_counted_against_it(self):
+        d = self.derive(["DEV", "TEST", "STAGE", "INTERNAL"], [])
+        self.assertNotIn("PROD", d["skipped_stages"])
+        self.assertNotIn("PROD", d["pending_stages"])
+
+    def test_nothing_anywhere_is_pending_rather_than_skipped(self):
+        d = self.derive([], [])
+        self.assertEqual(d["stages_reached"], [])
+        self.assertEqual(d["skipped_stages"], [])
+        self.assertEqual(d["pending_stages"], rev.STAGE_ORDER)
+
+
+class ClaimsRequireRecords(unittest.TestCase):
+    """No claim may appear without the record that backs it."""
+
+    def evidence(self, release, promotions, sealed):
+        return {
+            "release": release, "promotions": promotions, "pr": None, "project": "clients",
+            "artifacts": [{"type": "pypi", "path": "a.whl", "commit": None, "attestation": None,
+                           "public": None, "repos": ["clients-pypi-dev-local"],
+                           "published_build_linked": None, "sealed": False}],
+            "source": None, "signatures": {}, "about": "",
+            "derived": {"types": ["pypi"], "attested_types": [], "unattested_types": ["pypi"],
+                        "stages": [], "terminal_stage": None, "sealed": sealed,
+                        "stages_reached": ["DEV"], "resident_stages": ["DEV"],
+                        "skipped_stages": [], "pending_stages": ["TEST", "STAGE", "PREVIEW", "PROD"],
+                        "self_approved": False, "unlinked_published": [], "any_commit": False},
+        }
+
+    def test_an_unsealed_artifact_claims_nothing_about_custody(self):
+        rows = rev.claim_rows(self.evidence(None, [], False))
+        self.assertEqual(rows, [])
+
+    def test_an_unsealed_artifact_names_the_missing_bundle_as_the_root_gap(self):
+        rows = rev.gap_rows(self.evidence(None, [], False))
+        self.assertIn("A release bundle holding these bytes", [r[0] for r in rows])
+
+    def test_the_document_renders_without_a_release(self):
+        ev = self.evidence(None, [], False)
+        out = rev.render_markdown(ev, rev.document(ev))
+        self.assertIn("a.whl: artifact evidence", out)
+        self.assertIn("Where this is", out)
+        self.assertIn("has reached DEV", out)
+        self.assertIn("not been promoted to TEST", out)
+        # The claim that would be a lie if it appeared.
+        self.assertNotIn("could not change after sealing", out)
+
+
+class CollectUnbundled(unittest.TestCase):
+    """collect() end to end against stubbed transport, for an artifact still in DEV.
+
+    The classification tests above mirror the derivation; this one runs the real thing, so the
+    two cannot drift apart without a failure here.
+    """
+
+    TARGET = "clients-pypi-dev-local/aerospike/16.0.1/aerospike-16.0.1.whl"
+
+    def setUp(self):
+        self.calls = []
+        self._real = (rev.jf, rev.aql, rev.gh)
+
+        def fake_jf(path):
+            self.calls.append(path)
+            if "api/storage/" in path and path.endswith("?properties"):
+                return {"properties": {}}
+            if "api/storage/" in path:
+                return {"checksums": {"sha256": "abc123"}}
+            return {}
+
+        def fake_aql(_query):
+            # In no release bundle, and present only in the dev repository.
+            return {"results": [{"repo": "clients-pypi-dev-local",
+                                 "path": "aerospike/16.0.1",
+                                 "name": "aerospike-16.0.1.whl"}]}
+
+        rev.jf, rev.aql, rev.gh = fake_jf, fake_aql, lambda _p: None
+
+    def tearDown(self):
+        rev.jf, rev.aql, rev.gh = self._real
+
+    def test_reports_on_an_artifact_that_is_in_no_release_bundle(self):
+        ev = rev.collect(self.TARGET, "")
+        self.assertIsNone(ev["release"])
+        self.assertEqual(ev["project"], "clients")
+        self.assertEqual(len(ev["artifacts"]), 1)
+        self.assertEqual(ev["artifacts"][0]["type"], "pypi")
+        self.assertFalse(ev["artifacts"][0]["sealed"])
+
+    def test_places_it_at_dev_with_the_rest_pending(self):
+        derived = rev.collect(self.TARGET, "")["derived"]
+        self.assertEqual(derived["stages_reached"], ["DEV"])
+        self.assertEqual(derived["skipped_stages"], [])
+        self.assertEqual(derived["pending_stages"], ["TEST", "STAGE", "PREVIEW", "PROD"])
+        self.assertFalse(derived["sealed"])
+
+    def test_renders_a_document_that_claims_nothing_it_cannot_back(self):
+        ev = rev.collect(self.TARGET, "")
+        out = rev.render_markdown(ev, rev.document(ev))
+        self.assertIn("has reached DEV", out)
+        self.assertIn("not been promoted to TEST, STAGE, PREVIEW and PROD", out)
+        self.assertIn("A release bundle holding these bytes", out)
+        for lie in ("could not change after sealing", "promotion attestation names the seal"):
+            self.assertNotIn(lie, out)
+
+
+class CollectBundled(unittest.TestCase):
+    """The sealed, fully promoted path still produces the full document."""
+
+    SEAL = {"_type": "https://in-toto.io/Statement/v1", "predicateType": "slsa",
+            "subject": [{"digest": {"sha256": "abc123"}}]}
+
+    def setUp(self):
+        self._real = (rev.jf, rev.aql, rev.gh)
+
+        def fake_jf(path):
+            if "lifecycle/api/v2/release_bundle/records" in path:
+                return {"created": "2026-08-01T10:00:00Z", "created_by": "ci",
+                        "total_artifacts_count": 1,
+                        "artifacts": [{"package_type": "pypi", "path": "a.whl",
+                                       "checksum": "abc123", "properties": []}]}
+            if path.endswith("release-bundle.json.evd"):
+                return {"payload": rev.base64.b64encode(
+                    rev.json.dumps(self.SEAL).encode()).decode()}
+            if "api/storage/" in path and path.endswith("?properties"):
+                return {"properties": {}}
+            if "api/storage/" in path and "release-bundles-v2" in path:
+                return {"children": [{"uri": "/promotion-PROD.evd"}]}
+            if "api/storage/" in path:
+                return {"checksums": {"sha256": "abc123"}}
+            if path.endswith("promotion-PROD.evd"):
+                return {}
+            return {}
+
+        rev.jf = fake_jf
+        rev.aql = lambda _q: {"results": [{"repo": "clients-pypi-prod-public-local",
+                                           "path": "a", "name": "a.whl"}]}
+        rev.gh = lambda _p: None
+
+    def tearDown(self):
+        rev.jf, rev.aql, rev.gh = self._real
+
+    def test_a_bundled_release_still_reports_its_release_block(self):
+        ev = rev.collect("bundle:my-release/1.2.3@clients", "")
+        self.assertIsNotNone(ev["release"])
+        self.assertEqual(ev["release"]["name"], "my-release")
+        self.assertEqual(ev["release"]["version"], "1.2.3")
+        self.assertTrue(ev["derived"]["sealed"])
+
+    def test_residence_in_a_public_repository_counts_as_reaching_prod(self):
+        derived = rev.collect("bundle:my-release/1.2.3@clients", "")["derived"]
+        self.assertIn("PROD", derived["stages_reached"])
+        self.assertEqual(derived["pending_stages"], [])
+
+    def test_the_full_document_renders(self):
+        ev = rev.collect("bundle:my-release/1.2.3@clients", "")
+        out = rev.render_markdown(ev, rev.document(ev))
+        self.assertIn("my-release 1.2.3: release evidence", out)
+        self.assertIn("Chain of custody", out)
+        self.assertIn("could not change after sealing", out)
+
+    def test_an_unattributable_promotion_stays_visible_without_counting_as_a_stage(self):
+        # The stub's promotion attestation carries no target environment, which is what an
+        # unreadable or malformed record looks like.
+        ev = rev.collect("bundle:my-release/1.2.3@clients", "")
+        self.assertEqual([p["stage"] for p in ev["promotions"]], ["UNKNOWN"])
+        self.assertNotIn("UNKNOWN", ev["derived"]["stages_reached"])
+        rev.render_markdown(ev, rev.document(ev))  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/release-evidence/tests/test_release_evidence.py
+++ b/.github/actions/release-evidence/tests/test_release_evidence.py
@@ -166,6 +166,17 @@ class ClaimsRequireRecords(unittest.TestCase):
         rows = rev.claim_rows(self.pr_evidence(["reviewer"], "2026-01-01T00:00:00Z"))
         self.assertEqual(len([r for r in rows if "approved by someone" in r[0]]), 1)
 
+    def test_stages_not_yet_reached_are_named_as_gaps(self):
+        rows = rev.gap_rows(self.evidence(None, [], False))
+        titles = [r[0] for r in rows]
+        self.assertIn("A recorded TEST, STAGE, PREVIEW and PROD transition", titles)
+
+    def test_a_pending_gap_reads_as_ahead_rather_than_passed_over(self):
+        row = next(r for r in rev.gap_rows(self.evidence(None, [], False))
+                   if r[0].startswith("A recorded TEST"))
+        self.assertIn("lie ahead of it", row[1])
+        self.assertNotIn("passed over", row[1])
+
     def test_a_missing_approval_is_named_as_a_gap_rather_than_left_silent(self):
         rows = rev.gap_rows(self.pr_evidence([], None))
         self.assertIn("An approving review on the authorizing pull request", [r[0] for r in rows])

--- a/.github/actions/release-evidence/tests/test_release_evidence.py
+++ b/.github/actions/release-evidence/tests/test_release_evidence.py
@@ -135,7 +135,8 @@ class ClaimsRequireRecords(unittest.TestCase):
                         "stages": [], "terminal_stage": None, "sealed": sealed,
                         "stages_reached": ["DEV"], "resident_stages": ["DEV"],
                         "skipped_stages": [], "pending_stages": ["TEST", "STAGE", "PREVIEW", "PROD"],
-                        "self_approved": False, "unlinked_published": [], "any_commit": False},
+                        "self_approved": False, "independently_approved": False,
+                        "unlinked_published": [], "any_commit": False},
         }
 
     def test_an_unsealed_artifact_claims_nothing_about_custody(self):
@@ -146,6 +147,8 @@ class ClaimsRequireRecords(unittest.TestCase):
         ev = self.evidence(None, [], False)
         ev["pr"] = {"number": 7, "title": "t", "author": "writer", "merged_at": merged_at,
                     "repo": "aerospike/shared-workflows", "approvers": approvers}
+        ev["derived"]["independently_approved"] = any(a != "writer" for a in approvers)
+        ev["derived"]["self_approved"] = "writer" in approvers
         ev["source"] = {"repo": "aerospike/shared-workflows", "commit": "abcdef1234567890",
                         "run": "https://github.com/aerospike/shared-workflows/actions/runs/1",
                         "env": 12}
@@ -162,6 +165,19 @@ class ClaimsRequireRecords(unittest.TestCase):
     def test_an_independently_approved_merged_pr_makes_the_claim(self):
         rows = rev.claim_rows(self.pr_evidence(["reviewer"], "2026-01-01T00:00:00Z"))
         self.assertEqual(len([r for r in rows if "approved by someone" in r[0]]), 1)
+
+    def test_a_missing_approval_is_named_as_a_gap_rather_than_left_silent(self):
+        rows = rev.gap_rows(self.pr_evidence([], None))
+        self.assertIn("An approving review on the authorizing pull request", [r[0] for r in rows])
+
+    def test_an_approved_pr_raises_no_approval_gap(self):
+        rows = rev.gap_rows(self.pr_evidence(["reviewer"], "2026-01-01T00:00:00Z"))
+        self.assertNotIn("An approving review on the authorizing pull request", [r[0] for r in rows])
+
+    def test_no_approvals_does_not_read_as_declining_to_self_approve(self):
+        ev = self.pr_evidence([], None)
+        out = rev.render_markdown(ev, rev.document(ev))
+        self.assertNotIn("could not approve their own change", out)
 
     def test_an_open_pr_is_described_as_open_rather_than_merged_at_no_date(self):
         rows = rev.custody_rows(self.pr_evidence([], None))

--- a/.github/actions/release-evidence/tests/test_release_evidence.py
+++ b/.github/actions/release-evidence/tests/test_release_evidence.py
@@ -121,6 +121,42 @@ class StageClassification(unittest.TestCase):
         self.assertEqual(d["pending_stages"], rev.STAGE_ORDER)
 
 
+class ContainersCollapseToTheImage(unittest.TestCase):
+    """An image is one shipped thing, whether its repository is typed docker or oci."""
+
+    def record(self, package_type):
+        paths = [
+            "img/1.0.0/manifest.json",
+            "img/1.0.0/sha256__aaaa",
+            "img/_uploads/manifest-sha256__bbbb.json",
+            "img/_uploads/sha256__cccc",
+            "img/sha256:dddd/manifest.json",
+            "img/sha256:dddd/sha256__eeee",
+        ]
+        return {"artifacts": [{"path": p, "package_type": package_type} for p in paths]}
+
+    def test_an_oci_image_collapses_to_its_tag_manifest(self):
+        kept = [a["path"] for a in rev.primary_artifacts(self.record("oci"))]
+        self.assertEqual(kept, ["img/1.0.0/manifest.json"])
+
+    def test_a_docker_image_collapses_the_same_way(self):
+        kept = [a["path"] for a in rev.primary_artifacts(self.record("docker"))]
+        self.assertEqual(kept, ["img/1.0.0/manifest.json"])
+
+    def test_a_multi_arch_list_manifest_is_kept(self):
+        record = {"artifacts": [{"path": "img/1.0.0_20260101T000000Z/list.manifest.json",
+                                 "package_type": "docker"}]}
+        self.assertEqual(len(rev.primary_artifacts(record)), 1)
+
+    def test_upload_staging_is_never_a_shipped_thing(self):
+        kept = [a["path"] for a in rev.primary_artifacts(self.record("oci"))]
+        self.assertFalse([p for p in kept if "_uploads" in p])
+
+    def test_a_non_container_type_is_untouched(self):
+        record = {"artifacts": [{"path": "a/b/c-1.0.jar", "package_type": "maven"}]}
+        self.assertEqual(len(rev.primary_artifacts(record)), 1)
+
+
 class ClaimsRequireRecords(unittest.TestCase):
     """No claim may appear without the record that backs it."""
 

--- a/.github/actions/release-evidence/verify-artifact.sh
+++ b/.github/actions/release-evidence/verify-artifact.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Walk the evidence chain backwards from any published artifact.
+#
+#   JFROG_TOKEN=<jfrog token> ./verify-artifact.sh <repo/path | full URL | sha256:HEX>
+#
+# For a container, point it at the tag's list.manifest.json, whose sha256 is the
+# index digest that GitHub attests. Set REPO=owner/name if the artifact carries
+# nothing that identifies its source repository.
+#
+# Needs curl, jq, and gh.
+set -uo pipefail
+
+BASE="${JF_BASE:-https://aerospike.jfrog.io}"
+TOKEN="${JFROG_TOKEN:-${TOKEN-}}"
+: "${TOKEN:?set JFROG_TOKEN to a JFrog access token}"
+target="${1:?usage: verify-artifact.sh <repo/path | full URL | sha256:HEX>}"
+path="${target#*/artifactory/}"
+# Package-type endpoints are what a consumer copies: api/helm/helm/..., api/pypi/pypi/...
+[[ $path == api/*/*/* ]] && path="${path#api/*/}"
+
+jf() { curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/$1"; }
+aql() { curl -sS -H "Authorization: Bearer $TOKEN" -H "Content-Type: text/plain" \
+    -X POST "$BASE/artifactory/api/search/aql" --data "$1"; }
+uri() { jq -rn --arg s "$1" '$s|@uri'; }
+step() { printf '\n===== %s =====\n' "$1"; }
+
+# ------------------------------------------------------------------- gather
+if [[ $path == sha256:* ]]; then
+    sha="${path#sha256:}"
+    props='{}'
+else
+    sha=$(jf "artifactory/api/storage/$path" | jq -r '.checksums.sha256 // empty')
+    [[ -n $sha ]] || {
+        echo "no sha256 for $path" >&2
+        exit 1
+    }
+    props=$(jf "artifactory/api/storage/$path?properties" | jq '.properties // {}')
+fi
+
+# Find every physical repo holding these bytes. This resolves a public virtual to the
+# locals behind it, and the release bundle repo names the JFrog project.
+hits=$(aql "items.find({\"sha256\":\"$sha\"}).include(\"repo\",\"path\",\"name\")")
+rb_repo=$(jq -r '[.results[] | select(.repo|endswith("-release-bundles-v2"))][0].repo // empty' <<<"$hits")
+rb_path=$(jq -r '[.results[] | select(.repo|endswith("-release-bundles-v2"))][0].path // empty' <<<"$hits")
+
+project="${rb_repo%-release-bundles-v2}"
+[[ -z $project ]] && project=$(jq -r '[.results[].repo | select(contains("-"))][0] // ""' <<<"$hits" |
+    sed -E 's/-.*//')
+
+bname=$(jq -r '(.["build.name"]   // [])[0] // empty' <<<"$props")
+bnum=$(jq -r '(.["build.number"] // [])[0] // empty' <<<"$props")
+
+vcs=''
+run=''
+if [[ -n $bname && -n $bnum ]]; then
+    bi=$(jf "artifactory/api/build/$(uri "$bname")/$(uri "$bnum")?project=$project")
+    vcs=$(jq -c '.buildInfo.vcs[0] // empty' <<<"$bi")
+    run=$(jq -r '.buildInfo.url // empty' <<<"$bi")
+    # A matrix pipeline keeps vcs on a metadata child, reachable through the parent.
+    if [[ -z $vcs ]]; then
+        pbi=$(jf "artifactory/api/build/$(uri "$bname")/$(uri "${bnum%-artifacts}")?project=$project")
+        [[ -z $run ]] && run=$(jq -r '.buildInfo.url // empty' <<<"$pbi")
+        child=$(jq -r '[.buildInfo.modules[]?.id | select(contains("-buildinfo-"))][0] // empty' <<<"$pbi")
+        [[ -n $child ]] && vcs=$(jf "artifactory/api/build/$(uri "$bname")/$(uri "${child##*/}")?project=$project" |
+            jq -c '.buildInfo.vcs[0] // empty')
+    fi
+fi
+
+# Source repository: the VCS block, else the CI run URL, else an override.
+gh_repo="${REPO-}"
+[[ -z $gh_repo ]] && gh_repo=$(jq -r 'if (.["vcs.provider"]//[""])[0] == "github"
+  then ((.["vcs.org"]//[""])[0] + "/" + (.["vcs.repo"]//[""])[0]) else "" end
+  | sub("^/$";"")' <<<"$props")
+[[ -z $gh_repo && -n $vcs ]] && gh_repo=$(jq -r '.url // ""' <<<"$vcs" |
+    sed -E 's#^https://github.com/##; s#\.git$##')
+[[ -z $gh_repo && -n $run ]] && gh_repo=$(sed -E 's#^https://github.com/([^/]+/[^/]+)/.*#\1#' <<<"$run")
+
+# A container carries its own origin in OCI labels, which survives when the
+# manifest has no build.* properties.
+labels='{}'
+if [[ -z $gh_repo && $path == *manifest.json ]]; then
+    img="${path%/*/*}"
+    dir=$(dirname "$path")
+    mf=$(jf "artifactory/$path")
+    if jq -e '.manifests' >/dev/null 2>&1 <<<"$mf"; then
+        child=$(jq -r '[.manifests[] | select(.platform.os != "unknown")][0].digest // empty' <<<"$mf")
+        dir="$img/$child"
+        mf=$(jf "artifactory/$dir/manifest.json")
+    fi
+    cfg=$(jq -r '.config.digest // empty' <<<"$mf")
+    [[ -n $cfg ]] && labels=$(jf "artifactory/$dir/${cfg/:/__}" | jq -c '.config.Labels // {}')
+    gh_repo=$(jq -r '."org.opencontainers.image.source" // ""' <<<"$labels" |
+        sed -E 's#^https://github.com/##')
+fi
+
+att=''
+[[ -n $gh_repo ]] && att=$(gh api "repos/$gh_repo/attestations/sha256:$sha" 2>/dev/null |
+    jq -r '.attestations[0].bundle.dsseEnvelope.payload // empty' | base64 -d 2>/dev/null)
+
+# The commit: the VCS block, else the OCI label, else the attestation.
+commit=''
+source='nowhere: no VCS block, no image label, no attestation'
+[[ -n $vcs ]] && {
+    commit=$(jq -r '.revision // ""' <<<"$vcs")
+    source='JFrog build-info'
+}
+[[ -z $commit ]] && commit=$(jq -r '."org.opencontainers.image.revision" // ""' <<<"$labels") &&
+    [[ -n $commit ]] && source='OCI image labels, not in build-info'
+[[ -z $commit && -n $att ]] && commit=$(jq -r \
+    '.predicate.buildDefinition.resolvedDependencies[0].digest.gitCommit // ""' <<<"$att") &&
+    [[ -n $commit ]] && source='GitHub attestation, not in build-info'
+
+# ------------------------------------------------------------------- report
+step "The artifact"
+jq -n --arg p "$path" --arg s "$sha" --arg b "${bname-}" --arg n "${bnum-}" --arg r "${gh_repo-}" \
+    '{path: $p, sha256: $s, build: $b, number: $n, source_repo: $r}'
+
+step "Every repository holding these exact bytes"
+jq -r '[.results[].repo] | unique | .[]' <<<"$hits"
+
+step "The commit it was built from"
+jq -n --arg c "${commit-}" --arg r "$run" --argjson v "${vcs:-null}" --arg s "$source" '{
+  revision: (if $c == "" then null else $c end),
+  message:  (($v.message // "") | split("\n")[0]),
+  branch:   ($v.branch // ""),
+  run:      $r,
+  recorded_in: $s }'
+
+if [[ -n $rb_repo ]]; then
+    bundle=$(jq -rn --arg p "$rb_path" '$p | split("/") | .[0:2] | join("/")')
+    proj="${rb_repo%-release-bundles-v2}"
+
+    step "The seal, and whether it covers this artifact"
+    jf "artifactory/$rb_repo/$bundle/release-bundle.json.evd" |
+        jq --arg s "$sha" --arg b "$bundle" '.payload | @base64d | fromjson | {
+      bundle:    $b,
+      statement: ._type,
+      predicate: .predicateType,
+      files:     (.subject | length),
+      covers_this_artifact: ([.subject[].digest.sha256] | index($s) != null) }'
+
+    step "Promotion history: stage, when, and who authorized it"
+    jf "lifecycle/api/v2/promotion/records/$bundle?project=$proj" |
+        jq '[.promotions[] | {stage: .environment, when: .created, by: .created_by}]'
+else
+    step "The release bundle these bytes were sealed into"
+    echo '{ "bundle": null, "note": "these bytes are in no release bundle" }'
+fi
+
+step "SLSA build provenance"
+if [[ -n $att ]]; then
+    jq '{predicateType,
+       builder:   .predicate.runDetails.builder.id,
+       buildType: .predicate.buildDefinition.buildType,
+       runner:    .predicate.buildDefinition.internalParameters.github.runner_environment}' <<<"$att"
+else
+    echo '{ "attestation": null, "note": "no GitHub build provenance for this digest" }'
+fi
+
+step "The peer review that authorized the change"
+if [[ -n $gh_repo && -n ${commit-} ]]; then
+    gh api "repos/$gh_repo/commits/$commit/pulls" 2>/dev/null |
+        jq '[.[] | {pr: .number, title: .title, author: .user.login, merged_at: .merged_at}]' ||
+        echo '{ "note": "no pull request found for this commit" }'
+else
+    echo '{ "note": "no commit to look up" }'
+fi

--- a/.github/workflows/example_composable-matrix.yaml
+++ b/.github/workflows/example_composable-matrix.yaml
@@ -14,6 +14,9 @@ name: Example Composable Matrix CI/CD
 # up the old bundle before deploy (promoted bundles can lock artifacts in
 # dev-local repos, so deletion must happen before new artifacts are uploaded).
 #
+# WARNING: the delete-existing-bundle job is scaffolding for this example and must
+# not be copied into a real pipeline. See the warning above that job.
+#
 # WORKFLOW FLOW:
 #  1. extract-version        - read version from file or input
 #  2. build (matrix)         - DEB/RPM builds across distros using FPM for packaging
@@ -31,6 +34,7 @@ name: Example Composable Matrix CI/CD
 #  8. deploy                 - upload to JFrog Artifactory (reusable_deploy-artifacts.yaml)
 #  9. create-release-bundle  - create bundle (reusable_create-release-bundle.yaml, workflow_dispatch only)
 # 10. promote-release-bundle - promote bundle to DEV (workflow_dispatch only)
+# 11. release-evidence       - report digests, seal, promotions, provenance, PR
 #
 # npm, Java, and Mac are separate jobs because they use different working
 # directories, runners, and toolchains. They could also be folded into a matrix
@@ -369,8 +373,14 @@ jobs:
       oidc-audience: aerospike/testing
     secrets: inherit
 
-  # Delete existing bundle before deploy. Promoted bundles can lock artifacts
-  # in dev-local repos, causing deploy uploads to fail.
+  # WARNING: do not copy this job into a real pipeline.
+  #
+  # A release bundle is the immutable record of what shipped. Deleting one throws
+  # away its promotion history and the guarantee that what was tested is what
+  # ships, and nothing restores it. This job exists only because the example
+  # republishes the same fixed version on every run, and the previous run's bundle
+  # locks its artifacts in dev-local so the next deploy cannot overwrite them.
+  # A real pipeline publishes a new version instead of deleting the old bundle.
   delete-existing-bundle:
     needs: [sign, extract-version]
     runs-on: ubuntu-22.04
@@ -447,3 +457,49 @@ jobs:
           environment: DEV
           jf-project: test
           include-repos: test-deb-dev-local;test-rpm-dev-local;test-maven-dev-local;test-npm-dev-local;test-pypi-dev-local;test-go-dev-local;test-helm-dev-local;test-generic-dev-local
+
+  # Report what the bundle can prove: digests, the bundle seal, promotion history,
+  # SLSA provenance, and the authorizing pull request. Reads signed records only.
+  # Runs after promotion so the promotion history has an entry to report.
+  release-evidence:
+    needs: [promote-release-bundle, extract-version]
+    runs-on: ubuntu-22.04
+    if: always() && !cancelled() && needs.promote-release-bundle.result == 'success' && github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: Checkout shared-workflows (actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+      - name: Setup JFrog CLI
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: https://artifact.aerospike.io
+          JF_PROJECT: test
+        with:
+          oidc-provider-name: gh-dev-test
+          oidc-audience: aerospike/testing
+      - name: Record release evidence
+        uses: ./.github/actions/release-evidence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          target: bundle:test-release/${{ needs.extract-version.outputs.version }}@test
+          about: the multi-ecosystem release published by this example
+          output-path: release-evidence.md
+          jf-url: https://artifact.aerospike.io
+      - name: Publish evidence to the run summary
+        run: cat release-evidence.md >>"$GITHUB_STEP_SUMMARY"
+      - name: Upload evidence document
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-evidence
+          path: release-evidence.md

--- a/.github/workflows/example_docker-test.yaml
+++ b/.github/workflows/example_docker-test.yaml
@@ -36,8 +36,14 @@ jobs:
       version: ${{ steps.extract.outputs.version }}
       git_tag: ${{ steps.extract.outputs.git_tag }}
 
-  # Delete existing bundle before deploy. Promoted bundles can lock artifacts
-  # in dev-local repos, causing deploy uploads to fail.
+  # WARNING: do not copy this job into a real pipeline.
+  #
+  # A release bundle is the immutable record of what shipped. Deleting one throws
+  # away its promotion history and the guarantee that what was tested is what
+  # ships, and nothing restores it. This job exists only because the example
+  # republishes the same fixed version on every run, and the previous run's bundle
+  # locks its artifacts in dev-local so the next deploy cannot overwrite them.
+  # A real pipeline publishes a new version instead of deleting the old bundle.
   delete-existing-bundle:
     needs: [extract-version]
     runs-on: ubuntu-22.04
@@ -90,3 +96,48 @@ jobs:
       version: ${{ needs.extract-version.outputs.version }}
       oidc-provider-name: gh-dev-test
       oidc-audience: aerospike/testing
+
+  # Report what the bundle can prove: digests, the bundle seal, promotion history,
+  # SLSA provenance, and the authorizing pull request. Reads signed records only.
+  release-evidence:
+    needs: [create-release-bundle, extract-version]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: Checkout shared-workflows (actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+      - name: Setup JFrog CLI
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: https://artifact.aerospike.io
+          JF_PROJECT: test
+        with:
+          oidc-provider-name: gh-dev-test
+          oidc-audience: aerospike/testing
+      - name: Record release evidence
+        uses: ./.github/actions/release-evidence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          target: bundle:test-docker-release/${{ needs.extract-version.outputs.version }}@test
+          about: the container image published by this example
+          output-path: release-evidence.md
+          jf-url: https://artifact.aerospike.io
+      - name: Publish evidence to the run summary
+        run: cat release-evidence.md >>"$GITHUB_STEP_SUMMARY"
+      - name: Upload evidence document
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-evidence
+          path: release-evidence.md

--- a/.github/workflows/example_expanded-integration.yaml
+++ b/.github/workflows/example_expanded-integration.yaml
@@ -27,9 +27,16 @@ concurrency:
 jobs:
   # Manual dispatches should not take arguments.
   # here we use a file (VERSION.example) to set the test version that will be used.
-  # Since this action actually produces an immutable release bundle you must remove it or change the version
-  # to remove the test bundle use the command `jf release-bundle-delete-local test-release 1.2.9 --project=test`
   # In a real CI/CD pipeline you could trigger on version tag or commit also. Here we use the file so we can show the behaviour on demand.
+  #
+  # Because the version is fixed, re-running this example needs the previous bundle
+  # gone first: it is immutable, and once promoted it locks its artifacts in
+  # dev-local so the next deploy cannot overwrite them. Delete it by hand with
+  # `jf release-bundle-delete-local test-release 1.2.9 --project=test`.
+  #
+  # WARNING: never do that in a real pipeline. A release bundle is the immutable
+  # record of what shipped, and deleting one throws away its promotion history and
+  # the guarantee that what was tested is what ships. Publish a new version instead.
   extract-version:
     runs-on: ubuntu-latest
     steps:
@@ -501,3 +508,48 @@ jobs:
       oidc-audience: aerospike/testing
       dry-run: false
       gh-bundle-metadata-artifact-name: ${{ needs.deploy-artifacts.outputs.bundle-metadata-available == 'true' && needs.deploy-artifacts.outputs.bundle-metadata-artifact-name || '' }}
+
+  # Report what the bundle can prove: digests, the bundle seal, promotion history,
+  # SLSA provenance, and the authorizing pull request. Reads signed records only.
+  release-evidence:
+    needs: [create-release-bundle, extract-version]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: Checkout shared-workflows (actions)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+      - name: Setup JFrog CLI
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: https://artifact.aerospike.io
+          JF_PROJECT: test
+        with:
+          oidc-provider-name: gh-dev-test
+          oidc-audience: aerospike/testing
+      - name: Record release evidence
+        uses: ./.github/actions/release-evidence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          target: bundle:test-release/${{ needs.extract-version.outputs.version }}@test
+          about: the multi-ecosystem release published by this example
+          output-path: release-evidence.md
+          jf-url: https://artifact.aerospike.io
+      - name: Publish evidence to the run summary
+        run: cat release-evidence.md >>"$GITHUB_STEP_SUMMARY"
+      - name: Upload evidence document
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-evidence
+          path: release-evidence.md

--- a/.github/workflows/test_deploy-artifacts-integration.yaml
+++ b/.github/workflows/test_deploy-artifacts-integration.yaml
@@ -325,6 +325,11 @@ jobs:
           # Promoted bundles lock their artifacts and block re-deployment to the same
           # paths. Delete all versions of test-release before wiping the repos so the
           # artifact deletes below don't silently 409.
+          #
+          # WARNING: teardown for a test fixture, not a pattern to copy. A release
+          # bundle is the immutable record of what shipped, and deleting one throws
+          # away its promotion history. Never do this to a bundle outside the test
+          # project.
           versions=$(jf release-bundle-search versions test-release \
             --project=test --format=json 2>/dev/null \
             || echo '{"release_bundles":[]}')

--- a/.github/workflows/test_release-evidence.yaml
+++ b/.github/workflows/test_release-evidence.yaml
@@ -24,3 +24,60 @@ jobs:
 
       - name: Check verify-artifact.sh syntax
         run: bash -n .github/actions/release-evidence/verify-artifact.sh
+
+  # Exercises the runner-only parts (OIDC token derivation, gh attestation lookups)
+  # against the bundle the examples publish, in about a minute and without building
+  # or publishing anything. Dispatch only, so pull requests stay independent of JFrog.
+  # The version comes from VERSION.example, as it does in the examples themselves.
+  live-evidence:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Extract Version
+        id: extract
+        uses: ./.github/actions/extract-version-from-tag
+        with:
+          version-file: .github/workflows/VERSION.example
+
+      - name: Setup JFrog CLI
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: https://artifact.aerospike.io
+          JF_PROJECT: test
+        with:
+          oidc-provider-name: gh-dev-test
+          oidc-audience: aerospike/testing
+
+      - name: Record release evidence
+        uses: ./.github/actions/release-evidence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          target: bundle:test-release/${{ steps.extract.outputs.version }}@test
+          output-path: release-evidence.md
+          jf-url: https://artifact.aerospike.io
+
+      - name: Publish evidence to the run summary
+        run: cat release-evidence.md >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if the document came back hollow
+        run: |
+          set -euo pipefail
+          missing=0
+          for section in "## The release" "## Chain of custody"; do
+            grep -qF "$section" release-evidence.md || { echo "missing section: $section" >&2; missing=1; }
+          done
+          grep -qE 'sha256 [0-9a-f]{64}' release-evidence.md || { echo "no digest reported" >&2; missing=1; }
+          exit "$missing"

--- a/.github/workflows/test_release-evidence.yaml
+++ b/.github/workflows/test_release-evidence.yaml
@@ -1,0 +1,26 @@
+name: "Test: Release Evidence"
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run release-evidence unit tests
+        run: python3 -m unittest discover .github/actions/release-evidence/tests -v
+
+      - name: Check verify-artifact.sh syntax
+        run: bash -n .github/actions/release-evidence/verify-artifact.sh

--- a/.github/workflows/test_release-evidence.yaml
+++ b/.github/workflows/test_release-evidence.yaml
@@ -26,9 +26,13 @@ jobs:
         run: bash -n .github/actions/release-evidence/verify-artifact.sh
 
   # Exercises the runner-only parts (OIDC token derivation, gh attestation lookups)
-  # against the bundle the examples publish, in about a minute and without building
-  # or publishing anything. Dispatch only, so pull requests stay independent of JFrog.
-  # The version comes from VERSION.example, as it does in the examples themselves.
+  # in about a minute, without building or publishing anything. Dispatch only, so
+  # pull requests stay independent of JFrog.
+  #
+  # The target is a long-lived bundle rather than one the examples publish. Every
+  # example bundle is deleted and rebuilt by the workflows that own it, and
+  # test_deploy-artifacts-integration removes every version of test-release in an
+  # `if: always()` teardown, so a target from that set is absent more often than not.
   live-evidence:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
@@ -45,12 +49,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Extract Version
-        id: extract
-        uses: ./.github/actions/extract-version-from-tag
-        with:
-          version-file: .github/workflows/VERSION.example
-
       - name: Setup JFrog CLI
         uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
         env:
@@ -65,7 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          target: bundle:test-release/${{ steps.extract.outputs.version }}@test
+          target: bundle:ako-rerel-demo/rev2@test
           output-path: release-evidence.md
           jf-url: https://artifact.aerospike.io
 
@@ -76,7 +74,7 @@ jobs:
         run: |
           set -euo pipefail
           missing=0
-          for section in "## The release" "## Chain of custody"; do
+          for section in "## The release" "## Chain of custody" "## What we could prove with more evidence"; do
             grep -qF "$section" release-evidence.md || { echo "missing section: $section" >&2; missing=1; }
           done
           grep -qE 'sha256 [0-9a-f]{64}' release-evidence.md || { echo "no digest reported" >&2; missing=1; }


### PR DESCRIPTION
Moves the artifact evidence scripts into shared-workflows so CI and interactive use run the same code. The scripts trace what a published artifact or release can prove from the signed records JFrog and GitHub already hold: digests, the bundle seal, promotion history with approvers, SLSA provenance, and the authorizing pull request. They read only.

They were written for the `artifact-evidence` skill in `citrusleaf/agent-skills`. That repo is internal, so a pipeline consuming them needed a cross-repo token. Here they are public, callable with no credential, and versioned alongside the workflows they describe. The skill keeps its prose and references and points at these paths.

## Changes

- `.github/actions/release-evidence/verify-artifact.sh`: one artifact, reporting digest, holding repositories, commit, seal, promotions, provenance, and PR
- `.github/actions/release-evidence/release-evidence.py`: the whole release the artifact belongs to, as a markdown or JSON document
- `.github/actions/release-evidence/action.yaml`: composite wrapper resolving the JFrog token from the input, then `JFROG_TOKEN`, then an already-configured JFrog CLI
- `.github/actions/release-evidence/README.md`: inputs, standalone usage, and how to read the output

Scripts follow the `delete-release-bundle` layout, sitting next to the action that calls them.

## Test plan

- [x] Both scripts exercised against four live releases before the move: multi-type, single-type, one with no recorded commit, and one terminating at INTERNAL rather than PROD
- [x] `trunk check` clean on all four files
- [x] `action.yaml` parses; `release-evidence.py` compiles; `verify-artifact.sh` passes `bash -n`
- [ ] First consumer run from `citrusleaf/artifact-publisher`, which calls this per publish

## Note for review

An internal Jira link embedded in generated documents was removed, since this repo is public. No other internal references were present.